### PR TITLE
Fix test failing after porting feature to OData 8.0-beta

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -9351,11 +9351,11 @@
             Be noted: should put this middle ware before "UseRouting()".
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware.#ctor(Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser,Microsoft.AspNetCore.Http.RequestDelegate)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware.#ctor(System.Collections.Generic.IEnumerable{Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser},Microsoft.AspNetCore.Http.RequestDelegate)">
             <summary>
             Instantiates a new instance of <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware"/>.
             </summary>
-            <param name="queryRequestParser">The query request parser.</param>
+            <param name="queryRequestParsers">The query request parsers.</param>
             <param name="next">The next middleware.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware.Invoke(Microsoft.AspNetCore.Http.HttpContext)">
@@ -9365,11 +9365,12 @@
             <param name="context">The http context.</param>
             <returns>A task that can be awaited.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware.TransformQueryRequestAsync(Microsoft.AspNetCore.Http.HttpRequest)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware.TransformQueryRequestAsync(Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser,Microsoft.AspNetCore.Http.HttpRequest)">
             <summary>
             Transforms a POST request targeted at a resource path ending in $query into a GET request.
             The query options are parsed from the request body and appended to the request URL.
             </summary>
+            <param name="parser">The query request parser.</param>
             <param name="request">The Http request.</param>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQuerySettings">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -11274,7 +11274,7 @@
             <summary>
             The convention for an odata template string.
             It looks for the <see cref="T:Microsoft.AspNetCore.Mvc.RouteAttribute"/> on controller
-            and <see cref="T:Microsoft.AspNetCore.Mvc.RouteAttribute"/> or other Http attribute for example <see cref="T:Microsoft.AspNetCore.Mvc.HttpGetAttribute"/> on action.
+            and <see cref="T:Microsoft.AspNetCore.Mvc.RouteAttribute"/> or other Http Verb attribute, for example <see cref="T:Microsoft.AspNetCore.Mvc.HttpGetAttribute"/> on action.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Routing.Conventions.AttributeRoutingConvention.#ctor(Microsoft.Extensions.Logging.ILogger{Microsoft.AspNetCore.OData.Routing.Conventions.AttributeRoutingConvention},Microsoft.AspNetCore.OData.Routing.Parser.IODataPathTemplateParser)">

--- a/src/Microsoft.AspNetCore.OData/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataServiceCollectionExtensions.cs
@@ -109,7 +109,8 @@ namespace Microsoft.AspNetCore.OData
                 throw Error.ArgumentNull(nameof(services));
             }
 
-            services.TryAddSingleton<IODataQueryRequestParser, DefaultODataQueryRequestParser>();
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IODataQueryRequestParser, DefaultODataQueryRequestParser>());
             services.TryAddSingleton<IAssemblyResolver, DefaultAssemblyResolver>();
             services.TryAddSingleton<IODataTypeMappingProvider, ODataTypeMappingProvider>();
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Commons/WebHostTestFixtureOfT.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Commons/WebHostTestFixtureOfT.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Commons
         {
             Type testType = typeof(TTest);
 
-            MethodInfo method  = testType.GetMethod("UpdateServices",
+            MethodInfo method  = testType.GetMethod("UpdateConfigureServices",
                 BindingFlags.NonPublic | BindingFlags.Static,
                 null,
                 new Type[] { typeof(IServiceCollection) },
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Commons
                    webBuilder
                         .UseKestrel(options =>
                         {
-                             options.Listen(IPAddress.Loopback, _port);
+                            options.Listen(IPAddress.Loopback, _port);
                         })
                         //.UseStartup<TTest>()
                        .ConfigureServices(services =>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/CustomQueryOptionsParserTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/CustomQueryOptionsParserTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
 using Xunit;
@@ -25,7 +26,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         {
             services.ConfigureControllers(typeof(DollarQueryCustomersController));
             services.AddOData(opt => opt.AddModel("odata", GetEdmModel()).Count().Filter().OrderBy().Expand().SetMaxTop(null).Select());
-            services.AddSingleton<IODataQueryRequestParser, CustomODataQueryOptionsParser>();
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IODataQueryRequestParser, CustomODataQueryOptionsParser>());
+            // NOTE: The following statement also does what is expected
+            // services.AddSingleton<IODataQueryRequestParser, CustomODataQueryOptionsParser>();
         }
 
         protected static void UpdateConfigure(IApplicationBuilder app)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/DollarQueryTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/DollarQueryTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.E2E.Tests.Commons;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
@@ -16,14 +17,14 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
 {
-    public class DollarQueryTests : WebApiTestBase<DollarQueryTests>
+    public class DollarQueryTests : WebHostTestBase<DollarQueryTests>
     {
         private const string CustomersResourcePath = "odata/DollarQueryCustomers";
         private const string SingleCustomerResourcePath = "odata/DollarQueryCustomers(1)";
         private const string ApplicationJsonODataMinimalMetadataStreamingTrue = "application/json;odata.metadata=minimal;odata.streaming=true";
         private const string ApplicationJsonODataMinimalMetadataStreamingFalse = "application/json;odata.metadata=minimal;odata.streaming=false";
 
-        public DollarQueryTests(WebApiTestFixture<DollarQueryTests> fixture)
+        public DollarQueryTests(WebHostTestFixture<DollarQueryTests> fixture)
             : base(fixture)
         {
         }
@@ -91,7 +92,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ForSupportedMediaType(string resourcePath, string queryOptionsPayload)
         {
             // Arrange
-            string requestUri = resourcePath + "/$query";
+            string requestUri = $"{this.BaseAddress}/{resourcePath}/$query";
             var contentType = "text/plain";
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
@@ -100,10 +101,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Arrange
             Assert.True(response.IsSuccessStatusCode);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ReturnsExpectedResult()
         {
             // Arrange
-            string requestUri = CustomersResourcePath + "/$query";
+            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
             var contentType = "text/plain";
             var queryOptionsPayload = "$filter=Id eq 1";
 
@@ -123,10 +123,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -137,7 +136,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_PlusQueryOptionsOnRequestUrl()
         {
             // Arrange
-            string requestUri = CustomersResourcePath + "/$query?$orderby=Id desc";
+            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query?$orderby=Id desc";
             var contentType = "text/plain";
             string payload = "$filter=Id eq 1 or Id eq 9";
 
@@ -147,10 +146,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = payload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -163,7 +161,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_RepeatedOnRequestUrl()
         {
             // Arrange
-            string requestUri = CustomersResourcePath + "/$query?$filter=Id eq 1";
+            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query?$filter=Id eq 1";
             var contentType = "text/plain";
             string payload = "$filter=Id eq 1";
 
@@ -173,10 +171,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = payload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -187,7 +184,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ForUnsupportedMediaType()
         {
             // Arrange
-            string requestUri = CustomersResourcePath + "/$query";
+            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
             var contentType = "application/xml";
             var queryOptionsPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><QueryOptions><filter>Id le 5</filter></QueryOptions>";
 
@@ -197,10 +194,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -210,7 +206,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_Empty()
         {
             // Arrange
-            string requestUri = CustomersResourcePath + "/$query";
+            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
             var contentType = "text/plain";
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
@@ -219,25 +215,21 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = 0;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var response = await client.SendAsync(request);
+            var response = await this.Client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
         }
 
-        [Fact(Skip = "It seems the 8192 can't make the long query options failing, need more investigation!")]
+        [Fact]
         public async Task ODataQueryOptionsInRequestBody_MitigateLimitViolationOnLongUrl()
         {
-            // KestrelServerLimits.MaxRequestLineSize equals 8192 so setting query string length to that value
-            // should be enough to make us breach the threshold
-            // NOTE: Change of limit could cause test to start failing
-            var queryStringLength = 8192;
+            var queryStringLength = new Server.Kestrel.Core.KestrelServerLimits().MaxRequestLineSize;
 
             // Arrange
-            var baseUri = CustomersResourcePath;
+            var baseUri = $"{this.BaseAddress}/{CustomersResourcePath}";
             var builder = new StringBuilder();
             var loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
@@ -254,13 +246,13 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
 
             var getRequest = new HttpRequestMessage(HttpMethod.Get, baseUri + '?' + queryOptionsString);
             getRequest.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-            HttpClient client = CreateClient();
 
             // Act
-            var getResponse = await client.SendAsync(getRequest);
+            var getResponse = await this.Client.SendAsync(getRequest);
 
             // Assert: Should fail because threshold is exceeed
             Assert.False(getResponse.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.RequestUriTooLong, getResponse.StatusCode);
 
             // Arrange: Now send the same query string in the request body
             var postRequest = new HttpRequestMessage(HttpMethod.Post, baseUri + "/$query");
@@ -269,7 +261,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             postRequest.Content.Headers.ContentType = new MediaTypeWithQualityHeaderValue(contentType);
 
             // Act
-            var postResponse = await client.SendAsync(postRequest);
+            var postResponse = await this.Client.SendAsync(postRequest);
 
             // Assert: Should pass because the query options were sent in the request body
             Assert.True(postResponse.IsSuccessStatusCode);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/DollarQueryTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryRequest/DollarQueryTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.OData.E2E.Tests.Commons;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
@@ -17,14 +16,14 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
 {
-    public class DollarQueryTests : WebHostTestBase<DollarQueryTests>
+    public class DollarQueryTests : WebApiTestBase<DollarQueryTests>
     {
         private const string CustomersResourcePath = "odata/DollarQueryCustomers";
         private const string SingleCustomerResourcePath = "odata/DollarQueryCustomers(1)";
         private const string ApplicationJsonODataMinimalMetadataStreamingTrue = "application/json;odata.metadata=minimal;odata.streaming=true";
         private const string ApplicationJsonODataMinimalMetadataStreamingFalse = "application/json;odata.metadata=minimal;odata.streaming=false";
 
-        public DollarQueryTests(WebHostTestFixture<DollarQueryTests> fixture)
+        public DollarQueryTests(WebApiTestFixture<DollarQueryTests> fixture)
             : base(fixture)
         {
         }
@@ -92,7 +91,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ForSupportedMediaType(string resourcePath, string queryOptionsPayload)
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{resourcePath}/$query";
+            string requestUri = resourcePath + "/$query";
             var contentType = "text/plain";
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
@@ -101,9 +100,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Arrange
             Assert.True(response.IsSuccessStatusCode);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ReturnsExpectedResult()
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
+            string requestUri = CustomersResourcePath + "/$query";
             var contentType = "text/plain";
             var queryOptionsPayload = "$filter=Id eq 1";
 
@@ -123,9 +123,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -136,7 +137,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_PlusQueryOptionsOnRequestUrl()
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query?$orderby=Id desc";
+            string requestUri = CustomersResourcePath + "/$query?$orderby=Id desc";
             var contentType = "text/plain";
             string payload = "$filter=Id eq 1 or Id eq 9";
 
@@ -146,9 +147,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = payload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -161,7 +163,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_RepeatedOnRequestUrl()
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query?$filter=Id eq 1";
+            string requestUri = CustomersResourcePath + "/$query?$filter=Id eq 1";
             var contentType = "text/plain";
             string payload = "$filter=Id eq 1";
 
@@ -171,9 +173,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = payload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -184,7 +187,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_ForUnsupportedMediaType()
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
+            string requestUri = CustomersResourcePath + "/$query";
             var contentType = "application/xml";
             var queryOptionsPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><QueryOptions><filter>Id le 5</filter></QueryOptions>";
 
@@ -194,9 +197,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = queryOptionsPayload.Length;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -206,7 +210,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
         public async Task ODataQueryOptionsInRequestBody_Empty()
         {
             // Arrange
-            string requestUri = $"{this.BaseAddress}/{CustomersResourcePath}/$query";
+            string requestUri = CustomersResourcePath + "/$query";
             var contentType = "text/plain";
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
@@ -215,56 +219,13 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Routing.QueryRequest
             request.Content.Headers.ContentLength = 0;
 
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
+            HttpClient client = CreateClient();
 
             // Act
-            var response = await this.Client.SendAsync(request);
+            var response = await client.SendAsync(request);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
-        }
-
-        [Fact]
-        public async Task ODataQueryOptionsInRequestBody_MitigateLimitViolationOnLongUrl()
-        {
-            var queryStringLength = new Server.Kestrel.Core.KestrelServerLimits().MaxRequestLineSize;
-
-            // Arrange
-            var baseUri = $"{this.BaseAddress}/{CustomersResourcePath}";
-            var builder = new StringBuilder();
-            var loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
-            builder.AppendFormat("$filter=Name eq '{0}", loremIpsum);
-            // Ensure that query string breaches the threshold
-            do
-            {
-                builder.AppendFormat(" {0}", loremIpsum);
-            }
-            while (builder.Length < queryStringLength);
-
-            builder.Append("'");
-            var queryOptionsString = builder.ToString();
-
-            var getRequest = new HttpRequestMessage(HttpMethod.Get, baseUri + '?' + queryOptionsString);
-            getRequest.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ApplicationJsonODataMinimalMetadataStreamingTrue));
-
-            // Act
-            var getResponse = await this.Client.SendAsync(getRequest);
-
-            // Assert: Should fail because threshold is exceeed
-            Assert.False(getResponse.IsSuccessStatusCode);
-            Assert.Equal(HttpStatusCode.RequestUriTooLong, getResponse.StatusCode);
-
-            // Arrange: Now send the same query string in the request body
-            var postRequest = new HttpRequestMessage(HttpMethod.Post, baseUri + "/$query");
-            var contentType = "text/plain";
-            postRequest.Content = new StringContent(queryOptionsString);
-            postRequest.Content.Headers.ContentType = new MediaTypeWithQualityHeaderValue(contentType);
-
-            // Act
-            var postResponse = await this.Client.SendAsync(postRequest);
-
-            // Assert: Should pass because the query options were sent in the request body
-            Assert.True(postResponse.IsSuccessStatusCode);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -1369,7 +1369,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.As
 }
 
 public class Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware {
-	public ODataQueryRequestMiddleware (Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser queryRequestParser, Microsoft.AspNetCore.Http.RequestDelegate next)
+	public ODataQueryRequestMiddleware (System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser]] queryRequestParsers, Microsoft.AspNetCore.Http.RequestDelegate next)
 
 	[
 	AsyncStateMachineAttribute(),

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -1369,7 +1369,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.As
 }
 
 public class Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware {
-	public ODataQueryRequestMiddleware (Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser queryRequestParser, Microsoft.AspNetCore.Http.RequestDelegate next)
+	public ODataQueryRequestMiddleware (System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser]] queryRequestParsers, Microsoft.AspNetCore.Http.RequestDelegate next)
 
 	[
 	AsyncStateMachineAttribute(),


### PR DESCRIPTION
Fixes test failing subsequent to porting feature to support passing of query options in request body
Related to #119  