### PR TITLE
Incorrect Assert in ConvertPrimitiveValue

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -124,11 +124,24 @@ namespace Microsoft.AspNetCore.OData.Edm
                 }
                 else
                 {
-                    Contract.Assert(type == typeof(uint) || type == typeof(ushort) || type == typeof(ulong));
-
-                    // Note that we are not casting the return value to nullable<T> as even if we do it
-                    // CLR would unbox it back to T.
-                    return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
+                    try
+                    {
+                        // Note that we are not casting the return value to nullable<T> as even if we do it
+                        // CLR would unbox it back to T.
+                        return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
+                    }
+                    catch (InvalidCastException)
+                    {
+                        throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, type));
+                    }
+                    catch (FormatException)
+                    {
+                        throw new ValidationException(Error.Format(SRResources.PropertyUnrecognizedFormat, type));
+                    }
+                    catch (OverflowException)
+                    {
+                        throw new ValidationException(Error.Format(SRResources.PropertyTypeOverflow, type));
+                    }
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
@@ -241,10 +242,10 @@ namespace Microsoft.AspNetCore.OData.Formatter
             ILogger logger = context.RequestServices.GetService<ILogger>();
             if (logger == null)
             {
-                throw ex;
+                ExceptionDispatchInfo.Capture(ex).Throw();
             }
 
-            logger.LogError(ex, String.Empty);
+            logger.LogError(ex, string.Empty);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6872,6 +6872,11 @@
               Looks up a localized string similar to The type &apos;{0}&apos; of the parameter &apos;{1}&apos; must be a collection..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyCannotBeConverted">
+            <summary>
+              Looks up a localized string similar to The value cannot be converted to type {0}..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyIsNotCollection">
             <summary>
               Looks up a localized string similar to The type &apos;{0}&apos; of the property &apos;{1}&apos; on type &apos;{2}&apos; must be a collection..
@@ -6925,6 +6930,16 @@
         <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyOrPathWasRemovedFromContext">
             <summary>
               Looks up a localized string similar to Property or path {0} isn&apos;t available in the current context. It was removed in earlier transformation..
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyTypeOverflow">
+            <summary>
+              Looks up a localized string similar to The value has a value that is out of range of type {0}..
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyUnrecognizedFormat">
+            <summary>
+              Looks up a localized string similar to The value has a format that is not recognized by type {0}..
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.QueryCannotBeEmpty">

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -1276,6 +1276,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value cannot be converted to type {0}..
+        /// </summary>
+        internal static string PropertyCannotBeConverted {
+            get {
+                return ResourceManager.GetString("PropertyCannotBeConverted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; of the property &apos;{1}&apos; on type &apos;{2}&apos; must be a collection..
         /// </summary>
         internal static string PropertyIsNotCollection {
@@ -1371,6 +1380,24 @@ namespace Microsoft.AspNetCore.OData {
         internal static string PropertyOrPathWasRemovedFromContext {
             get {
                 return ResourceManager.GetString("PropertyOrPathWasRemovedFromContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value has a value that is out of range of type {0}..
+        /// </summary>
+        internal static string PropertyTypeOverflow {
+            get {
+                return ResourceManager.GetString("PropertyTypeOverflow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value has a format that is not recognized by type {0}..
+        /// </summary>
+        internal static string PropertyUnrecognizedFormat {
+            get {
+                return ResourceManager.GetString("PropertyUnrecognizedFormat", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -1,103 +1,122 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
-        Microsoft ResX Schema
-
-        Version 1.3
-
-        The primary goals of this format is to allow a simple XML format 
-        that is mostly human readable. The generation and parsing of the 
-        various data types are done through the TypeConverter classes 
-        associated with the data types.
-
-        Example:
+  <!-- 
+    Microsoft ResX Schema 
     
-        ... ado.net/XML headers & schema ...
-        <resheader name="resmimetype">text/microsoft-resx</resheader>
-        <resheader name="version">1.3</resheader>
-        <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-        <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-        <data name="Name1">this is my long string</data>
-        <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-        <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-            [base64 mime encoded serialized .NET Framework object]
-        </data>
-        <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-            [base64 mime encoded string representing a byte array form of the .NET Framework object]
-        </data>
-
-        There are any number of "resheader" rows that contain simple 
-        name/value pairs.
-
-        Each data row contains a name, and value. The row also contains a 
-        type or mimetype. Type corresponds to a .NET class that support 
-        text/value conversion through the TypeConverter architecture. 
-        Classes that don't support this are serialized and stored with the 
-        mimetype set.
-
-        The mimetype is used for serialized objects, and tells the 
-        ResXResourceReader how to depersist the object. This is currently not 
-        extensible. For a given mimetype the value must be set accordingly:
-
-        Note - application/x-microsoft.net.object.binary.base64 is the format 
-        that the ResXResourceWriter will generate, however the reader can 
-        read any of the formats listed below.
-
-        mimetype: application/x-microsoft.net.object.binary.base64
-        value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
-        mimetype: application/x-microsoft.net.object.soap.base64
-        value   : The object must be serialized with 
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
-        mimetype: application/x-microsoft.net.object.bytearray.base64
-        value   : The object must be serialized into a byte array 
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" />
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>1.3</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="NullContainer" xml:space="preserve">
     <value>The container built by the container builder must not be null.</value>
   </data>
@@ -661,5 +680,14 @@
   </data>
   <data name="CannotParseQueryRequestPayload" xml:space="preserve">
     <value>Unable to parse query request payload.</value>
+  </data>
+  <data name="PropertyCannotBeConverted" xml:space="preserve">
+    <value>The value cannot be converted to type {0}.</value>
+  </data>
+  <data name="PropertyTypeOverflow" xml:space="preserve">
+    <value>The value has a value that is out of range of type {0}.</value>
+  </data>
+  <data name="PropertyUnrecognizedFormat" xml:space="preserve">
+    <value>The value has a format that is not recognized by type {0}.</value>
   </data>
 </root>

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Xml.Linq;
-using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.AspNetCore.OData.Tests.Commons;
@@ -14,56 +13,105 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
 {
     public class EdmPrimitiveHelperTests
     {
-        public static TheoryDataSet<object, object, Type> ConvertPrimitiveValue_NonStandardPrimitives_Data
+        private enum TestEnum
         {
-            get
-            {
-                return new TheoryDataSet<object, object, Type>
-                {
-                     { "1", (char)'1', typeof(char) },
-                     { "1", (char?)'1', typeof(char?) },
-                     { "123", (char[]) new char[] {'1', '2', '3' }, typeof(char[]) },
-                     { (int)1 , (ushort)1, typeof(ushort)},
-                     { (int?)1, (ushort?)1,  typeof(ushort?) },
-                     { (long)1, (uint)1,  typeof(uint) },
-                     { (long?)1, (uint?)1, typeof(uint?) },
-                     { (long)1 , (ulong)1, typeof(ulong)},
-                     { (long?)1 ,(ulong?)1, typeof(ulong?)},
-                    //(Stream) new MemoryStream(new byte[] { 1 }), // TODO: Enable once we have support for streams
-                     { "<element xmlns=\"namespace\" />" ,(XElement)new XElement(XName.Get("element","namespace")), typeof(XElement)},
-                };
-            }
+            Zero = 0,
+            One = 1,
+            Two = 2,
+            Three = 3
+        };
+
+        private struct TestStruct
+        {
+            public int X { get; set; }
         }
 
+        public static TheoryDataSet<object, object, Type> ConvertPrimitiveValue_NonStandardPrimitives_Data
+            => new TheoryDataSet<object, object, Type>
+                {
+                    { 1, 1, typeof(int) },
+                    { "1", (char)'1', typeof(char) },
+                    { "1", (char?)'1', typeof(char?) },
+                    { "123", (char[]) new char[] {'1', '2', '3' }, typeof(char[]) },
+                    { (int)1 , (ushort)1, typeof(ushort)},
+                    { (int?)1, (ushort?)1,  typeof(ushort?) },
+                    { (long)1, (uint)1,  typeof(uint) },
+                    { (long?)1, (uint?)1, typeof(uint?) },
+                    { (long)1 , (ulong)1, typeof(ulong) },
+                    { (long?)1 ,(ulong?)1, typeof(ulong?) },
+                    //(Stream) new MemoryStream(new byte[] { 1 }), // TODO: Enable once we have support for streams
+                    { "<element xmlns=\"namespace\" />" ,(XElement)new XElement(XName.Get("element","namespace")), typeof(XElement)}
+                };
+
+        public static TheoryDataSet<object, object, Type> ConvertPrimitiveValue_NonStandardPrimitives_ExtraData
+            => new TheoryDataSet<object, object, Type>
+                {
+                    { "", (char?)null, typeof(char?) },
+                    { "Two", TestEnum.Two, typeof(TestEnum) },
+                    { "True", true, typeof(bool) },
+                    { "true", true, typeof(bool) },
+                    { "  True  ", true, typeof(bool) },
+                    { "False", false, typeof(bool) },
+                    { "false", false, typeof(bool) },
+                    { "  False  ", false, typeof(bool) },
+                    { TestEnum.Two, (double)2.0, typeof(double) }
+                };
+
+        public static TheoryDataSet<object, Type, string> ConvertThrow_NonStandardPrimitives_Data
+            => new TheoryDataSet<object, Type, string>
+                {
+                    { 9, typeof(char), "The value must be a string with a length of 1." },
+                    { "", typeof(char), "The value must be a string with a length of 1." },
+                    { "123", typeof(char), "The value must be a string with a length of 1." },
+                    { 9, typeof(char?), "The value must be a string with a maximum length of 1." },
+                    { "123", typeof(char?), "The value must be a string with a maximum length of 1." },
+                    { 123, typeof(XElement), "The value must be a string." },
+                    { 9, typeof(char[]), "The value must be a string." },
+                    { 9, typeof(XElement), "The value must be a string." },
+                    { 9, typeof(TestEnum), "The value must be a string." },
+                    { 9, typeof(DateTime), "The value must be a DateTimeOffset or Date." },
+                    { 9, typeof(TimeSpan), "The value must be a Edm.TimeOfDay." },
+                    { "", typeof(bool), "The value must be a boolean." },
+                    { "0", typeof(bool), "The value must be a boolean." },
+                    { 0, typeof(bool), "The value must be a boolean." },
+                    { 1024, typeof(byte), "The value has a value that is out of range of type System.Byte." },
+                    { "data", typeof(long),  "The value has a format that is not recognized by type System.Int64." },
+                    { "data", typeof(TestStruct),  "The value cannot be converted to type Microsoft.AspNetCore.OData.Tests.Edm.EdmPrimitiveHelperTests+TestStruct." },
+                    { new TestStruct(), typeof(int),  "The value cannot be converted to type System.Int32." }
+                };
+
         public static TheoryDataSet<DateTimeOffset> ConvertDateTime_NonStandardPrimitives_Data
-        {
-            get
-            {
-                return new TheoryDataSet<DateTimeOffset>
+            => new TheoryDataSet<DateTimeOffset>
                 {
                     DateTimeOffset.Parse("2014-12-12T01:02:03Z"),
                     DateTimeOffset.Parse("2014-12-12T01:02:03-8:00"),
                     DateTimeOffset.Parse("2014-12-12T01:02:03+8:00"),
                 };
-            }
-        }
 
         [Theory]
         [MemberData(nameof(ConvertPrimitiveValue_NonStandardPrimitives_Data))]
+        [MemberData(nameof(ConvertPrimitiveValue_NonStandardPrimitives_ExtraData))] 
         public void ConvertPrimitiveValue_NonStandardPrimitives(object valueToConvert, object result, Type conversionType)
         {
             // Arrange & Act
             object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, conversionType);
 
             // Assert
-            Assert.Equal(result.GetType(), actual.GetType());
-            Assert.Equal(result.ToString(), actual.ToString());
+            if (result == null)
+            {
+                Assert.Equal(result, actual);
+            }
+            else
+            {
+                Assert.Equal(result.GetType(), actual.GetType());
+                Assert.Equal(result.ToString(), actual.ToString());
+            }
         }
 
         [Theory]
         [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
         public void ConvertDateTimeValue_NonStandardPrimitives_DefaultTimeZoneInfo(DateTimeOffset valueToConvert)
-        { 
+        {
             // Arrange & Act
             object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
 
@@ -86,32 +134,13 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
         }
 
         [Theory]
-        [InlineData("123")]
-        [InlineData("")]
-        public void ConvertPrimitiveValueToChar_Throws(string input)
+        [MemberData(nameof(ConvertThrow_NonStandardPrimitives_Data))]
+        public void ConvertPrimitiveValue_Throws(object valueToConvert, Type conversionType, string exception)
         {
             // Arrange & Act & Assert
             ExceptionAssert.Throws<ValidationException>(
-                () => EdmPrimitiveHelper.ConvertPrimitiveValue(input, typeof(char)),
-                "The value must be a string with a length of 1.");
-        }
-
-        [Fact]
-        public void ConvertPrimitiveValueToNullableChar_Throws()
-        {
-            // Arrange & Act & Assert
-            ExceptionAssert.Throws<ValidationException>(
-                () => EdmPrimitiveHelper.ConvertPrimitiveValue("123", typeof(char?)),
-                "The value must be a string with a maximum length of 1.");
-        }
-
-        [Fact]
-        public void ConvertPrimitiveValueToXElement_Throws_IfInputIsNotString()
-        {
-            // Arrange & Act & Assert
-            ExceptionAssert.Throws<ValidationException>(
-                () => EdmPrimitiveHelper.ConvertPrimitiveValue(123, typeof(XElement)),
-                "The value must be a string.");
+                () => EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, conversionType),
+                exception);
         }
     }
 }


### PR DESCRIPTION
Incorrect Assert in ConvertPrimitiveValue
LoggerError unnecessarily adds an additional frame to call stack
Fixes #131 
Fixes #140 

Change `ConvertPrimitiveValue` to simply call `Convert.ChangeType` and catch the common exceptions that indicate a type conversion is not allowed, then throw a corresponding `ValidationException`.

Update test cases to cover almost all of the code paths.

**Note**: `ConvertPrimitiveValue_NonStandardPrimitives_Data` is shared by tests for other methods with slightly different semantics, so the two tests vectors cannot be merged.
 
Rewrite the Throw test cases to use a common simplified test method.