### PR TITLE
Fixed issues with concurrency.

### DIFF
--- a/sample/ODataCustomizedSample/Startup.cs
+++ b/sample/ODataCustomizedSample/Startup.cs
@@ -52,6 +52,8 @@ namespace ODataCustomizedSample
 
             app.UseRouting();
 
+            app.UseOData();
+
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>

--- a/sample/ODataRoutingSample/Startup.cs
+++ b/sample/ODataRoutingSample/Startup.cs
@@ -76,7 +76,7 @@ namespace ODataRoutingSample
             //app.UseODataOpenApi();
 
             // Add the OData Batch middleware to support OData $Batch
-            app.UseODataBatching();
+            app.UseOData(batching: true);
 
             app.UseSwagger();
             app.UseSwaggerUI(c =>

--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
 
             // QueryValidators.
             builder.AddService<CountQueryValidator>(ServiceLifetime.Singleton);
-            builder.AddService<FilterQueryValidator>(ServiceLifetime.Singleton);
+            builder.AddService<FilterQueryValidator>(ServiceLifetime.Scoped);
             builder.AddService<ODataQueryValidator>(ServiceLifetime.Singleton);
             builder.AddService<OrderByQueryValidator>(ServiceLifetime.Singleton);
             builder.AddService<SelectExpandQueryValidator>(ServiceLifetime.Singleton);

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.OData.Batch
 
                 // If a batch handler is present, register the route with the batch path mapper. This will be used
                 // by the batching middleware to handle the batch request. Batching still requires the injection
-                // of the batching middleware via UseODataBatching().
+                // of the batching middleware via UseOData(batching: true).
                 ODataBatchHandler batchHandler = subServiceProvider.GetService<ODataBatchHandler>();
                 if (batchHandler != null)
                 {

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5797,18 +5797,24 @@
             Provides extension methods for <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/> to add OData routes.
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions.UseOData(Microsoft.AspNetCore.Builder.IApplicationBuilder,System.Boolean)" -->
+        <member name="M:Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions.UseOData(Microsoft.AspNetCore.Builder.IApplicationBuilder,System.Boolean)">
+            <summary>
+            Use OData middleware.
+            </summary>
+            <param name="app">The <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/> to use.</param>
+            <param name="batching">Value which determines whether OData batching is enabled.</param>
+            <returns>The <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/>.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataMiddleware">
             <summary>
             Defines a middleware for dealing with general per-request
             init and cleanup functionality related to OData queries.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.ODataMiddleware.#ctor(System.IServiceProvider,Microsoft.AspNetCore.Http.RequestDelegate)">
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate)">
             <summary>
             Instantiates a new instance of <see cref="T:Microsoft.AspNetCore.OData.ODataMiddleware"/>.
             </summary>
-            <param name="serviceProvider">The service provider, we don't inject the ODataOptions.</param>
             <param name="next">The next middleware.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiddleware.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext)">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5797,12 +5797,26 @@
             Provides extension methods for <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/> to add OData routes.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions.UseODataBatching(Microsoft.AspNetCore.Builder.IApplicationBuilder)">
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions.UseOData(Microsoft.AspNetCore.Builder.IApplicationBuilder,System.Boolean)" -->
+        <member name="T:Microsoft.AspNetCore.OData.ODataMiddleware">
             <summary>
-            Use OData batching middleware.
+            Defines a middleware for dealing with general per-request
+            init and cleanup functionality related to OData queries.
             </summary>
-            <param name="app">The <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/> to use.</param>
-            <returns>The <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiddleware.#ctor(System.IServiceProvider,Microsoft.AspNetCore.Http.RequestDelegate)">
+            <summary>
+            Instantiates a new instance of <see cref="T:Microsoft.AspNetCore.OData.ODataMiddleware"/>.
+            </summary>
+            <param name="serviceProvider">The service provider, we don't inject the ODataOptions.</param>
+            <param name="next">The next middleware.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiddleware.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Invoke the OData middleware.
+            </summary>
+            <param name="context">The http context.</param>
+            <returns>A task that can be awaited.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataOptions">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/ODataApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataApplicationBuilderExtensions.cs
@@ -13,18 +13,27 @@ namespace Microsoft.AspNetCore.OData
     public static class ODataApplicationBuilderExtensions
     {
         /// <summary>
-        /// Use OData batching middleware.
+        /// Use OData middleware.
+        /// </summary>
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
+        /// <param name="batching">Value which determines whether OData batching is enabled.</param>
         /// <returns>The <see cref="IApplicationBuilder "/>.</returns>
-        public static IApplicationBuilder UseODataBatching(this IApplicationBuilder app)
+        public static IApplicationBuilder UseOData(this IApplicationBuilder app, bool batching = false)
         {
             if (app == null)
             {
                 throw new ArgumentNullException(nameof(app));
             }
 
-            return app.UseMiddleware<ODataBatchMiddleware>();
+            app.UseMiddleware<ODataMiddleware>();
+
+            if (batching)
+            {
+                app.UseMiddleware<ODataBatchMiddleware>();
+            }
+
+            return app;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/ODataApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataApplicationBuilderExtensions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.OData
         /// <summary>
         /// Use OData middleware.
         /// </summary>
-        /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
         /// <param name="batching">Value which determines whether OData batching is enabled.</param>
         /// <returns>The <see cref="IApplicationBuilder "/>.</returns>

--- a/src/Microsoft.AspNetCore.OData/ODataMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiddleware.cs
@@ -19,9 +19,8 @@ namespace Microsoft.AspNetCore.OData
         /// <summary>
         /// Instantiates a new instance of <see cref="ODataMiddleware"/>.
         /// </summary>
-        /// <param name="serviceProvider">The service provider, we don't inject the ODataOptions.</param>
         /// <param name="next">The next middleware.</param>
-        public ODataMiddleware(IServiceProvider serviceProvider, RequestDelegate next)
+        public ODataMiddleware(RequestDelegate next)
         {
             _next = next;
         }

--- a/src/Microsoft.AspNetCore.OData/ODataMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiddleware.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Extensions;
+
+namespace Microsoft.AspNetCore.OData
+{
+    /// <summary>
+    /// Defines a middleware for dealing with general per-request
+    /// init and cleanup functionality related to OData queries.
+    /// </summary>
+    public class ODataMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="ODataMiddleware"/>.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider, we don't inject the ODataOptions.</param>
+        /// <param name="next">The next middleware.</param>
+        public ODataMiddleware(IServiceProvider serviceProvider, RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        /// <summary>
+        /// Invoke the OData middleware.
+        /// </summary>
+        /// <param name="context">The http context.</param>
+        /// <returns>A task that can be awaited.</returns>
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            var prefix = context.Request.ODataFeature().PrefixName;
+            if (prefix != null)
+            {
+                context.Request.CreateSubServiceProvider(context.Request.ODataFeature().PrefixName);
+                await _next(context).ConfigureAwait(false);
+                context.Request.DeleteSubRequestProvider(true);
+            }
+            else
+            {
+                await _next(context).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ConcurrentQuery/ConcurrentQueryTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ConcurrentQuery/ConcurrentQueryTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ConcurrentQuery
         /// For OData paths enable query should work with expansion.
         /// </summary>
         /// <returns>Task tracking operation.</returns>
-        ////[Fact] - Commented out as running this test right now throws 'Concurrent reads or writes are not supported' exception
+        [Fact]
         public async Task ConcurrentQueryExecutionIsThreadSafe()
         {
             // Arrange
@@ -61,7 +61,6 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ConcurrentQuery
                     request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
 
                     HttpResponseMessage response = await this.Client.SendAsync(request);
-
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
                     List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();

--- a/test/Microsoft.AspNetCore.OData.TestCommon/TestStartupBase.cs
+++ b/test/Microsoft.AspNetCore.OData.TestCommon/TestStartupBase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.OData.TestCommon
@@ -21,6 +22,8 @@ namespace Microsoft.AspNetCore.OData.TestCommon
             ConfigureBeforeRouting(app, env);
 
             app.UseRouting();
+
+            app.UseOData();
 
             ConfigureInRouting(app, env);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
@@ -587,7 +587,7 @@ Host: example.com
                 })
                 .Configure(app =>
                 {
-                    app.UseODataBatching();
+                    app.UseOData(batching: true);
                     app.UseRouting();
                     app.UseEndpoints(endpoints =>
                     {
@@ -794,8 +794,8 @@ Accept-Charset: UTF-8
                         applicationPartManager.ApplicationParts.Add(part);
                     }
 
-                    app.UseODataBatching();
                     app.UseRouting();
+                    app.UseOData(batching: true);
                     app.UseEndpoints(endpoints =>
                     {
                         endpoints.MapControllers();
@@ -890,7 +890,7 @@ Accept-Charset: UTF-8
                         applicationPartManager.ApplicationParts.Add(part);
                     }
 
-                    app.UseODataBatching();
+                    app.UseOData(batching: true);
                     app.UseRouting();
                     app.UseEndpoints(endpoints =>
                     {

--- a/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
@@ -794,8 +794,8 @@ Accept-Charset: UTF-8
                         applicationPartManager.ApplicationParts.Add(part);
                     }
 
-                    app.UseRouting();
                     app.UseOData(batching: true);
+                    app.UseRouting();
                     app.UseEndpoints(endpoints =>
                     {
                         endpoints.MapControllers();

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -5,7 +5,7 @@ public sealed class Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseODataBatching (Microsoft.AspNetCore.Builder.IApplicationBuilder app)
+	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseOData (Microsoft.AspNetCore.Builder.IApplicationBuilder app, params bool batching)
 }
 
 [
@@ -36,6 +36,15 @@ public sealed class Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions 
 public sealed class Microsoft.AspNetCore.OData.ODataUriFunctions {
 	public static void AddCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
 	public static bool RemoveCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
+}
+
+public class Microsoft.AspNetCore.OData.ODataMiddleware {
+	public ODataMiddleware (Microsoft.AspNetCore.Http.RequestDelegate next)
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public System.Threading.Tasks.Task InvokeAsync (Microsoft.AspNetCore.Http.HttpContext context)
 }
 
 public class Microsoft.AspNetCore.OData.ODataOptions {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -5,7 +5,7 @@ public sealed class Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseODataBatching (Microsoft.AspNetCore.Builder.IApplicationBuilder app)
+	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseOData (Microsoft.AspNetCore.Builder.IApplicationBuilder app, params bool batching)
 }
 
 [
@@ -36,6 +36,15 @@ public sealed class Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions 
 public sealed class Microsoft.AspNetCore.OData.ODataUriFunctions {
 	public static void AddCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
 	public static bool RemoveCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
+}
+
+public class Microsoft.AspNetCore.OData.ODataMiddleware {
+	public ODataMiddleware (Microsoft.AspNetCore.Http.RequestDelegate next)
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public System.Threading.Tasks.Task InvokeAsync (Microsoft.AspNetCore.Http.HttpContext context)
 }
 
 public class Microsoft.AspNetCore.OData.ODataOptions {


### PR DESCRIPTION
* Existing concurrency tests re-enabled and now pass.
* Made the `FilterQueryValidator` injected as scoped as opposed to singleton due to the max node counting field being shared across all concurrent requests causing a false positive for the max node detection.
* Removed `app.UseODataBatch()` and instead added `app.UseOData()` with a boolean value controlling batched mode. This is because a middleware is needed to set up the scoping, so the requirement to add a middleware is not just for batching anymore.