### PR TITLE
fix issue #34, add the attributes to new selector model

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/ActionModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ActionModelExtensions.cs
@@ -168,57 +168,6 @@ namespace Microsoft.AspNetCore.OData.Extensions
         /// Adds the OData selector model to the action.
         /// </summary>
         /// <param name="action">The given action model.</param>
-        /// <param name="prefix">The prefix.</param>
-        /// <param name="model">The Edm model.</param>
-        /// <param name="path">The OData path template.</param>
-        public static void AddSelector(this ActionModel action, string prefix, IEdmModel model, ODataPathTemplate path)
-        {
-            if (action == null)
-            {
-                throw Error.ArgumentNull(nameof(action));
-            }
-
-            if (model == null)
-            {
-                throw Error.ArgumentNull(nameof(model));
-            }
-
-            if (path == null)
-            {
-                throw Error.ArgumentNull(nameof(path));
-            }
-
-            var httpMethods = action.GetSupportedHttpMethods();
-
-            foreach (var template in path.GetTemplates())
-            {
-                SelectorModel selectorModel = action.Selectors.FirstOrDefault(s => s.AttributeRouteModel == null);
-                if (selectorModel == null)
-                {
-                    selectorModel = new SelectorModel();
-                    action.Selectors.Add(selectorModel);
-                }
-
-                string templateStr = string.IsNullOrEmpty(prefix) ? template : $"{prefix}/{template}";
-
-                selectorModel.AttributeRouteModel = new AttributeRouteModel(new RouteAttribute(templateStr) { Name = templateStr });
-
-                ODataRoutingMetadata odataMetadata = new ODataRoutingMetadata(prefix, model, path);
-                selectorModel.EndpointMetadata.Add(odataMetadata);
-
-                // Check with .NET Team whether the "Endpoint name metadata"
-                // selectorModel.EndpointMetadata.Add(new EndpointNameMetadata(templateStr));
-                foreach (var httpMethod in httpMethods)
-                {
-                    odataMetadata.HttpMethods.Add(httpMethod);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Adds the OData selector model to the action.
-        /// </summary>
-        /// <param name="action">The given action model.</param>
         /// <param name="httpMethod">The supported http methods, if mulitple, using ',' to separate.</param>
         /// <param name="prefix">The prefix.</param>
         /// <param name="model">The Edm model.</param>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2038,15 +2038,6 @@
             <param name="action">The action model.</param>
             <returns>The supported http methods.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.AddSelector(Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel,System.String,Microsoft.OData.Edm.IEdmModel,Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate)">
-            <summary>
-            Adds the OData selector model to the action.
-            </summary>
-            <param name="action">The given action model.</param>
-            <param name="prefix">The prefix.</param>
-            <param name="model">The Edm model.</param>
-            <param name="path">The OData path template.</param>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.AddSelector(Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel,System.String,System.String,Microsoft.OData.Edm.IEdmModel,Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate)">
             <summary>
             Adds the OData selector model to the action.

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                             ODataPathTemplate pathTemplate = _templateParser.Parse(context.Model, routeTemplate, context.ServiceProvider);
 
                             // Add the httpMethod?
-                            action.AddSelector(context.Prefix, context.Model, pathTemplate);
+                            action.AddSelector(null, context.Prefix, context.Model, pathTemplate);
                         }
                         catch (ODataException ex)
                         {

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/SingletonRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/SingletonRoutingConvention.cs
@@ -48,11 +48,11 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             string singletonName = context.Singleton.Name;
 
             string actionMethodName = action.ActionMethod.Name;
-            if (IsSupportedActionName(actionMethodName, singletonName))
+            if (IsSupportedActionName(actionMethodName, singletonName, out string httpMethod))
             {
                 // ~/Me
                 ODataPathTemplate template = new ODataPathTemplate(new SingletonSegmentTemplate(context.Singleton));
-                action.AddSelector(context.Prefix, context.Model, template);
+                action.AddSelector(httpMethod, context.Prefix, context.Model, template);
 
                 // processed
                 return true;
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             }
 
             string actionPrefix = actionMethodName.Substring(0, index);
-            if (IsSupportedActionName(actionPrefix, singletonName))
+            if (IsSupportedActionName(actionPrefix, singletonName, out httpMethod))
             {
                 string castTypeName = actionMethodName.Substring(index + 4);
                 IEdmEntityType entityType = context.Singleton.EntityType();
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                         new SingletonSegmentTemplate(context.Singleton),
                         new CastSegmentTemplate(castType, entityType, context.Singleton));
 
-                    action.AddSelector(context.Prefix, context.Model, template);
+                    action.AddSelector(httpMethod, context.Prefix, context.Model, template);
                     return true;
                 }
             }
@@ -89,14 +89,26 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             return false;
         }
 
-        private static bool IsSupportedActionName(string actionName, string singletonName)
+        private static bool IsSupportedActionName(string actionName, string singletonName, out string httpMethod)
         {
-            return actionName == "Get" ||
-                actionName == $"Get{singletonName}" ||
-                actionName == "Put" ||
-                actionName == $"Put{singletonName}" ||
-                actionName == "Patch" ||
-                actionName == $"Patch{singletonName}";
+            if (actionName == "Get" || actionName == $"Get{singletonName}")
+            {
+                httpMethod = "Get";
+                return true;
+            }
+            else if (actionName == "Put" || actionName == $"Put{singletonName}")
+            {
+                httpMethod = "put";
+                return true;
+            }
+            else if (actionName == "Patch" || actionName == $"Patch{singletonName}")
+            {
+                httpMethod = "patch";
+                return true;
+            }
+
+            httpMethod = "";
+            return false;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -502,11 +502,6 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions 
 	[
 	ExtensionAttribute(),
 	]
-	public static void AddSelector (Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, string prefix, Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate path)
-
-	[
-	ExtensionAttribute(),
-	]
 	public static void AddSelector (Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, string httpMethod, string prefix, Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate path)
 
 	[

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -502,11 +502,6 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions 
 	[
 	ExtensionAttribute(),
 	]
-	public static void AddSelector (Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, string prefix, Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate path)
-
-	[
-	ExtensionAttribute(),
-	]
 	public static void AddSelector (Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, string httpMethod, string prefix, Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate path)
 
 	[


### PR DESCRIPTION
Related to issue #34.

It seems we can’t hit the Authorize because the new added "SelectorModel" doesn't have the attributes added.

 
In the debug endpoint, there’s no “AuthorizeAttribute” in the metadata of Endpoint

 
![image](https://user-images.githubusercontent.com/9426627/99589184-8783cc80-29a0-11eb-9f8b-a026693ef73f.png)



However,  for “Get” method, the metadata of Endpoint has the “AuthrozeAttribute” as below:

 
![image](https://user-images.githubusercontent.com/9426627/99589840-62438e00-29a1-11eb-92de-08a82891d7c2.png)

This PR is to fix this problem.

 
