### PR TITLE
Fix AmbiguousMatchException for properties with new modifier

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             // Expression:  source.Property
             string propertyName = _model.GetClrPropertyName(property);
-            PropertyInfo propertyInfo = source.Type.GetProperty(propertyName);
+            PropertyInfo propertyInfo = source.Type.GetProperties().First(p => p.Name == propertyName);
             Expression propertyValue = Expression.Property(source, propertyInfo);
             Type nullablePropertyType = TypeHelper.ToNullable(propertyValue.Type);
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -909,6 +909,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
         [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/Taxes")]
         [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/VipAddress")]
         [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/VipAddresses")]
+        [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/HomeAddress")]
+        [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/Addresses")]
         public void GetSelectExpandProperties_ForDirectProperty_OutputCorrectProperties(string select)
         {
             // Arrange
@@ -1159,6 +1161,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
         [InlineData("Addresses/Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryCnAddress/CnCities")]
         [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/VipAddress/Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryCnAddress/CnCities")]
         [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/VipAddresses/Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryUsAddress/UsCities")]
+        [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/HomeAddress/Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryCnAddress/CnCities")]
+        [InlineData("Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryVipCustomer/Addresses/Microsoft.AspNetCore.OData.Tests.Query.Expressions.QueryUsAddress/UsCities")]
         public void GetSelectExpandProperties_ForNonDirectNavigationProperty_ReturnsCorrectExpandedProperties(string expand)
         {
             // Arrange
@@ -1896,6 +1900,10 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
         public QueryAddress VipAddress { get; set; }
 
         public QueryAddress[] VipAddresses { get; set; }
+        
+        public new QueryUsAddress HomeAddress { get; set; }
+
+        public new QueryCnAddress[] Addresses { get; set; }
 
         public QueryVipOrder SpecialOrder { get; set; }
 


### PR DESCRIPTION
Fix for properties with new modifier (first property in collection is always current, not base class)