### PR TITLE
Add ODataResourceSerializer tests and fixes for dynamic property support

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -598,7 +598,6 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 dynamicPropertyDictionary.Where(x => selectExpandNode.SelectedDynamicProperties == null || selectExpandNode.SelectedDynamicProperties.Contains(x.Key));
             foreach (KeyValuePair<string, object> dynamicProperty in dynamicPropertiesToSelect)
             {
-                // TODO: test dynamic properties with null/empty keys not included
                 if (string.IsNullOrEmpty(dynamicProperty.Key))
                 {
                     continue;

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -985,7 +985,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 
             // Assert
             Assert.Equal("Default.Customer", resource.TypeName);
-            Assert.Equal(3, resource.Properties.Count());
+            Assert.Equal(4, resource.Properties.Count());
 
             // Verify the declared properties
             ODataProperty street = Assert.Single(resource.Properties.Where(p => p.Name == "CustomerId"));
@@ -1001,8 +1001,205 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             ODataProperty guidProperty = Assert.Single(resource.Properties.Where(p => p.Name == "GuidProperty"));
             Assert.Equal(new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"), guidProperty.Value);
 
-            ODataProperty nullProperty = resource.Properties.SingleOrDefault(p => p.Name == "NullProperty");
-            Assert.Null(nullProperty);
+            ODataProperty nullProperty = resource.Properties.Single(p => p.Name == "NullProperty");
+            Assert.Null(nullProperty.Value);
+        }
+
+        [Fact]
+        public void CreateResource_Works_ToIgnoreDynamicPropertiesWithEmptyNames_ForOpenEntityType()
+        {
+            // Arrange
+            IEdmModel model = SerializationTestsHelpers.SimpleOpenTypeModel();
+
+            IEdmEntitySet customers = model.EntityContainer.FindEntitySet("Customers");
+
+            IEdmEntityType customerType = model.FindDeclaredType("Default.Customer") as IEdmEntityType;
+            Type simpleOpenCustomer = typeof(SimpleOpenCustomer);
+            model.SetAnnotationValue(customerType, new ClrTypeAnnotation(simpleOpenCustomer));
+
+            IEdmComplexType addressType = model.FindDeclaredType("Default.Address") as IEdmComplexType;
+            Type simpleOpenAddress = typeof(SimpleOpenAddress);
+            model.SetAnnotationValue(addressType, new ClrTypeAnnotation(simpleOpenAddress));
+
+            IEdmEnumType enumType = model.FindDeclaredType("Default.SimpleEnum") as IEdmEnumType;
+            Type simpleEnumType = typeof(SimpleEnum);
+            model.SetAnnotationValue(enumType, new ClrTypeAnnotation(simpleEnumType));
+
+            model.SetAnnotationValue(customerType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenCustomer.GetProperty("CustomerProperties")));
+
+            model.SetAnnotationValue(addressType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenAddress.GetProperty("Properties")));
+
+            ODataResourceSerializer serializer = new ODataResourceSerializer(_serializerProvider);
+
+            var request = RequestFactory.Create(opt => opt.AddModel("route", model));
+            request.ODataFeature().PrefixName = "route";
+            SelectExpandNode selectExpandNode = new SelectExpandNode(null, customerType, model);
+            ODataSerializerContext writeContext = new ODataSerializerContext
+            {
+                Model = model,
+                Path = new ODataPath(new EntitySetSegment(customers)),
+                Request = request
+            };
+
+            SimpleOpenCustomer customer = new SimpleOpenCustomer()
+            {
+                CustomerId = 991,
+                Name = "Name #991",
+                Address = new SimpleOpenAddress
+                {
+                    City = "a city",
+                    Street = "a street",
+                    Properties = new Dictionary<string, object> { { "ArrayProperty", new[] { "15", "14", "13" } } }
+                },
+                CustomerProperties = new Dictionary<string, object>()
+            };
+
+            customer.CustomerProperties.Add("GuidProperty", new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"));
+            customer.CustomerProperties.Add("", "EmptyProperty");
+
+            ResourceContext entityContext = new ResourceContext(writeContext,
+                customerType.ToEdmTypeReference(false) as IEdmEntityTypeReference, customer);
+
+            // Act
+            ODataResource resource = serializer.CreateResource(selectExpandNode, entityContext);
+
+            // Assert
+            Assert.Equal("Default.Customer", resource.TypeName);
+            Assert.Equal(3, resource.Properties.Count());
+
+            // Verify properties with empty names are ignored
+            ODataProperty emptyProperty = resource.Properties.SingleOrDefault(p => p.Name == "");
+            Assert.Null(emptyProperty);
+        }
+
+        [Fact]
+        public void CreateResource_Throws_IfDynamicPropertyUsesExistingName_ForOpenType()
+        {
+            // Arrange
+            IEdmModel model = SerializationTestsHelpers.SimpleOpenTypeModel();
+
+            IEdmEntitySet customers = model.EntityContainer.FindEntitySet("Customers");
+
+            IEdmEntityType customerType = model.FindDeclaredType("Default.Customer") as IEdmEntityType;
+            Type simpleOpenCustomer = typeof(SimpleOpenCustomer);
+            model.SetAnnotationValue(customerType, new ClrTypeAnnotation(simpleOpenCustomer));
+
+            IEdmComplexType addressType = model.FindDeclaredType("Default.Address") as IEdmComplexType;
+            Type simpleOpenAddress = typeof(SimpleOpenAddress);
+            model.SetAnnotationValue(addressType, new ClrTypeAnnotation(simpleOpenAddress));
+
+            IEdmEnumType enumType = model.FindDeclaredType("Default.SimpleEnum") as IEdmEnumType;
+            Type simpleEnumType = typeof(SimpleEnum);
+            model.SetAnnotationValue(enumType, new ClrTypeAnnotation(simpleEnumType));
+
+            model.SetAnnotationValue(customerType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenCustomer.GetProperty("CustomerProperties")));
+
+            model.SetAnnotationValue(addressType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenAddress.GetProperty("Properties")));
+
+            ODataResourceSerializer serializer = new ODataResourceSerializer(_serializerProvider);
+
+            var request = RequestFactory.Create(opt => opt.AddModel("route", model));
+            request.ODataFeature().PrefixName = "route";
+            SelectExpandNode selectExpandNode = new SelectExpandNode(null, customerType, model);
+            ODataSerializerContext writeContext = new ODataSerializerContext
+            {
+                Model = model,
+                Path = new ODataPath(new EntitySetSegment(customers)),
+                Request = request
+            };
+
+            SimpleOpenCustomer customer = new SimpleOpenCustomer()
+            {
+                CustomerId = 991,
+                Name = "Name #991",
+                Address = new SimpleOpenAddress
+                {
+                    City = "a city",
+                    Street = "a street",
+                    Properties = new Dictionary<string, object> { { "ArrayProperty", new[] { "15", "14", "13" } } }
+                },
+                CustomerProperties = new Dictionary<string, object>()
+            };
+
+            customer.CustomerProperties.Add("GuidProperty", new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"));
+            customer.CustomerProperties.Add("Name", "DynamicName");
+
+            ResourceContext entityContext = new ResourceContext(writeContext,
+                customerType.ToEdmTypeReference(false) as IEdmEntityTypeReference, customer);
+
+            // Act & Assert
+            ExceptionAssert.Throws<InvalidOperationException>(
+                () => serializer.CreateResource(selectExpandNode, entityContext),
+                "Name",
+                partialMatch: true);
+        }
+
+        [Fact]
+        public void CreateResource_Throws_IfNullDynamicPropertyUsesExistingName_ForOpenType()
+        {
+            // Arrange
+            IEdmModel model = SerializationTestsHelpers.SimpleOpenTypeModel();
+
+            IEdmEntitySet customers = model.EntityContainer.FindEntitySet("Customers");
+
+            IEdmEntityType customerType = model.FindDeclaredType("Default.Customer") as IEdmEntityType;
+            Type simpleOpenCustomer = typeof(SimpleOpenCustomer);
+            model.SetAnnotationValue(customerType, new ClrTypeAnnotation(simpleOpenCustomer));
+
+            IEdmComplexType addressType = model.FindDeclaredType("Default.Address") as IEdmComplexType;
+            Type simpleOpenAddress = typeof(SimpleOpenAddress);
+            model.SetAnnotationValue(addressType, new ClrTypeAnnotation(simpleOpenAddress));
+
+            IEdmEnumType enumType = model.FindDeclaredType("Default.SimpleEnum") as IEdmEnumType;
+            Type simpleEnumType = typeof(SimpleEnum);
+            model.SetAnnotationValue(enumType, new ClrTypeAnnotation(simpleEnumType));
+
+            model.SetAnnotationValue(customerType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenCustomer.GetProperty("CustomerProperties")));
+
+            model.SetAnnotationValue(addressType, new DynamicPropertyDictionaryAnnotation(
+                simpleOpenAddress.GetProperty("Properties")));
+
+            ODataResourceSerializer serializer = new ODataResourceSerializer(_serializerProvider);
+
+            var request = RequestFactory.Create(opt => opt.AddModel("route", model));
+            request.ODataFeature().PrefixName = "route";
+            SelectExpandNode selectExpandNode = new SelectExpandNode(null, customerType, model);
+            ODataSerializerContext writeContext = new ODataSerializerContext
+            {
+                Model = model,
+                Path = new ODataPath(new EntitySetSegment(customers)),
+                Request = request
+            };
+
+            SimpleOpenCustomer customer = new SimpleOpenCustomer()
+            {
+                CustomerId = 991,
+                Name = "Name #991",
+                Address = new SimpleOpenAddress
+                {
+                    City = "a city",
+                    Street = "a street",
+                    Properties = new Dictionary<string, object> { { "ArrayProperty", new[] { "15", "14", "13" } } }
+                },
+                CustomerProperties = new Dictionary<string, object>()
+            };
+
+            customer.CustomerProperties.Add("GuidProperty", new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"));
+            customer.CustomerProperties.Add("Name", null);
+
+            ResourceContext entityContext = new ResourceContext(writeContext,
+                customerType.ToEdmTypeReference(false) as IEdmEntityTypeReference, customer);
+
+            // Act & Assert
+            ExceptionAssert.Throws<InvalidOperationException>(
+                () => serializer.CreateResource(selectExpandNode, entityContext),
+                "Name",
+                partialMatch: true);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/Scenarios/OpenComplexTypeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Scenarios/OpenComplexTypeTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Scenarios
             Assert.Equal("My Dynamic Place", result["Place"]);
             Assert.Equal("2c1f450a-a2a7-4fe1-a25d-4d9332fc0694", result["Token"]);
             Assert.Equal("2015-03-02", result["Birthday"]);
-            Assert.Null(result["Region"]);
+            Assert.Equal(JTokenType.Null, result["Region"].Type);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/Scenarios/OpenEntityTypeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Scenarios/OpenEntityTypeTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Scenarios
             Assert.Equal(new JArray(new[] { 200, 100, 300, 0, 400 }), result["ListProp"]);
             Assert.Equal("0001-01-01", result["DateList"][0]);
             Assert.Equal("9999-12-31", result["DateList"][1]);
-            Assert.Null(result["Receipt"]);
+            Assert.Equal(JTokenType.Null, result["Receipt"].Type);
         }
 
         [Theory]


### PR DESCRIPTION
- Add more tests for dynamic property support in `ODataResourceSerializer`.
- Fixed a potential bug where a dynamic property with null value could be added to the resource even if it had the same name as an existing declared property
- Allowed null dynamic properties by default (see explanation below for more context)

There's a test called `CreateResource_Works_ToAppendNullDynamicProperties_ForOpenEntityType()`, based on the name, I assume that it should verify that dynamic properties with null values are added to the resource. However, the test actually verifies that dynamic properties with null values are actually *not* included in the resource. So I was confused about what the expected behaviour is.

Looking at the existing code, it seems that null dynamic properties are not allowed by default. They are only allowed when the resource is for an EdmDeltaComplexObject or an EdmDeltaResourceObject. So the name of the test is confusing

Furthermore, in WebApi 7.x, null dynamic properties can also be enabled by setting an option (`resourceContext.InternalRequest.Options.NullDynamicPropertyEnabled`), but this is not checked in 8.x

After an offline discussion with @xuzhg, we concluded to allow null dynamic properties by default. I updated the code and tests to reflect that.