### PR TITLE
Support odata.bind or odata.id Link

### DIFF
--- a/sample/ODataRoutingSample/Controllers/v1/OrganizationsController.cs
+++ b/sample/ODataRoutingSample/Controllers/v1/OrganizationsController.cs
@@ -13,9 +13,11 @@ namespace ODataRoutingSample.Controllers.v1
     [ODataModel("v1")]
     public class OrganizationsController : Controller
     {
+        [EnableQuery]
         public IActionResult Post([FromBody]Organization org)
         {
-            return Ok();
+            org.OrganizationId = 99;
+            return Ok(org);
         }
 
         [HttpPatch]

--- a/sample/ODataRoutingSample/Controllers/v1/OrganizationsController.cs
+++ b/sample/ODataRoutingSample/Controllers/v1/OrganizationsController.cs
@@ -13,6 +13,11 @@ namespace ODataRoutingSample.Controllers.v1
     [ODataModel("v1")]
     public class OrganizationsController : Controller
     {
+        public IActionResult Post([FromBody]Organization org)
+        {
+            return Ok();
+        }
+
         [HttpPatch]
         [EnableQuery]
        // public IActionResult Patch(EdmChangedObjectCollection changes)

--- a/sample/ODataRoutingSample/Models/Organization.cs
+++ b/sample/ODataRoutingSample/Models/Organization.cs
@@ -17,5 +17,9 @@ namespace ODataRoutingSample.Models
     public class Department
     {
         public int DepartmentId { get; set; }
+
+        public string Alias { get; set; }
+
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -37,7 +37,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// <summary>
         /// Gets or sets the EDM model associated with the request.
         /// </summary>
-        public IEdmModel Model { get; set; }
+        public IEdmModel Model { get;
+            set; }
 
         /// <summary>
         /// Gets or sets the HTTP Request whose response is being serialized.

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -12090,6 +12090,30 @@
             Represents a segment that is not understood.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Parser.IODataPathParser.Parse(Microsoft.OData.Edm.IEdmModel,System.Uri,System.Uri,System.IServiceProvider)">
+            <summary>
+            Parses the specified OData path template as an <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate"/>.
+            </summary>
+            <param name="model">The Edm model.</param>
+            <param name="odataPath">The OData path template to parse.</param>
+            <param name="requestProvider">The OData service provider.</param>
+            <returns>A parsed representation of the template, or <c>null</c> if the template does not match the model.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Routing.Parser.DefaultODataPathParser">
+            <summary>
+            Exposes the ability to parse an OData path template as an <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Parser.DefaultODataPathParser.Parse(Microsoft.OData.Edm.IEdmModel,System.Uri,System.Uri,System.IServiceProvider)">
+            <summary>
+            Parse the string like "/users/{id}/contactFolders/{contactFolderId}/contacts"
+            to segments
+            </summary>
+            <param name="model">the Edm model.</param>
+            <param name="odataPath">the setting.</param>
+            <param name="requestProvider">The service provider.</param>
+            <returns>Null or <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate"/>.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Routing.Parser.DefaultODataPathTemplateParser">
             <summary>
             Exposes the ability to parse an OData path template as an <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate"/>.

--- a/src/Microsoft.AspNetCore.OData/Routing/Parser/DefaultODataPathParser.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Parser/DefaultODataPathParser.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.OData.Routing.Template;
+using Microsoft.OData.Edm;
+using Microsoft.OData;
+using Microsoft.OData.UriParser;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Extensions;
+
+namespace Microsoft.AspNetCore.OData.Routing.Parser
+{
+    public interface IODataPathParser
+    {
+        /// <summary>
+        /// Parses the specified OData path template as an <see cref="ODataPathTemplate"/>.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="odataPath">The OData path template to parse.</param>
+        /// <param name="requestProvider">The OData service provider.</param>
+        /// <returns>A parsed representation of the template, or <c>null</c> if the template does not match the model.</returns>
+        ODataPath Parse(IEdmModel model, Uri serviceRoot, Uri odataPath, IServiceProvider requestProvider);
+    }
+
+    /// <summary>
+    /// Exposes the ability to parse an OData path template as an <see cref="ODataPathTemplate"/>.
+    /// </summary>
+    public class DefaultODataPathParser : IODataPathParser
+    {
+        /// <summary>
+        /// Parse the string like "/users/{id}/contactFolders/{contactFolderId}/contacts"
+        /// to segments
+        /// </summary>
+        /// <param name="model">the Edm model.</param>
+        /// <param name="odataPath">the setting.</param>
+        /// <param name="requestProvider">The service provider.</param>
+        /// <returns>Null or <see cref="ODataPathTemplate"/>.</returns>
+        public virtual ODataPath Parse(IEdmModel model, Uri serviceRoot, Uri odataPath, IServiceProvider requestProvider)
+        {
+            ODataUriParser uriParser;
+            if (serviceRoot != null)
+            {
+                uriParser = new ODataUriParser(model, serviceRoot, odataPath, requestProvider);
+            }
+            else
+            {
+                uriParser = new ODataUriParser(model, odataPath, requestProvider);
+            }
+
+            uriParser.Resolver = new UnqualifiedODataUriResolver { EnableCaseInsensitive = true };
+            uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash; // support key in parenthese and key as segment.
+
+            return uriParser.ParsePath();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Routing/Parser/DefaultODataPathParser.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Parser/DefaultODataPathParser.cs
@@ -51,7 +51,14 @@ namespace Microsoft.AspNetCore.OData.Routing.Parser
             uriParser.Resolver = new UnqualifiedODataUriResolver { EnableCaseInsensitive = true };
             uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash; // support key in parenthese and key as segment.
 
-            return uriParser.ParsePath();
+            try
+            {
+                return uriParser.ParsePath();
+            }
+            catch (ODataException ex)
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Send request to:

`http://localhost:5000/v1/Organizations`

```json
{
  "@odata.context":"http://localhost:5000/v1/$metadata#Organizations/$entity",
  "Name": "Peter",
  "Departs@odata.bind":[ "Departments(4)", "Departments(5)"]
}

```

Or it can support:

`http://localhost:5000/v1/Organizations?$expand=Departs`

```json
{
  "@odata.context":"http://localhost:5000/v1/$metadata#Organizations/$entity",
  "Name": "Peter",
  "Departs": [{
     "@odata.id": "Departments(4)" 
  },
  {
      "@odata.id": "Departments(5)",
      "Alias": "No2"
  }
  ]
}
```

the response payload looks like: 

```json
{
    "@odata.context": "http://localhost:5000/v1/$metadata#Organizations(Departs())/$entity",
    "OrganizationId": 99,
    "Name": "Peter",
    "Departs": [
        {
            "DepartmentId": 4,
            "Alias": null,
            "Name": null
        },
        {
            "DepartmentId": 5,
            "Alias": "No2",
            "Name": null
        }
    ]
}
```
