### PR TITLE
closes #125: removed cast to KeySegmentTemplate

### DIFF
--- a/sample/ODataDynamicModel/Extensions/EntitySetWithKeyTemplateSegment.cs
+++ b/sample/ODataDynamicModel/Extensions/EntitySetWithKeyTemplateSegment.cs
@@ -14,9 +14,9 @@ namespace ODataDynamicModel.Extensions
 {
     public class EntitySetWithKeyTemplateSegment : ODataSegmentTemplate
     {
-        public override string Literal => "{entityset}({key})";
+        public override string Literal => "{key}";
 
-        public override ODataSegmentKind Kind => ODataSegmentKind.EntitySet;
+        public override ODataSegmentKind Kind => ODataSegmentKind.Key;
 
         public override IEdmType EdmType => null;
 

--- a/sample/ODataDynamicModel/Extensions/MyODataRoutingApplicationModelProvider.cs
+++ b/sample/ODataDynamicModel/Extensions/MyODataRoutingApplicationModelProvider.cs
@@ -54,6 +54,7 @@ namespace ODataDynamicModel.Extensions
                 if (actionModel.ActionName == "GetNavigation")
                 {
                     ODataPathTemplate path = new ODataPathTemplate(
+                        new EntitySetTemplateSegment(),
                         new EntitySetWithKeyTemplateSegment(),
                         new NavigationTemplateSegment());
 
@@ -62,6 +63,7 @@ namespace ODataDynamicModel.Extensions
                 else if (actionModel.ActionName == "GetName")
                 {
                     ODataPathTemplate path = new ODataPathTemplate(
+                        new EntitySetTemplateSegment(),
                         new EntitySetWithKeyTemplateSegment(),
                         new StaticNameSegment());
 
@@ -76,7 +78,7 @@ namespace ODataDynamicModel.Extensions
                     }
                     else
                     {
-                        ODataPathTemplate path = new ODataPathTemplate(new EntitySetWithKeyTemplateSegment());
+                        ODataPathTemplate path = new ODataPathTemplate(new EntitySetTemplateSegment(), new EntitySetWithKeyTemplateSegment());
                         actionModel.AddSelector("get", prefix, model, path);
                     }
                 }

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/ODataPathTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/ODataPathTemplate.cs
@@ -70,8 +70,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 {
                     // for key segment, if it's single key, let's add key as segment template also
                     // otherwise, we only add the key in parenthesis template.
-                    KeySegmentTemplate keySg = segment as KeySegmentTemplate;
-                    templates = AppendKeyTemplate(templates, keySg, options);
+                    templates = AppendKeyTemplate(templates, segment, options);
                     continue;
                 }
 
@@ -98,8 +97,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                             templates = CombinateTemplates(templates, navigationLinkSegment.Segment.NavigationProperty.Name);
 
                             // append "key"
-                            KeySegmentTemplate keySg = nextSegment as KeySegmentTemplate;
-                            templates = AppendKeyTemplate(templates, keySg, options);
+                            templates = AppendKeyTemplate(templates, nextSegment, options);
 
                             // append $ref
                             templates = CombinateTemplates(templates, "/$ref");
@@ -133,7 +131,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
             return templates.Select(t => t.ToString());
         }
 
-        private static IList<StringBuilder> AppendKeyTemplate(IList<StringBuilder> templates, KeySegmentTemplate segment, ODataRouteOptions options)
+        private static IList<StringBuilder> AppendKeyTemplate(IList<StringBuilder> templates, ODataSegmentTemplate segment, ODataRouteOptions options)
         {
             Contract.Assert(segment != null);
             Contract.Assert(options != null);


### PR DESCRIPTION
Removing cast to KeySegmentTemplate so we get path segment key and parenthesis as well. 