### PR TITLE
#74 count in filter throws not supported

### DIFF
--- a/sample/ODataRoutingSample/Controllers/v1/CustomersController.cs
+++ b/sample/ODataRoutingSample/Controllers/v1/CustomersController.cs
@@ -81,6 +81,7 @@ namespace ODataRoutingSample.Controllers.v1
             {
                 new Customer
                 {
+                    Id = 1,
                     Name = "Jonier",
                     FavoriteColor = Color.Red,
                     HomeAddress = new Address { City = "Redmond", Street = "156 AVE NE" },
@@ -92,6 +93,7 @@ namespace ODataRoutingSample.Controllers.v1
                 },
                 new Customer
                 {
+                    Id = 2,
                     Name = "Sam",
                     FavoriteColor = Color.Blue,
                     HomeAddress = new CnAddress { City = "Bellevue", Street = "Main St NE", Postcode = "201100" },
@@ -103,6 +105,7 @@ namespace ODataRoutingSample.Controllers.v1
                 },
                 new Customer
                 {
+                    Id = 3,
                     Name = "Peter",
                     FavoriteColor = Color.Green,
                     HomeAddress = new UsAddress { City = "Hollewye", Street = "Main St NE", Zipcode = "98029" },

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
@@ -858,6 +858,10 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                     // No setting validations
                     break;
 
+                case QueryNodeKind.Count:
+                    // No setting validations
+                    break;
+
                 case QueryNodeKind.NamedFunctionParameter:
                 case QueryNodeKind.ParameterAlias:
                 case QueryNodeKind.EntitySet:

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultController.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ActionResult
     public class CustomersController : ControllerBase
     {
         [HttpGet]
-        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Expand)]
+        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Expand | AllowedQueryOptions.Filter)]
         public async Task<ActionResult<IEnumerable<Customer>>> Get()
         {
             return await Task.FromResult(new List<Customer>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ActionResult
         public async Task ActionResultODataPathReturnsExpansion()
         {
             // Arrange
-            string queryUrl = string.Format("odata/Customers?$expand=books");
+            string queryUrl = "odata/Customers?$expand=books";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
 
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ActionResult
         public async Task ActionResultODataPathReturnsBaseWithoutExpansion()
         {
             // Arrange
-            string queryUrl = string.Format("odata/Customers");
+            string queryUrl = "odata/Customers";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
 
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ActionResult
         public async Task ActionResultShouldAllowCountInFilter(int filterParam, int expectedItemsCount)
         {
             // Arrange
-            string queryUrl = string.Format($"odata/Customers?$filter=Books/$count eq {filterParam}");
+            string queryUrl = $"odata/Customers?$filter=Books/$count eq {filterParam}";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/ActionResult/ActionResultTests.cs
@@ -89,5 +89,30 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.ActionResult
             Assert.Equal("CustId", customers.First().Id);
             Assert.Null(customers.First().Books);
         }
+
+        /// <summary>
+        /// $filter should work with $count.
+        /// </summary>
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(0, 0)]
+        public async Task ActionResultShouldAllowCountInFilter(int filterParam, int expectedItemsCount)
+        {
+            // Arrange
+            string queryUrl = string.Format($"odata/Customers?$filter=Books/$count eq {filterParam}");
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+
+            // Act
+            HttpResponseMessage response = await this.Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
+
+            Assert.Equal(expectedItemsCount, customers.Count());
+
+        }
     }
 }


### PR DESCRIPTION

- Added `QueryNodeKind.Count` as a valid option on  `ValidateSingleValueNode`
- Added e2e tests for $count in $filter
- Fixed missing Id's in customer list on ODataRoutingSample