### PR TITLE
Improvement to (de)serialization code

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
             builder.AddService<SkipTokenHandler, DefaultSkipTokenHandler>(ServiceLifetime.Singleton);
 
             // SerializerProvider and DeserializerProvider.
-            builder.AddService<IODataSerializerProvider, DefaultODataSerializerProvider>(ServiceLifetime.Singleton);
+            builder.AddService<IODataSerializerProvider, ODataSerializerProvider>(ServiceLifetime.Singleton);
             builder.AddService<IODataDeserializerProvider, ODataDeserializerProvider>(ServiceLifetime.Singleton);
 
             // Deserializers.

--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
 
             // SerializerProvider and DeserializerProvider.
             builder.AddService<ODataSerializerProvider, DefaultODataSerializerProvider>(ServiceLifetime.Singleton);
-            builder.AddService<ODataDeserializerProvider, DefaultODataDeserializerProvider>(ServiceLifetime.Singleton);
+            builder.AddService<IODataDeserializerProvider, DefaultODataDeserializerProvider>(ServiceLifetime.Singleton);
 
             // Deserializers.
             builder.AddService<ODataResourceDeserializer>(ServiceLifetime.Singleton);

--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -62,8 +62,8 @@ namespace Microsoft.AspNetCore.OData.Abstracts
             builder.AddService<SkipTokenHandler, DefaultSkipTokenHandler>(ServiceLifetime.Singleton);
 
             // SerializerProvider and DeserializerProvider.
-            builder.AddService<ODataSerializerProvider, DefaultODataSerializerProvider>(ServiceLifetime.Singleton);
-            builder.AddService<IODataDeserializerProvider, DefaultODataDeserializerProvider>(ServiceLifetime.Singleton);
+            builder.AddService<IODataSerializerProvider, DefaultODataSerializerProvider>(ServiceLifetime.Singleton);
+            builder.AddService<IODataDeserializerProvider, ODataDeserializerProvider>(ServiceLifetime.Singleton);
 
             // Deserializers.
             builder.AddService<ODataResourceDeserializer>(ServiceLifetime.Singleton);

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -161,14 +161,14 @@ namespace Microsoft.AspNetCore.OData.Extensions
         /// get the deserializer provider associated with the request.
         /// </summary>
         /// <returns></returns>
-        public static ODataDeserializerProvider GetDeserializerProvider(this HttpRequest request)
+        public static IODataDeserializerProvider GetDeserializerProvider(this HttpRequest request)
         {
             if (request == null)
             {
                 throw Error.ArgumentNull(nameof(request));
             }
 
-            return request.GetSubServiceProvider().GetRequiredService<ODataDeserializerProvider>();
+            return request.GetSubServiceProvider().GetRequiredService<IODataDeserializerProvider>();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -161,14 +161,14 @@ namespace Microsoft.AspNetCore.OData.Extensions
         /// get the deserializer provider associated with the request.
         /// </summary>
         /// <returns></returns>
-        public static IODataDeserializerProvider GetDeserializerProvider(this HttpRequest request)
+        public static ODataDeserializerProvider GetDeserializerProvider(this HttpRequest request)
         {
             if (request == null)
             {
                 throw Error.ArgumentNull(nameof(request));
             }
 
-            return request.GetSubServiceProvider().GetRequiredService<IODataDeserializerProvider>();
+            return request.GetSubServiceProvider().GetRequiredService<ODataDeserializerProvider>();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DefaultODataDeserializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DefaultODataDeserializerProvider.cs
@@ -14,9 +14,9 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// The default <see cref="ODataDeserializerProvider"/>.
+    /// The default <see cref="IODataDeserializerProvider"/>.
     /// </summary>
-    public class DefaultODataDeserializerProvider : ODataDeserializerProvider
+    public class DefaultODataDeserializerProvider : IODataDeserializerProvider
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         }
 
         /// <inheritdoc />
-        public override ODataEdmTypeDeserializer GetEdmTypeDeserializer(IEdmTypeReference edmType, bool isDelta = false)
+        public IODataEdmTypeDeserializer GetEdmTypeDeserializer(IEdmTypeReference edmType, bool isDelta = false)
         {
             if (edmType == null)
             {
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         }
 
         /// <inheritdoc />
-        public override ODataDeserializer GetODataDeserializer(Type type, HttpRequest request)
+        public IODataDeserializer GetODataDeserializer(Type type, HttpRequest request)
         {
             if (type == null)
             {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 Contract.Assert(collectionType != null, "The type for collection must be a IEdmCollectionType.");
             }
 
-            ODataEdmTypeDeserializer deserializer = deserializerProvider.GetEdmTypeDeserializer(collectionType);
+            IODataEdmTypeDeserializer deserializer = deserializerProvider.GetEdmTypeDeserializer(collectionType);
             return deserializer.ReadInline(collection, collectionType, readContext);
         }
 
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 edmEnumType = propertyType.AsEnum();
             }
 
-            ODataEdmTypeDeserializer deserializer = deserializerProvider.GetEdmTypeDeserializer(edmEnumType);
+            IODataEdmTypeDeserializer deserializer = deserializerProvider.GetEdmTypeDeserializer(edmEnumType);
             return deserializer.ReadInline(enumValue, propertyType, readContext);
         }
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
     internal static class DeserializationHelpers
     {
         internal static void ApplyProperty(ODataProperty property, IEdmStructuredTypeReference resourceType, object resource,
-            ODataDeserializerProvider deserializerProvider, ODataDeserializerContext readContext)
+            IODataDeserializerProvider deserializerProvider, ODataDeserializerContext readContext)
         {
             IEdmStructuredType structuredType = resourceType.StructuredDefinition();
             IEdmProperty edmProperty = structuredType == null ? null : structuredType.ResolveProperty(property.Name);
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             }
         }
 
-        internal static object ConvertValue(object oDataValue, ref IEdmTypeReference propertyType, ODataDeserializerProvider deserializerProvider,
+        internal static object ConvertValue(object oDataValue, ref IEdmTypeReference propertyType, IODataDeserializerProvider deserializerProvider,
             ODataDeserializerContext readContext, out EdmTypeKind typeKind)
         {
             if (oDataValue == null)
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         }
 
         private static object ConvertCollectionValue(ODataCollectionValue collection,
-            ref IEdmTypeReference propertyType, ODataDeserializerProvider deserializerProvider,
+            ref IEdmTypeReference propertyType, IODataDeserializerProvider deserializerProvider,
             ODataDeserializerContext readContext)
         {
             IEdmCollectionTypeReference collectionType;
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         }
 
         private static object ConvertEnumValue(ODataEnumValue enumValue, ref IEdmTypeReference propertyType,
-            ODataDeserializerProvider deserializerProvider, ODataDeserializerContext readContext)
+            IODataDeserializerProvider deserializerProvider, ODataDeserializerContext readContext)
         {
             IEdmEnumTypeReference edmEnumType;
             if (propertyType == null)

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataDeserializer.cs
@@ -1,35 +1,26 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using Microsoft.OData;
 using System;
 using System.Threading.Tasks;
-using Microsoft.OData;
 
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// An <see cref="ODataDeserializer"/> is used to read an ODataMessage into a CLR object.
+    /// An <see cref="IODataDeserializer"/> is used to read an ODataMessage into a CLR object.
     /// </summary>
     /// <remarks>
-    /// Each supported CLR type has a corresponding <see cref="ODataDeserializer" />. A CLR type is supported if it is one of
+    /// Each supported CLR type has a corresponding <see cref="IODataDeserializer" />. A CLR type is supported if it is one of
     /// the special types or if it has a backing EDM type. Some of the special types are Uri which maps to ODataReferenceLink payload, 
     /// Uri[] which maps to ODataReferenceLinks payload, ODataWorkspace which maps to ODataServiceDocument payload.
     /// </remarks>
-    public abstract class ODataDeserializer : IODataDeserializer
+    public interface IODataDeserializer
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ODataDeserializer"/> class.
-        /// </summary>
-        /// <param name="payloadKind">The kind of payload this deserializer handles.</param>
-        protected ODataDeserializer(ODataPayloadKind payloadKind)
-        {
-            ODataPayloadKind = payloadKind;
-        }
-
         /// <summary>
         /// The kind of ODataPayload this deserializer handles.
         /// </summary>
-        public ODataPayloadKind ODataPayloadKind { get; private set; }
+        ODataPayloadKind ODataPayloadKind { get; }
 
         /// <summary>
         /// Reads an <see cref="IODataRequestMessage"/> using messageReader.
@@ -38,9 +29,6 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// <param name="type">The type of the object to read into.</param>
         /// <param name="readContext">The read context.</param>
         /// <returns>The deserialized object.</returns>
-        public virtual Task<object> ReadAsync(ODataMessageReader messageReader, Type type, ODataDeserializerContext readContext)
-        {
-            throw Error.NotSupported(SRResources.DeserializerDoesNotSupportRead, GetType().Name);
-        }
+        Task<object> ReadAsync(ODataMessageReader messageReader, Type type, ODataDeserializerContext readContext);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataDeserializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataDeserializerProvider.cs
@@ -8,9 +8,10 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// Represents a factory that creates an <see cref="ODataDeserializer"/>.
+    /// Represents a factory that creates an <see cref="IODataDeserializer"/>.
     /// </summary>
-    public abstract class ODataDeserializerProvider
+    public interface IODataDeserializerProvider
+
     {
         /// <summary>
         /// Gets an <see cref="ODataDeserializer"/> for the given type.
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// <param name="type">The CLR type.</param>
         /// <param name="request">The request being deserialized.</param>
         /// <returns>An <see cref="ODataDeserializer"/> that can deserialize the given type.</returns>
-        public abstract ODataDeserializer GetODataDeserializer(Type type, HttpRequest request);
+        public IODataDeserializer GetODataDeserializer(Type type, HttpRequest request);
 
         /// <summary>
         /// Gets the <see cref="ODataEdmTypeDeserializer"/> for the given EDM type.
@@ -26,6 +27,6 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// <param name="edmType">The EDM type.</param>
         /// <param name="isDelta">Is delta</param>
         /// <returns>An <see cref="ODataEdmTypeDeserializer"/> that can deserialize the given EDM type.</returns>
-        public abstract ODataEdmTypeDeserializer GetEdmTypeDeserializer(IEdmTypeReference edmType, bool isDelta = false);
+        public IODataEdmTypeDeserializer GetEdmTypeDeserializer(IEdmTypeReference edmType, bool isDelta = false);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
+{
+    public interface IODataEdmTypeDeserializer
+    {
+        /// <summary>
+        /// Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.
+        /// </summary>
+        /// <param name="item">The item to deserialize.</param>
+        /// <param name="edmType">The EDM type of the object to read into.</param>
+        /// <param name="readContext">The <see cref="ODataDeserializerContext"/>.</param>
+        /// <returns>The deserialized object.</returns>
+        object ReadInline(object item, IEdmTypeReference edmType, ODataDeserializerContext readContext);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
@@ -5,6 +5,9 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
+    /// <summary>
+    /// Interface for all <see cref="ODataDeserializer" />s that deserialize into an object backed by <see cref="IEdmType"/>.
+    /// </summary>
     public interface IODataEdmTypeDeserializer: IODataDeserializer
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/IODataEdmTypeDeserializer.cs
@@ -5,7 +5,7 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
-    public interface IODataEdmTypeDeserializer
+    public interface IODataEdmTypeDeserializer: IODataDeserializer
     {
         /// <summary>
         /// Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataActionPayloadDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataActionPayloadDeserializer.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.OData.Routing;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// Represents an <see cref="ODataDeserializer"/> for reading OData action parameters.
+    /// Represents an <see cref="IODataDeserializer"/> for reading OData action parameters.
     /// </summary>
     public class ODataActionPayloadDeserializer : ODataDeserializer
     {
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataActionPayloadDeserializer"/> class.
         /// </summary>
         /// <param name="deserializerProvider">The deserializer provider to use to read inner objects.</param>
-        public ODataActionPayloadDeserializer(ODataDeserializerProvider deserializerProvider)
+        public ODataActionPayloadDeserializer(IODataDeserializerProvider deserializerProvider)
             : base(ODataPayloadKind.Parameter)
         {
             DeserializerProvider = deserializerProvider ?? throw new ArgumentNullException(nameof(deserializerProvider));
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// <summary>
         /// Gets the deserializer provider to use to read inner objects.
         /// </summary>
-        public ODataDeserializerProvider DeserializerProvider { get; private set; }
+        public IODataDeserializerProvider DeserializerProvider { get; private set; }
 
         /// <inheritdoc />
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataActionPayloadDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataActionPayloadDeserializer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                         }
                         else
                         {
-                            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(parameter.Type);
+                            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(parameter.Type);
                             payload[parameterName] = deserializer.ReadInline(reader.Value, parameter.Type, readContext);
                         }
                         break;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataCollectionDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataCollectionDeserializer.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 throw Error.ArgumentNull("elementType");
             }
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
             if (deserializer == null)
             {
                 throw new SerializationException(

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataCollectionDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataCollectionDeserializer.cs
@@ -17,7 +17,7 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// Represents an <see cref="ODataDeserializer"/> that can read OData collection payloads.
+    /// Represents an <see cref="IODataDeserializer"/> that can read OData collection payloads.
     /// </summary>
     public class ODataCollectionDeserializer : ODataEdmTypeDeserializer
     {
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataCollectionDeserializer"/> class.
         /// </summary>
         /// <param name="deserializerProvider">The deserializer provider to use to read inner objects.</param>
-        public ODataCollectionDeserializer(ODataDeserializerProvider deserializerProvider)
+        public ODataCollectionDeserializer(IODataDeserializerProvider deserializerProvider)
             : base(ODataPayloadKind.Collection, deserializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeltaResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeltaResourceSetDeserializer.cs
@@ -18,7 +18,7 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// Represents an <see cref="ODataDeserializer"/> that can read OData delta resource sets.
+    /// Represents an <see cref="IODataDeserializer"/> that can read OData delta resource sets.
     /// </summary>
     public class ODataDeltaResourceSetDeserializer : ODataEdmTypeDeserializer
     {
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataDeltaResourceSetDeserializer"/> class.
         /// </summary>
         /// <param name="deserializerProvider">The deserializer provider to use to read inner objects.</param>
-        public ODataDeltaResourceSetDeserializer(ODataDeserializerProvider deserializerProvider)
+        public ODataDeltaResourceSetDeserializer(IODataDeserializerProvider deserializerProvider)
             : base(ODataPayloadKind.Delta, deserializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeltaResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeltaResourceSetDeserializer.cs
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 throw Error.ArgumentNull(nameof(readContext));
             }
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
             if (deserializer == null)
             {
                 throw new SerializationException(

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializer.cs
@@ -26,18 +26,10 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             ODataPayloadKind = payloadKind;
         }
 
-        /// <summary>
-        /// The kind of ODataPayload this deserializer handles.
-        /// </summary>
+        /// <inheritdoc />
         public ODataPayloadKind ODataPayloadKind { get; private set; }
 
-        /// <summary>
-        /// Reads an <see cref="IODataRequestMessage"/> using messageReader.
-        /// </summary>
-        /// <param name="messageReader">The messageReader to use.</param>
-        /// <param name="type">The type of the object to read into.</param>
-        /// <param name="readContext">The read context.</param>
-        /// <returns>The deserialized object.</returns>
+        /// <inheritdoc/>
         public virtual Task<object> ReadAsync(ODataMessageReader messageReader, Type type, ODataDeserializerContext readContext)
         {
             throw Error.NotSupported(SRResources.DeserializerDoesNotSupportRead, GetType().Name);

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -12,7 +12,7 @@ using Microsoft.OData.UriParser;
 namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 {
     /// <summary>
-    /// This class encapsulates the state and settings that get passed to <see cref="ODataDeserializer"/>.
+    /// This class encapsulates the state and settings that get passed to <see cref="IODataDeserializer"/>.
     /// </summary>
     public class ODataDeserializerContext
     {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerProvider.cs
@@ -16,15 +16,15 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
     /// <summary>
     /// The default <see cref="IODataDeserializerProvider"/>.
     /// </summary>
-    public class DefaultODataDeserializerProvider : IODataDeserializerProvider
+    public class ODataDeserializerProvider: IODataDeserializerProvider
     {
         private readonly IServiceProvider _serviceProvider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultODataDeserializerProvider"/> class.
+        /// Initializes a new instance of the <see cref="ODataDeserializerProvider"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
-        public DefaultODataDeserializerProvider(IServiceProvider serviceProvider)
+        public ODataDeserializerProvider(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider ?? throw Error.ArgumentNull(nameof(serviceProvider));
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEdmTypeDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEdmTypeDeserializer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
     /// <summary>
     /// Base class for all <see cref="ODataDeserializer" />s that deserialize into an object backed by <see cref="IEdmType"/>.
     /// </summary>
-    public abstract class ODataEdmTypeDeserializer : ODataDeserializer
+    public abstract class ODataEdmTypeDeserializer : ODataDeserializer, IODataEdmTypeDeserializer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataEdmTypeDeserializer"/> class.
@@ -24,8 +24,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataEdmTypeDeserializer"/> class.
         /// </summary>
         /// <param name="payloadKind">The kind of OData payload this deserializer handles.</param>
-        /// <param name="deserializerProvider">The <see cref="ODataDeserializerProvider"/>.</param>
-        protected ODataEdmTypeDeserializer(ODataPayloadKind payloadKind, ODataDeserializerProvider deserializerProvider)
+        /// <param name="deserializerProvider">The <see cref="IODataDeserializerProvider"/>.</param>
+        protected ODataEdmTypeDeserializer(ODataPayloadKind payloadKind, IODataDeserializerProvider deserializerProvider)
             : this(payloadKind)
         {
             if (deserializerProvider == null)
@@ -37,9 +37,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         }
 
         /// <summary>
-        /// The <see cref="ODataDeserializerProvider"/> to use for deserializing inner items.
+        /// The <see cref="IODataDeserializerProvider"/> to use for deserializing inner items.
         /// </summary>
-        public ODataDeserializerProvider DeserializerProvider { get; private set; }
+        public IODataDeserializerProvider DeserializerProvider { get; private set; }
 
         /// <summary>
         /// Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEdmTypeDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEdmTypeDeserializer.cs
@@ -41,13 +41,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// </summary>
         public IODataDeserializerProvider DeserializerProvider { get; private set; }
 
-        /// <summary>
-        /// Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.
-        /// </summary>
-        /// <param name="item">The item to deserialize.</param>
-        /// <param name="edmType">The EDM type of the object to read into.</param>
-        /// <param name="readContext">The <see cref="ODataDeserializerContext"/>.</param>
-        /// <returns>The deserialized object.</returns>
+        /// <inheritdoc/>
         public virtual object ReadInline(object item, IEdmTypeReference edmType, ODataDeserializerContext readContext)
         {
             throw Error.NotSupported(SRResources.DoesNotSupportReadInLine, GetType().Name);

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataResourceDeserializer"/> class.
         /// </summary>
         /// <param name="deserializerProvider">The deserializer provider to use to read inner objects.</param>
-        public ODataResourceDeserializer(ODataDeserializerProvider deserializerProvider)
+        public ODataResourceDeserializer(IODataDeserializerProvider deserializerProvider)
             : base(ODataPayloadKind.Resource, deserializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     actualStructuredType = new EdmComplexTypeReference(actualType as IEdmComplexType, isNullable: false);
                 }
 
-                ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(actualStructuredType);
+                IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(actualStructuredType);
                 if (deserializer == null)
                 {
                     throw new SerializationException(
@@ -562,7 +562,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 return null;
             }
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType);
             if (deserializer == null)
             {
                 throw new SerializationException(Error.Format(SRResources.TypeCannotBeDeserialized, edmType.FullName()));
@@ -635,7 +635,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             IEdmTypeReference edmTypeReference = elementType.ToEdmTypeReference(true);
             EdmCollectionTypeReference collectionType = new EdmCollectionTypeReference(new EdmCollectionType(edmTypeReference));
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(collectionType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(collectionType);
             if (deserializer == null)
             {
                 throw new SerializationException(Error.Format(SRResources.TypeCannotBeDeserialized, collectionType.FullName()));
@@ -662,7 +662,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             Contract.Assert(edmType != null);
             Contract.Assert(readContext != null);
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType);
             if (deserializer == null)
             {
                 throw new SerializationException(Error.Format(SRResources.TypeCannotBeDeserialized, edmType.FullName()));
@@ -706,7 +706,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             Contract.Assert(readContext != null);
 
             IEdmTypeReference edmType = nestedProperty.Type;
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType, true);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType, true);
             if (deserializer == null)
             {
                 throw new SerializationException(Error.Format(SRResources.TypeCannotBeDeserialized, edmType.FullName()));

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 throw Error.ArgumentNull(nameof(resourceSet));
             }
 
-            ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
+            IODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(elementType);
             if (deserializer == null)
             {
                 throw new SerializationException(

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         /// Initializes a new instance of the <see cref="ODataResourceSetDeserializer"/> class.
         /// </summary>
         /// <param name="deserializerProvider">The deserializer provider to use to read inner objects.</param>
-        public ODataResourceSetDeserializer(ODataDeserializerProvider deserializerProvider)
+        public ODataResourceSetDeserializer(IODataDeserializerProvider deserializerProvider)
             : base(ODataPayloadKind.ResourceSet, deserializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/MediaType/IMediaTypeMappingCollection.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/MediaType/IMediaTypeMappingCollection.cs
@@ -8,10 +8,6 @@ namespace Microsoft.AspNetCore.OData.Formatter.MediaType
     /// <summary>
     /// An interface that defines a property to access a collection of <see cref="MediaTypeMapping"/> objects.
     /// </summary>
-    /// <remarks>
-    /// MediaTypeMapping is part of the platform in AspNet but defined here for AspNetCore to allow for reusing
-    /// the classes derive form it for managing media type mapping.
-    /// </remarks>
     interface IMediaTypeMappingCollection
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/MediaType/MediaTypeMapping.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/MediaType/MediaTypeMapping.cs
@@ -10,14 +10,10 @@ namespace Microsoft.AspNetCore.OData.Formatter.MediaType
     /// <summary>
     /// A class to support matching media types.
     /// </summary>
-    /// <remarks>
-    /// This is part of the platform in AspNet but defined here for AspNetCore to allow for reusing
-    /// the classes derive form it for managing media type mapping.
-    /// </remarks>
     public abstract class MediaTypeMapping
     {
         /// <summary>
-        /// Initializes a new instance of a System.Net.Http.Formatting.MediaTypeMapping with
+        /// Initializes a new instance of a <see cref="MediaTypeMapping"/> with
         /// the given mediaType value.
         /// </summary>
         /// <param name="mediaType">The mediaType that is associated with the request.</param>

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             IEdmModel model = odataFeature.Model;
             expectedPayloadType = null;
 
-            ODataDeserializerProvider deserializerProvider = request.GetSubServiceProvider().GetRequiredService<ODataDeserializerProvider>();
+            IODataDeserializerProvider deserializerProvider = request.GetSubServiceProvider().GetRequiredService<IODataDeserializerProvider>();
 
             // Get the deserializer using the CLR type first from the deserializer provider.
             ODataDeserializer deserializer = deserializerProvider.GetODataDeserializer(type, request);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 throw Error.ArgumentNull("type");
             }
 
-            ODataDeserializer deserializer = GetDeserializer(request, type, out _);
+            IODataDeserializer deserializer = GetDeserializer(request, type, out _);
             if (deserializer != null)
             {
                 return _payloadKinds.Contains(deserializer.ODataPayloadKind);
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             object result;
             IEdmModel model = request.GetModel();
             IEdmTypeReference expectedPayloadType;
-            ODataDeserializer deserializer = GetDeserializer(request, type, out expectedPayloadType);
+            IODataDeserializer deserializer = GetDeserializer(request, type, out expectedPayloadType);
             if (deserializer == null)
             {
                 throw Error.Argument("type", SRResources.FormatterReadIsNotSupportedForType, type.FullName, typeof(ODataInputFormatter).FullName);
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
         /// <param name="type">The input type.</param>
         /// <param name="expectedPayloadType">Output the expected payload type.</param>
         /// <returns>null or the OData deserializer</returns>
-        private static ODataDeserializer GetDeserializer(HttpRequest request, Type type,  out IEdmTypeReference expectedPayloadType)
+        private static IODataDeserializer GetDeserializer(HttpRequest request, Type type,  out IEdmTypeReference expectedPayloadType)
         {
             Contract.Assert(request != null);
 
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             IODataDeserializerProvider deserializerProvider = request.GetSubServiceProvider().GetRequiredService<IODataDeserializerProvider>();
 
             // Get the deserializer using the CLR type first from the deserializer provider.
-            ODataDeserializer deserializer = deserializerProvider.GetODataDeserializer(type, request);
+            IODataDeserializer deserializer = deserializerProvider.GetODataDeserializer(type, request);
             if (deserializer == null)
             {
                 expectedPayloadType = EdmLibHelper.GetExpectedPayloadType(type, path, model);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
@@ -70,8 +70,8 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 IEdmEnumTypeReference edmEnumType = edmTypeReference.AsEnum();
                 Contract.Assert(edmEnumType != null);
 
-                ODataDeserializerProvider deserializerProvider =
-                    requestContainer.GetRequiredService<ODataDeserializerProvider>();
+                IODataDeserializerProvider deserializerProvider =
+                    requestContainer.GetRequiredService<IODataDeserializerProvider>();
 
                 ODataEnumDeserializer deserializer =
                     (ODataEnumDeserializer)deserializerProvider.GetEdmTypeDeserializer(edmEnumType);
@@ -177,8 +177,8 @@ namespace Microsoft.AspNetCore.OData.Formatter
             IEdmCollectionTypeReference collectionType = edmTypeReference as IEdmCollectionTypeReference;
             Contract.Assert(collectionType != null);
 
-            ODataDeserializerProvider deserializerProvider =
-                requestContainer.GetRequiredService<ODataDeserializerProvider>();
+            IODataDeserializerProvider deserializerProvider =
+                requestContainer.GetRequiredService<IODataDeserializerProvider>();
             ODataCollectionDeserializer deserializer =
                 (ODataCollectionDeserializer)deserializerProvider.GetEdmTypeDeserializer(collectionType);
 
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             ODataResourceSetWrapper resourceSet =
                 odataReader.ReadResourceOrResourceSet() as ODataResourceSetWrapper;
 
-            ODataDeserializerProvider deserializerProvider = readContext.Request.GetDeserializerProvider();
+            IODataDeserializerProvider deserializerProvider = readContext.Request.GetDeserializerProvider();
 
             ODataResourceSetDeserializer resourceSetDeserializer =
                 (ODataResourceSetDeserializer)deserializerProvider.GetEdmTypeDeserializer(collectionType);
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             ODataResourceWrapper topLevelResource = item as ODataResourceWrapper;
             Contract.Assert(topLevelResource != null);
 
-            ODataDeserializerProvider deserializerProvider = readContext.Request.GetDeserializerProvider();
+            IODataDeserializerProvider deserializerProvider = readContext.Request.GetDeserializerProvider();
 
             ODataResourceDeserializer entityDeserializer =
                 (ODataResourceDeserializer)deserializerProvider.GetEdmTypeDeserializer(edmTypeReference);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
             type = TypeHelper.GetTaskInnerTypeOrSelf(type);
 
-            ODataSerializerProvider serializerProvider = request.GetSubServiceProvider().GetRequiredService<ODataSerializerProvider>();
+            IODataSerializerProvider serializerProvider = request.GetSubServiceProvider().GetRequiredService<IODataSerializerProvider>();
 
             // See if this type is a SingleResult or is derived from SingleResult.
             bool isSingleResult = false;
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             Uri baseAddress = GetBaseAddressInternal(request);
             MediaTypeHeaderValue contentType = GetContentType(response.Headers[HeaderNames.ContentType].FirstOrDefault());
 
-            ODataSerializerProvider serializerProvider = request.GetSubServiceProvider().GetRequiredService<ODataSerializerProvider>();
+            IODataSerializerProvider serializerProvider = request.GetSubServiceProvider().GetRequiredService<IODataSerializerProvider>();
 
             return ODataOutputFormatterHelper.WriteToStreamAsync(
                 type,
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
         }
 
         private static ODataPayloadKind? GetClrObjectResponsePayloadKind(Type type, bool isGenericSingleResult,
-            ODataSerializerProvider serializerProvider, HttpRequest request)
+            IODataSerializerProvider serializerProvider, HttpRequest request)
         {
             // SingleResult<T> should be serialized as T.
             if (isGenericSingleResult)

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 type = type.GetGenericArguments()[0];
             }
 
-            ODataSerializer serializer = serializerProvider.GetODataPayloadSerializer(type, request);
+            IODataSerializer serializer = serializerProvider.GetODataPayloadSerializer(type, request);
             return serializer == null ? null : (ODataPayloadKind?)serializer.ODataPayloadKind;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -148,10 +148,10 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
         }
 
-        internal static ODataSerializer GetSerializer(Type type, object value, HttpRequest request,
+        internal static IODataSerializer GetSerializer(Type type, object value, HttpRequest request,
             IODataSerializerProvider serializerProvider)
         {
-            ODataSerializer serializer;
+            IODataSerializer serializer;
 
             IEdmObject edmObject = value as IEdmObject;
             if (edmObject != null)

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 throw Error.InvalidOperation(SRResources.RequestMustHaveModel);
             }
 
-            ODataSerializer serializer = GetSerializer(type, value, request, serializerProvider);
+            IODataSerializer serializer = GetSerializer(type, value, request, serializerProvider);
 
             ODataPath path = request.ODataFeature().Path;
             IEdmNavigationSource targetNavigationSource = GetTargetNavigationSource(path, model);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             MediaTypeHeaderValue contentType,
             HttpRequest request,
             IHeaderDictionary requestHeaders,
-            ODataSerializerProvider serializerProvider)
+            IODataSerializerProvider serializerProvider)
         {
             if (model == null)
             {
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
         }
 
         internal static ODataSerializer GetSerializer(Type type, object value, HttpRequest request,
-            ODataSerializerProvider serializerProvider)
+            IODataSerializerProvider serializerProvider)
         {
             ODataSerializer serializer;
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/DefaultODataSerializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/DefaultODataSerializerProvider.cs
@@ -19,9 +19,9 @@ using Microsoft.OData.UriParser;
 namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 {
     /// <summary>
-    /// The default implementation of <see cref="ODataSerializerProvider"/>.
+    /// The default implementation of <see cref="IODataSerializerProvider"/>.
     /// </summary>
-    public class DefaultODataSerializerProvider : ODataSerializerProvider
+    public class DefaultODataSerializerProvider : IODataSerializerProvider
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         }
 
         /// <inheritdoc />
-        public override ODataEdmTypeSerializer GetEdmTypeSerializer(IEdmTypeReference edmType)
+        public IODataEdmTypeSerializer GetEdmTypeSerializer(IEdmTypeReference edmType)
         {
             if (edmType == null)
             {
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         }
 
         /// <inheritdoc />
-        public override ODataSerializer GetODataPayloadSerializer(Type type, HttpRequest request)
+        public IODataSerializer GetODataPayloadSerializer(Type type, HttpRequest request)
         {
             if (type == null)
             {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataEdmTypeSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataEdmTypeSerializer.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.OData.Formatter.Serialization
+{
+    /// <summary>
+    /// Represents an <see cref="IODataSerializer"/> that serializes instances of objects backed by an <see cref="IEdmType"/>.
+    /// </summary>
+    public interface IODataEdmTypeSerializer: IODataSerializer
+    {
+        /// <summary>
+        /// Creates an <see cref="ODataValue"/> for the object represented by <paramref name="graph"/>.
+        /// </summary>
+        /// <param name="graph">The value of the <see cref="ODataValue"/> to be created.</param>
+        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        /// <returns>The <see cref="ODataValue"/> created.</returns>
+        ODataValue CreateODataValue(object graph, IEdmTypeReference expectedType, ODataSerializerContext writeContext);
+
+        /// <summary>
+        /// Writes the given object specified by the parameter graph as a part of an existing OData message using the given
+        /// messageWriter and the writeContext.
+        /// </summary>
+        /// <param name="graph">The object to be written.</param>
+        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+        /// <param name="writer">The <see cref="ODataWriter" /> to be used for writing.</param>
+        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer, ODataSerializerContext writeContext);
+
+        /// <summary>
+        /// Creates an <see cref="ODataProperty"/> with name <paramref name="elementName"/> and value
+        /// based on the object represented by <paramref name="graph"/>.
+        /// </summary>
+        /// <param name="graph">The object to base the value of the property on.</param>
+        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+        /// <param name="elementName">The name of the property.</param>
+        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        /// <returns>The <see cref="ODataProperty"/> created.</returns>
+        ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
+            ODataSerializerContext writeContext);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataEdmTypeSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataEdmTypeSerializer.cs
@@ -30,17 +30,5 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// <param name="writer">The <see cref="ODataWriter" /> to be used for writing.</param>
         /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
         Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer, ODataSerializerContext writeContext);
-
-        /// <summary>
-        /// Creates an <see cref="ODataProperty"/> with name <paramref name="elementName"/> and value
-        /// based on the object represented by <paramref name="graph"/>.
-        /// </summary>
-        /// <param name="graph">The object to base the value of the property on.</param>
-        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-        /// <param name="elementName">The name of the property.</param>
-        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
-        /// <returns>The <see cref="ODataProperty"/> created.</returns>
-        ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
-            ODataSerializerContext writeContext);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.OData.Formatter.Serialization
+{
+    /// <summary>
+    /// An <see cref="IODataSerializer"/> is used to write a CLR object to an ODataMessage.
+    /// </summary>
+    /// <remarks>
+    /// Each supported CLR type has a corresponding <see cref="IODataSerializer" />. A CLR type is supported if it is one of
+    /// the special types or if it has a backing EDM type. Some of the special types are Uri which maps to ODataReferenceLink payload, 
+    /// Uri[] which maps to ODataReferenceLinks payload, etc.
+    /// </remarks>
+    public interface IODataSerializer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IODataSerializer"/> class.
+        /// </summary>
+        /// <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
+        ODataPayloadKind ODataPayloadKind { get; }
+
+        /// <summary>
+        /// Writes the given object specified by the parameter graph as a whole using the given messageWriter and writeContext.
+        /// </summary>
+        /// <param name="graph">The object to be written</param>
+        /// <param name="type">The type of the object to be written.</param>
+        /// <param name="messageWriter">The <see cref="ODataMessageWriter"/> to be used for writing.</param>
+        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        Task WriteObjectAsync(object graph, Type type, ODataMessageWriter messageWriter, ODataSerializerContext writeContext);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializer.cs
@@ -18,9 +18,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
     public interface IODataSerializer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="IODataSerializer"/> class.
+        /// The kind of OData payload that this serializer generates.
         /// </summary>
-        /// <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
         ODataPayloadKind ODataPayloadKind { get; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/IODataSerializerProvider.cs
@@ -8,24 +8,24 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 {
     /// <summary>
-    /// An ODataSerializerProvider is a factory for creating <see cref="ODataSerializer"/>s.
+    /// An <see cref="IODataSerializerProvider"/> is a factory for creating <see cref="IODataSerializer"/>s.
     /// </summary>
-    public abstract class ODataSerializerProvider
+    public interface IODataSerializerProvider
     {
         /// <summary>
         /// Gets an <see cref="ODataEdmTypeSerializer"/> for the given edmType.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmTypeReference"/>.</param>
         /// <returns>The <see cref="ODataSerializer"/>.</returns>
-        public abstract ODataEdmTypeSerializer GetEdmTypeSerializer(IEdmTypeReference edmType);
+        public IODataEdmTypeSerializer GetEdmTypeSerializer(IEdmTypeReference edmType);
 
         /// <summary>
         /// Gets an <see cref="ODataSerializer"/> for the given <paramref name="type"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> for which the serializer is being requested.</param>
         /// <param name="request">The request for which the response is being serialized.</param>
-        /// <returns>The <see cref="ODataSerializer"/> for the given type.</returns>
+        /// <returns>The <see cref="IODataSerializer"/> for the given type.</returns>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        public abstract ODataSerializer GetODataPayloadSerializer(Type type, HttpRequest request);
+        public IODataSerializer GetODataPayloadSerializer(Type type, HttpRequest request);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -204,6 +204,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             return value;
         }
 
+        /// <inheritdoc />
         public override ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
             ODataSerializerContext writeContext)
         {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -204,26 +204,6 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             return value;
         }
 
-        /// <inheritdoc />
-        public override ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
-            ODataSerializerContext writeContext)
-        {
-            Contract.Assert(elementName != null);
-            var property = CreateODataValue(graph, expectedType, writeContext);
-            if (property != null)
-            {
-                return new ODataProperty
-                {
-                    Name = elementName,
-                    Value = property
-                };
-            }
-            else
-            {
-                return null;
-            }
-        }
-
         /// <summary>
         /// Adds the type name annotations required for proper json light serialization.
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// Initializes a new instance of the <see cref="ODataCollectionSerializer"/> class.
         /// </summary>
         /// <param name="serializerProvider">The serializer provider to use to serialize nested objects.</param>
-        public ODataCollectionSerializer(ODataSerializerProvider serializerProvider)
+        public ODataCollectionSerializer(IODataSerializerProvider serializerProvider)
             : base(ODataPayloadKind.Collection, serializerProvider)
         {
         }
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 
             if (enumerable != null)
             {
-                ODataEdmTypeSerializer itemSerializer = null;
+                IODataEdmTypeSerializer itemSerializer = null;
                 foreach (object item in enumerable)
                 {
                     if (item == null)
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             return value;
         }
 
-        internal override ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
+        public override ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
             ODataSerializerContext writeContext)
         {
             Contract.Assert(elementName != null);

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataDeltaResourceSetSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataDeltaResourceSetSerializer.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// <summary>
         /// Initializes a new instance of <see cref="ODataDeltaResourceSetSerializer"/>.
         /// </summary>
-        /// <param name="serializerProvider">The <see cref="ODataSerializerProvider"/> to use to write nested entries.</param>
-        public ODataDeltaResourceSetSerializer(ODataSerializerProvider serializerProvider)
+        /// <param name="serializerProvider">The <see cref="IODataSerializerProvider"/> to use to write nested entries.</param>
+        public ODataDeltaResourceSetSerializer(IODataSerializerProvider serializerProvider)
             : base(ODataPayloadKind.Delta, serializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEdmTypeSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEdmTypeSerializer.cs
@@ -9,9 +9,9 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 {
     /// <summary>
-    /// Represents an <see cref="ODataSerializer"/> that serializes instances of objects backed by an <see cref="IEdmType"/>.
+    /// Represents an <see cref="IODataSerializer"/> that serializes instances of objects backed by an <see cref="IEdmType"/>.
     /// </summary>
-    public abstract class ODataEdmTypeSerializer : ODataSerializer
+    public abstract class ODataEdmTypeSerializer : ODataSerializer, IODataEdmTypeSerializer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataEdmTypeSerializer"/> class.
@@ -26,45 +26,33 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// Initializes a new instance of the <see cref="ODataEdmTypeSerializer"/> class.
         /// </summary>
         /// <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
-        /// <param name="serializerProvider">The <see cref="ODataSerializerProvider"/> to use to write inner objects.</param>
-        protected ODataEdmTypeSerializer(ODataPayloadKind payloadKind, ODataSerializerProvider serializerProvider)
+        /// <param name="serializerProvider">The <see cref="IODataSerializerProvider"/> to use to write inner objects.</param>
+        protected ODataEdmTypeSerializer(ODataPayloadKind payloadKind, IODataSerializerProvider serializerProvider)
             : this(payloadKind)
         {
             SerializerProvider = serializerProvider ?? throw Error.ArgumentNull(nameof(serializerProvider));
         }
 
         /// <summary>
-        /// Gets the <see cref="ODataSerializerProvider"/> that can be used to write inner objects.
+        /// Gets the <see cref="IODataSerializerProvider"/> that can be used to write inner objects.
         /// </summary>
-        public ODataSerializerProvider SerializerProvider { get; }
+        public IODataSerializerProvider SerializerProvider { get; }
 
-        /// <summary>
-        /// Writes the given object specified by the parameter graph as a part of an existing OData message using the given
-        /// messageWriter and the writeContext.
-        /// </summary>
-        /// <param name="graph">The object to be written.</param>
-        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-        /// <param name="writer">The <see cref="ODataWriter" /> to be used for writing.</param>
-        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        /// <inheritdoc/>
         public virtual Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer,
             ODataSerializerContext writeContext)
         {
             throw Error.NotSupported(SRResources.WriteObjectInlineNotSupported, GetType().Name);
         }
 
-        /// <summary>
-        /// Creates an <see cref="ODataValue"/> for the object represented by <paramref name="graph"/>.
-        /// </summary>
-        /// <param name="graph">The value of the <see cref="ODataValue"/> to be created.</param>
-        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
-        /// <returns>The <see cref="ODataValue"/> created.</returns>
+        /// <inheritdoc/>
         public virtual ODataValue CreateODataValue(object graph, IEdmTypeReference expectedType, ODataSerializerContext writeContext)
         {
             throw Error.NotSupported(SRResources.CreateODataValueNotSupported, GetType().Name);
         }
 
-        internal virtual ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
+        /// <inheritdoc/>
+        public virtual ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
             ODataSerializerContext writeContext)
         {
             Contract.Assert(elementName != null);

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEdmTypeSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEdmTypeSerializer.cs
@@ -50,17 +50,5 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         {
             throw Error.NotSupported(SRResources.CreateODataValueNotSupported, GetType().Name);
         }
-
-        /// <inheritdoc/>
-        public virtual ODataProperty CreateProperty(object graph, IEdmTypeReference expectedType, string elementName,
-            ODataSerializerContext writeContext)
-        {
-            Contract.Assert(elementName != null);
-            return new ODataProperty
-            {
-                Name = elementName,
-                Value = CreateODataValue(graph, expectedType, writeContext)
-            };
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             IEdmTypeReference edmType = writeContext.GetEdmType(graph, type);
             Contract.Assert(edmType != null);
 
-            await messageWriter.WritePropertyAsync(CreateProperty(graph, edmType, writeContext.RootElementName, writeContext)).ConfigureAwait(false);
+            await messageWriter.WritePropertyAsync(this.CreateProperty(graph, edmType, writeContext.RootElementName, writeContext)).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// <summary>
         /// Initializes a new instance of <see cref="ODataEnumSerializer"/>.
         /// </summary>
-        public ODataEnumSerializer(ODataSerializerProvider serializerProvider)
+        public ODataEnumSerializer(IODataSerializerProvider serializerProvider)
             : base(ODataPayloadKind.Property, serializerProvider)
         {
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             IEdmTypeReference edmType = writeContext.GetEdmType(graph, type);
             Contract.Assert(edmType != null);
 
-            await messageWriter.WritePropertyAsync(CreateProperty(graph, edmType, writeContext.RootElementName, writeContext)).ConfigureAwait(false);
+            await messageWriter.WritePropertyAsync(this.CreateProperty(graph, edmType, writeContext.RootElementName, writeContext)).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         private const string Resource = "Resource";
 
         /// <inheritdoc />
-        public ODataResourceSerializer(ODataSerializerProvider serializerProvider)
+        public ODataResourceSerializer(IODataSerializerProvider serializerProvider)
             : base(ODataPayloadKind.Resource, serializerProvider)
         {
         }
@@ -640,7 +640,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 }
                 else
                 {
-                    ODataEdmTypeSerializer propertySerializer = SerializerProvider.GetEdmTypeSerializer(edmTypeReference);
+                    IODataEdmTypeSerializer propertySerializer = SerializerProvider.GetEdmTypeSerializer(edmTypeReference);
                     if (propertySerializer == null)
                     {
                         throw Error.NotSupported(SRResources.DynamicPropertyCannotBeSerialized, dynamicProperty.Key,
@@ -771,7 +771,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             ODataSerializerContext nestedWriteContext = new ODataSerializerContext(resourceContext, null, null);
 
             // Write object.
-            ODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmType);
+            IODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmType);
             if (serializer == null)
             {
                 throw new SerializationException(
@@ -929,7 +929,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 ODataSerializerContext nestedWriteContext = new ODataSerializerContext(resourceContext, edmProperty, null /*resourceContext.SerializerContext.QueryContext*/, selectItem);
 
                 // write object.
-                ODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmProperty.Type);
+                IODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmProperty.Type);
                 if (serializer == null)
                 {
                     throw new SerializationException(Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString()));
@@ -1092,7 +1092,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 
             ODataSerializerContext writeContext = resourceContext.SerializerContext;
 
-            ODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(structuralProperty.Type);
+            IODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(structuralProperty.Type);
             if (serializer == null)
             {
                 throw new SerializationException(

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -34,8 +34,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// <summary>
         /// Initializes a new instance of <see cref="ODataResourceSetSerializer"/>.
         /// </summary>
-        /// <param name="serializerProvider">The <see cref="ODataSerializerProvider"/> to use to write nested entries.</param>
-        public ODataResourceSetSerializer(ODataSerializerProvider serializerProvider)
+        /// <param name="serializerProvider">The <see cref="IODataSerializerProvider"/> to use to write nested entries.</param>
+        public ODataResourceSetSerializer(IODataSerializerProvider serializerProvider)
             : base(ODataPayloadKind.ResourceSet, serializerProvider)
         {
         }
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 });
             }
 
-            ODataEdmTypeSerializer resourceSerializer = SerializerProvider.GetEdmTypeSerializer(elementType);
+            IODataEdmTypeSerializer resourceSerializer = SerializerProvider.GetEdmTypeSerializer(elementType);
             if (resourceSerializer == null)
             {
                 throw new SerializationException(

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializer.cs
@@ -8,14 +8,14 @@ using Microsoft.OData;
 namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 {
     /// <summary>
-    /// An ODataSerializer is used to write a CLR object to an ODataMessage.
+    /// Base class for <see cref="IODataSerializer"/> implementations.
     /// </summary>
     /// <remarks>
     /// Each supported CLR type has a corresponding <see cref="ODataSerializer" />. A CLR type is supported if it is one of
     /// the special types or if it has a backing EDM type. Some of the special types are Uri which maps to ODataReferenceLink payload, 
     /// Uri[] which maps to ODataReferenceLinks payload, etc.
     /// </remarks>
-    public abstract class ODataSerializer
+    public abstract class ODataSerializer : IODataSerializer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataSerializer"/> class.
@@ -28,18 +28,10 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             ODataPayloadKind = payloadKind;
         }
 
-        /// <summary>
-        /// Gets the <see cref="ODataPayloadKind"/> that this serializer generates.
-        /// </summary>
+        /// <inheritdoc/>
         public ODataPayloadKind ODataPayloadKind { get; }
 
-        /// <summary>
-        /// Writes the given object specified by the parameter graph as a whole using the given messageWriter and writeContext.
-        /// </summary>
-        /// <param name="graph">The object to be written</param>
-        /// <param name="type">The type of the object to be written.</param>
-        /// <param name="messageWriter">The <see cref="ODataMessageWriter"/> to be used for writing.</param>
-        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        /// <inheritdoc/>
         public virtual async Task WriteObjectAsync(object graph, Type type, ODataMessageWriter messageWriter, ODataSerializerContext writeContext)
         {
             await Task.Run(() => throw Error.NotSupported(SRResources.WriteObjectNotSupported, GetType().Name)).ConfigureAwait(false);

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerPropertyHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerPropertyHelper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// Creates an <see cref="ODataProperty"/> with name <paramref name="elementName"/> and value
         /// based on the object represented by <paramref name="graph"/>.
         /// </summary>
+        /// <param name="serializer">The <see cref="IODataEdmTypeSerializer"/> writing the property value.</param>
         /// <param name="graph">The object to base the value of the property on.</param>
         /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
         /// <param name="elementName">The name of the property.</param>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerPropertyHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerPropertyHelper.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Diagnostics.Contracts;
+using System.Threading.Tasks;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Formatter.Serialization
+{
+    internal static class ODataSerializerPropertyHelper
+    {
+        /// <summary>
+        /// Creates an <see cref="ODataProperty"/> with name <paramref name="elementName"/> and value
+        /// based on the object represented by <paramref name="graph"/>.
+        /// </summary>
+        /// <param name="graph">The object to base the value of the property on.</param>
+        /// <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+        /// <param name="elementName">The name of the property.</param>
+        /// <param name="writeContext">The <see cref="ODataSerializerContext"/>.</param>
+        /// <returns>The <see cref="ODataProperty"/> created.</returns>
+        public static ODataProperty CreateProperty(this IODataEdmTypeSerializer serializer, object graph, IEdmTypeReference expectedType, string elementName,
+            ODataSerializerContext writeContext)
+        {
+            if (serializer is ODataCollectionSerializer collectionSerializer)
+            {
+                return CreateCollectionProperty(collectionSerializer, graph, expectedType, elementName, writeContext);
+            }
+
+            Contract.Assert(elementName != null);
+            return new ODataProperty
+            {
+                Name = elementName,
+                Value = serializer.CreateODataValue(graph, expectedType, writeContext)
+            };
+        }
+
+        private static ODataProperty CreateCollectionProperty(ODataCollectionSerializer serializer, object graph, IEdmTypeReference expectedType, string elementName,
+            ODataSerializerContext writeContext)
+        {
+            Contract.Assert(elementName != null);
+            var property = serializer.CreateODataValue(graph, expectedType, writeContext);
+            if (property != null)
+            {
+                return new ODataProperty
+                {
+                    Name = elementName,
+                    Value = property
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerProvider.cs
@@ -21,15 +21,15 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
     /// <summary>
     /// The default implementation of <see cref="IODataSerializerProvider"/>.
     /// </summary>
-    public class DefaultODataSerializerProvider : IODataSerializerProvider
+    public class ODataSerializerProvider: IODataSerializerProvider
     {
         private readonly IServiceProvider _serviceProvider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultODataSerializerProvider"/> class.
+        /// Initializes a new instance of the <see cref="ODataSerializerProvider"/> class.
         /// </summary>
         /// <param name="serviceProvider">The root container.</param>
-        public DefaultODataSerializerProvider(IServiceProvider serviceProvider)
+        public ODataSerializerProvider(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider ?? throw Error.ArgumentNull(nameof(serviceProvider));
         }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2891,6 +2891,11 @@
             <param name="isDelta">Is delta</param>
             <returns>An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> that can deserialize the given EDM type.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer">
+            <summary>
+            Interface for all <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer" />s that deserialize into an object backed by <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
             <summary>
             Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.
@@ -3979,9 +3984,8 @@
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.ODataPayloadKind">
             <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> class.
+            The kind of OData payload that this serializer generates.
             </summary>
-            <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
             <summary>
@@ -4575,6 +4579,7 @@
             Creates an <see cref="T:Microsoft.OData.ODataProperty"/> with name <paramref name="elementName"/> and value
             based on the object represented by <paramref name="graph"/>.
             </summary>
+            <param name="serializer">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer"/> writing the property value.</param>
             <param name="graph">The object to base the value of the property on.</param>
             <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
             <param name="elementName">The name of the property.</param>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -3967,17 +3967,6 @@
             <param name="writer">The <see cref="T:Microsoft.OData.ODataWriter" /> to be used for writing.</param>
             <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <summary>
-            Creates an <see cref="T:Microsoft.OData.ODataProperty"/> with name <paramref name="elementName"/> and value
-            based on the object represented by <paramref name="graph"/>.
-            </summary>
-            <param name="graph">The object to base the value of the property on.</param>
-            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-            <param name="elementName">The name of the property.</param>
-            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
-            <returns>The <see cref="T:Microsoft.OData.ODataProperty"/> created.</returns>
-        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer">
             <summary>
             An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> is used to write a CLR object to an ODataMessage.
@@ -4058,9 +4047,6 @@
             <param name="elementType">The element EDM type of the collection.</param>
             <param name="writeContext">The serializer context to be used while creating the collection.</param>
             <returns>The created <see cref="T:Microsoft.OData.ODataCollectionValue"/>.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <inheritdoc />
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.AddTypeNameAnnotationAsNeeded(Microsoft.OData.ODataCollectionValue,Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel)">
             <summary>
@@ -4160,9 +4146,6 @@
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.CreateODataValue(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <inheritdoc/>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
             <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer">
@@ -4586,6 +4569,17 @@
             <summary>
             Gets or sets the navigation property being expanded.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerPropertyHelper.CreateProperty(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer,System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <summary>
+            Creates an <see cref="T:Microsoft.OData.ODataProperty"/> with name <paramref name="elementName"/> and value
+            based on the object represented by <paramref name="graph"/>.
+            </summary>
+            <param name="graph">The object to base the value of the property on.</param>
+            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+            <param name="elementName">The name of the property.</param>
+            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+            <returns>The <see cref="T:Microsoft.OData.ODataProperty"/> created.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2846,29 +2846,66 @@
         <member name="F:Microsoft.AspNetCore.OData.Formatter.DefaultODataETagHandler.NullLiteralInETag">
             <summary>null literal that needs to be return in ETag value when the value is null</summary>
         </member>
-        <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider">
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer">
             <summary>
-            The default <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider"/>.
+            An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/> is used to read an ODataMessage into a CLR object.
+            </summary>
+            <remarks>
+            Each supported CLR type has a corresponding <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer" />. A CLR type is supported if it is one of
+            the special types or if it has a backing EDM type. Some of the special types are Uri which maps to ODataReferenceLink payload, 
+            Uri[] which maps to ODataReferenceLinks payload, ODataWorkspace which maps to ODataServiceDocument payload.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer.ODataPayloadKind">
+            <summary>
+            The kind of ODataPayload this deserializer handles.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.#ctor(System.IServiceProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader,System.Type,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
             <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider"/> class.
+            Reads an <see cref="T:Microsoft.OData.IODataRequestMessage"/> using messageReader.
             </summary>
-            <param name="serviceProvider">The service provider.</param>
+            <param name="messageReader">The messageReader to use.</param>
+            <param name="type">The type of the object to read into.</param>
+            <param name="readContext">The read context.</param>
+            <returns>The deserialized object.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference,System.Boolean)">
-            <inheritdoc />
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider">
+            <summary>
+            Represents a factory that creates an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/>.
+            </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.GetODataDeserializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
-            <inheritdoc />
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider.GetODataDeserializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
+            <summary>
+            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> for the given type.
+            </summary>
+            <param name="type">The CLR type.</param>
+            <param name="request">The request being deserialized.</param>
+            <returns>An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can deserialize the given type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference,System.Boolean)">
+            <summary>
+            Gets the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> for the given EDM type.
+            </summary>
+            <param name="edmType">The EDM type.</param>
+            <param name="isDelta">Is delta</param>
+            <returns>An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> that can deserialize the given EDM type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
+            <summary>
+            Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.
+            </summary>
+            <param name="item">The item to deserialize.</param>
+            <param name="edmType">The EDM type of the object to read into.</param>
+            <param name="readContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext"/>.</param>
+            <returns>The deserialized object.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer">
             <summary>
-            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> for reading OData action parameters.
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/> for reading OData action parameters.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer"/> class.
             </summary>
@@ -2884,10 +2921,10 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer">
             <summary>
-            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can read OData collection payloads.
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/> that can read OData collection payloads.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer"/> class.
             </summary>
@@ -2910,10 +2947,10 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer">
             <summary>
-            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can read OData delta resource sets.
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/> that can read OData delta resource sets.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer"/> class.
             </summary>
@@ -2979,22 +3016,14 @@
             <param name="payloadKind">The kind of payload this deserializer handles.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer.ODataPayloadKind">
-            <summary>
-            The kind of ODataPayload this deserializer handles.
-            </summary>
+            <inheritdoc />
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader,System.Type,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
-            <summary>
-            Reads an <see cref="T:Microsoft.OData.IODataRequestMessage"/> using messageReader.
-            </summary>
-            <param name="messageReader">The messageReader to use.</param>
-            <param name="type">The type of the object to read into.</param>
-            <param name="readContext">The read context.</param>
-            <returns>The deserialized object.</returns>
+            <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext">
             <summary>
-            This class encapsulates the state and settings that get passed to <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/>.
+            This class encapsulates the state and settings that get passed to <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer"/>.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext.ResourceType">
@@ -3029,24 +3058,20 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider">
             <summary>
-            Represents a factory that creates an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/>.
+            The default <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider"/>.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetODataDeserializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.#ctor(System.IServiceProvider)">
             <summary>
-            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> for the given type.
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider"/> class.
             </summary>
-            <param name="type">The CLR type.</param>
-            <param name="request">The request being deserialized.</param>
-            <returns>An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can deserialize the given type.</returns>
+            <param name="serviceProvider">The service provider.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference,System.Boolean)">
-            <summary>
-            Gets the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> for the given EDM type.
-            </summary>
-            <param name="edmType">The EDM type.</param>
-            <param name="isDelta">Is delta</param>
-            <returns>An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> that can deserialize the given EDM type.</returns>
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetODataDeserializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
+            <inheritdoc />
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer">
             <summary>
@@ -3059,26 +3084,20 @@
             </summary>
             <param name="payloadKind">The kind of OData payload that this deserializer reads.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.#ctor(Microsoft.OData.ODataPayloadKind,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.#ctor(Microsoft.OData.ODataPayloadKind,Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer"/> class.
             </summary>
             <param name="payloadKind">The kind of OData payload this deserializer handles.</param>
-            <param name="deserializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider"/>.</param>
+            <param name="deserializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider"/>.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.DeserializerProvider">
             <summary>
-            The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider"/> to use for deserializing inner items.
+            The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider"/> to use for deserializing inner items.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
-            <summary>
-            Deserializes the item into a new object of type corresponding to <paramref name="edmType"/>.
-            </summary>
-            <param name="item">The item to deserialize.</param>
-            <param name="edmType">The EDM type of the object to read into.</param>
-            <param name="readContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext"/>.</param>
-            <returns>The deserialized object.</returns>
+            <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer">
             <summary>
@@ -3138,7 +3157,7 @@
             Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> for reading OData resource payloads.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer"/> class.
             </summary>
@@ -3250,7 +3269,7 @@
             Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can read OData resource sets.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer"/> class.
             </summary>
@@ -3924,29 +3943,93 @@
             <returns>A new <see cref="T:Microsoft.AspNetCore.OData.Formatter.ResourceSetContext"/>.</returns>
             <remarks>This signature uses types that are AspNetCore-specific.</remarks>
         </member>
-        <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider">
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer">
             <summary>
-            The default implementation of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/>.
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> that serializes instances of objects backed by an <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.#ctor(System.IServiceProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.CreateODataValue(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
             <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider"/> class.
+            Creates an <see cref="T:Microsoft.OData.ODataValue"/> for the object represented by <paramref name="graph"/>.
             </summary>
-            <param name="serviceProvider">The root container.</param>
+            <param name="graph">The value of the <see cref="T:Microsoft.OData.ODataValue"/> to be created.</param>
+            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+            <returns>The <see cref="T:Microsoft.OData.ODataValue"/> created.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference)">
-            <inheritdoc />
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.WriteObjectInlineAsync(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.OData.ODataWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <summary>
+            Writes the given object specified by the parameter graph as a part of an existing OData message using the given
+            messageWriter and the writeContext.
+            </summary>
+            <param name="graph">The object to be written.</param>
+            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+            <param name="writer">The <see cref="T:Microsoft.OData.ODataWriter" /> to be used for writing.</param>
+            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.GetODataPayloadSerializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
-            <inheritdoc />
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <summary>
+            Creates an <see cref="T:Microsoft.OData.ODataProperty"/> with name <paramref name="elementName"/> and value
+            based on the object represented by <paramref name="graph"/>.
+            </summary>
+            <param name="graph">The object to base the value of the property on.</param>
+            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
+            <param name="elementName">The name of the property.</param>
+            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+            <returns>The <see cref="T:Microsoft.OData.ODataProperty"/> created.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer">
+            <summary>
+            An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> is used to write a CLR object to an ODataMessage.
+            </summary>
+            <remarks>
+            Each supported CLR type has a corresponding <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer" />. A CLR type is supported if it is one of
+            the special types or if it has a backing EDM type. Some of the special types are Uri which maps to ODataReferenceLink payload, 
+            Uri[] which maps to ODataReferenceLinks payload, etc.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.ODataPayloadKind">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> class.
+            </summary>
+            <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <summary>
+            Writes the given object specified by the parameter graph as a whole using the given messageWriter and writeContext.
+            </summary>
+            <param name="graph">The object to be written</param>
+            <param name="type">The type of the object to be written.</param>
+            <param name="messageWriter">The <see cref="T:Microsoft.OData.ODataMessageWriter"/> to be used for writing.</param>
+            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider">
+            <summary>
+            An <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/> is a factory for creating <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference)">
+            <summary>
+            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer"/> for the given edmType.
+            </summary>
+            <param name="edmType">The <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.</param>
+            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider.GetODataPayloadSerializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
+            <summary>
+            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/> for the given <paramref name="type"/>.
+            </summary>
+            <param name="type">The <see cref="T:System.Type"/> for which the serializer is being requested.</param>
+            <param name="request">The request for which the response is being serialized.</param>
+            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> for the given type.</returns>
+            <remarks>This signature uses types that are AspNetCore-specific.</remarks>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer">
             <summary>
             ODataSerializer for serializing collection of primitive or enum types.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer"/> class.
             </summary>
@@ -3976,6 +4059,9 @@
             <param name="writeContext">The serializer context to be used while creating the collection.</param>
             <returns>The created <see cref="T:Microsoft.OData.ODataCollectionValue"/>.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.AddTypeNameAnnotationAsNeeded(Microsoft.OData.ODataCollectionValue,Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel)">
             <summary>
             Adds the type name annotations required for proper json light serialization.
@@ -3989,11 +4075,11 @@
             The Collection is of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmChangedObject"/> which is the base interface implemented by all objects which are a part of the DeltaResourceSet payload.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <summary>
             Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer"/>.
             </summary>
-            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/> to use to write nested entries.</param>
+            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/> to use to write nested entries.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
             <inheritdoc />
@@ -4049,7 +4135,7 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer">
             <summary>
-            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/> that serializes instances of objects backed by an <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> that serializes instances of objects backed by an <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.#ctor(Microsoft.OData.ODataPayloadKind)">
@@ -4058,36 +4144,26 @@
             </summary>
             <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.#ctor(Microsoft.OData.ODataPayloadKind,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.#ctor(Microsoft.OData.ODataPayloadKind,Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer"/> class.
             </summary>
             <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
-            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/> to use to write inner objects.</param>
+            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/> to use to write inner objects.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.SerializerProvider">
             <summary>
-            Gets the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/> that can be used to write inner objects.
+            Gets the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/> that can be used to write inner objects.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.WriteObjectInlineAsync(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.OData.ODataWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <summary>
-            Writes the given object specified by the parameter graph as a part of an existing OData message using the given
-            messageWriter and the writeContext.
-            </summary>
-            <param name="graph">The object to be written.</param>
-            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-            <param name="writer">The <see cref="T:Microsoft.OData.ODataWriter" /> to be used for writing.</param>
-            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+            <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.CreateODataValue(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <summary>
-            Creates an <see cref="T:Microsoft.OData.ODataValue"/> for the object represented by <paramref name="graph"/>.
-            </summary>
-            <param name="graph">The value of the <see cref="T:Microsoft.OData.ODataValue"/> to be created.</param>
-            <param name="expectedType">The expected EDM type of the object represented by <paramref name="graph"/>.</param>
-            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
-            <returns>The <see cref="T:Microsoft.OData.ODataValue"/> created.</returns>
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.CreateProperty(System.Object,Microsoft.OData.Edm.IEdmTypeReference,System.String,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
+            <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer">
             <summary>
@@ -4120,7 +4196,7 @@
             Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/> for serializing <see cref="T:Microsoft.OData.Edm.IEdmEnumType" />'s.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <summary>
             Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer"/>.
             </summary>
@@ -4225,7 +4301,7 @@
             ODataSerializer for serializing instances of <see cref="T:Microsoft.OData.Edm.IEdmEntityType"/> or <see cref="T:Microsoft.OData.Edm.IEdmComplexType"/>
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
@@ -4328,11 +4404,11 @@
             OData serializer for serializing a collection of <see cref="T:Microsoft.OData.Edm.IEdmEntityType" /> or <see cref="T:Microsoft.OData.Edm.IEdmComplexType"/>
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.#ctor(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider)">
             <summary>
             Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer"/>.
             </summary>
-            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/> to use to write nested entries.</param>
+            <param name="serializerProvider">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/> to use to write nested entries.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
             <inheritdoc />
@@ -4369,7 +4445,7 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer">
             <summary>
-            An ODataSerializer is used to write a CLR object to an ODataMessage.
+            Base class for <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> implementations.
             </summary>
             <remarks>
             Each supported CLR type has a corresponding <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer" />. A CLR type is supported if it is one of
@@ -4384,18 +4460,10 @@
             <param name="payloadKind">The kind of OData payload that this serializer generates.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer.ODataPayloadKind">
-            <summary>
-            Gets the <see cref="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer.ODataPayloadKind"/> that this serializer generates.
-            </summary>
+            <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer.WriteObjectAsync(System.Object,System.Type,Microsoft.OData.ODataMessageWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext)">
-            <summary>
-            Writes the given object specified by the parameter graph as a whole using the given messageWriter and writeContext.
-            </summary>
-            <param name="graph">The object to be written</param>
-            <param name="type">The type of the object to be written.</param>
-            <param name="messageWriter">The <see cref="T:Microsoft.OData.ODataMessageWriter"/> to be used for writing.</param>
-            <param name="writeContext">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/>.</param>
+            <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext">
             <summary>
@@ -4521,24 +4589,20 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider">
             <summary>
-            An ODataSerializerProvider is a factory for creating <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/>s.
+            The default implementation of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider"/>.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.#ctor(System.IServiceProvider)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider"/> class.
+            </summary>
+            <param name="serviceProvider">The root container.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference)">
-            <summary>
-            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer"/> for the given edmType.
-            </summary>
-            <param name="edmType">The <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.</param>
-            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/>.</returns>
+            <inheritdoc />
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetODataPayloadSerializer(System.Type,Microsoft.AspNetCore.Http.HttpRequest)">
-            <summary>
-            Gets an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/> for the given <paramref name="type"/>.
-            </summary>
-            <param name="type">The <see cref="T:System.Type"/> for which the serializer is being requested.</param>
-            <param name="request">The request for which the response is being serialized.</param>
-            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer"/> for the given type.</returns>
-            <remarks>This signature uses types that are AspNetCore-specific.</remarks>
+            <inheritdoc />
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1577,7 +1577,6 @@ virtual Microsoft.AspNetCore.OData.Deltas.Delta<T>.ExpectedClrType.get -> System
 virtual Microsoft.AspNetCore.OData.Deltas.Delta<T>.StructuredType.get -> System.Type
 virtual Microsoft.AspNetCore.OData.Deltas.DeltaLinkBase<T>.ExpectedClrType.get -> System.Type
 virtual Microsoft.AspNetCore.OData.Deltas.DeltaLinkBase<T>.StructuredType.get -> System.Type
-virtual Microsoft.AspNetCore.OData.Deltas.DeltaSet<T>.GetOriginal(Microsoft.AspNetCore.OData.Deltas.IDeltaSetItem deltaItem, System.Collections.IEnumerable originalSet) -> T
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildEditLink(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel, System.Uri idLink) -> System.Uri
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildEntitySelfLinks(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel) -> Microsoft.AspNetCore.OData.Edm.EntitySelfLinks
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildIdLink(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel) -> System.Uri

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -9,12 +9,8 @@ abstract Microsoft.AspNetCore.OData.Deltas.Delta.TryGetPropertyType(string name,
 abstract Microsoft.AspNetCore.OData.Deltas.Delta.TryGetPropertyValue(string name, out object value) -> bool
 abstract Microsoft.AspNetCore.OData.Deltas.Delta.TrySetPropertyValue(string name, object value) -> bool
 abstract Microsoft.AspNetCore.OData.Deltas.DeltaLinkBase<T>.Kind.get -> Microsoft.AspNetCore.OData.Deltas.DeltaItemKind
-abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference edmType, bool isDelta = false) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer
-abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetODataDeserializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer
 abstract Microsoft.AspNetCore.OData.Formatter.MediaType.MediaTypeMapping.TryMatchMediaType(Microsoft.AspNetCore.Http.HttpRequest request) -> double
 abstract Microsoft.AspNetCore.OData.Formatter.MediaType.ODataRawValueMediaTypeMapping.IsMatch(Microsoft.OData.UriParser.PropertySegment propertySegment) -> bool
-abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference edmType) -> Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer
-abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetODataPayloadSerializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer
 abstract Microsoft.AspNetCore.OData.Formatter.Value.EdmDeltaLinkBase.Kind.get -> Microsoft.AspNetCore.OData.Deltas.DeltaItemKind
 abstract Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase.Bind(Microsoft.OData.UriParser.QueryNode node) -> System.Linq.Expressions.Expression
 abstract Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase.Parameter.get -> System.Linq.Expressions.ParameterExpression
@@ -295,15 +291,21 @@ Microsoft.AspNetCore.OData.Extensions.HttpResponseExtensions
 Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers
 Microsoft.AspNetCore.OData.Extensions.SerializableErrorExtensions
 Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys
-Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider
-Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.DefaultODataDeserializerProvider(System.IServiceProvider serviceProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer.ODataPayloadKind.get -> Microsoft.OData.ODataPayloadKind
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext) -> System.Threading.Tasks.Task<object>
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference edmType, bool isDelta = false) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider.GetODataDeserializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer.ReadInline(object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext) -> object
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.DeserializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.ODataActionPayloadDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.DeserializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.ODataActionPayloadDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer.ODataCollectionDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer.ODataCollectionDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer.ODataDeltaResourceSetDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer.ODataDeltaResourceSetDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer.ODataDeserializer(Microsoft.OData.ODataPayloadKind payloadKind) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer.ODataPayloadKind.get -> Microsoft.OData.ODataPayloadKind
@@ -322,11 +324,13 @@ Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext.Re
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext.TimeZone.get -> System.TimeZoneInfo
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext.TimeZone.set -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.ODataDeserializerProvider() -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference edmType, bool isDelta = false) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.GetODataDeserializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider.ODataDeserializerProvider(System.IServiceProvider serviceProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.DeserializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.DeserializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.ODataEdmTypeDeserializer(Microsoft.OData.ODataPayloadKind payloadKind) -> void
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.ODataEdmTypeDeserializer(Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer.ODataEdmTypeDeserializer(Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer.ODataEntityReferenceLinkDeserializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer
@@ -334,9 +338,9 @@ Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.OData
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer.ODataPrimitiveDeserializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer.ODataResourceDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer.ODataResourceDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer
-Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer.ODataResourceSetDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer.ODataResourceSetDeserializer(Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.FromODataBodyAttribute
 Microsoft.AspNetCore.OData.Formatter.FromODataBodyAttribute.FromODataBodyAttribute() -> void
 Microsoft.AspNetCore.OData.Formatter.FromODataUriAttribute
@@ -418,22 +422,29 @@ Microsoft.AspNetCore.OData.Formatter.ResourceSetContext.Request.set -> void
 Microsoft.AspNetCore.OData.Formatter.ResourceSetContext.ResourceSetContext() -> void
 Microsoft.AspNetCore.OData.Formatter.ResourceSetContext.ResourceSetInstance.get -> object
 Microsoft.AspNetCore.OData.Formatter.ResourceSetContext.ResourceSetInstance.set -> void
-Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider
-Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.DefaultODataSerializerProvider(System.IServiceProvider serviceProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.CreateODataValue(object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> Microsoft.OData.ODataValue
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer.WriteObjectInlineAsync(object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> System.Threading.Tasks.Task
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.ODataPayloadKind.get -> Microsoft.OData.ODataPayloadKind
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer.WriteObjectAsync(object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> System.Threading.Tasks.Task
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference edmType) -> Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer
+Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider.GetODataPayloadSerializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.ODataCollectionSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.ODataCollectionSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.ODataDeltaResourceSetSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.ODataDeltaResourceSetSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.ODataEdmTypeSerializer(Microsoft.OData.ODataPayloadKind payloadKind) -> void
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.ODataEdmTypeSerializer(Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.SerializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.ODataEdmTypeSerializer(Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer.SerializerProvider.get -> Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer.ODataEntityReferenceLinkSerializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer.ODataEntityReferenceLinksSerializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.ODataEnumSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.ODataEnumSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer.ODataErrorSerializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSerializer
@@ -443,9 +454,9 @@ Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer.ODat
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer.ODataRawValueSerializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.ODataResourceSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.ODataResourceSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.ODataResourceSetSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.ODataResourceSetSerializer(Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer.ODataPayloadKind.get -> Microsoft.OData.ODataPayloadKind
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer.ODataSerializer(Microsoft.OData.ODataPayloadKind payloadKind) -> void
@@ -480,7 +491,9 @@ Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.SkipEx
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.TimeZone.get -> System.TimeZoneInfo
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.TimeZone.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.ODataSerializerProvider() -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference edmType) -> Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.GetODataPayloadSerializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider.ODataSerializerProvider(System.IServiceProvider serviceProvider) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer.ODataServiceDocumentSerializer() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode
@@ -1293,8 +1306,6 @@ override Microsoft.AspNetCore.OData.Deltas.Delta<T>.TrySetPropertyValue(string n
 override Microsoft.AspNetCore.OData.Deltas.DeltaDeletedLink<T>.Kind.get -> Microsoft.AspNetCore.OData.Deltas.DeltaItemKind
 override Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource<T>.Kind.get -> Microsoft.AspNetCore.OData.Deltas.DeltaItemKind
 override Microsoft.AspNetCore.OData.Deltas.DeltaLink<T>.Kind.get -> Microsoft.AspNetCore.OData.Deltas.DeltaItemKind
-override Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.GetEdmTypeDeserializer(Microsoft.OData.Edm.IEdmTypeReference edmType, bool isDelta = false) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer
-override Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider.GetODataDeserializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer
 override Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext) -> System.Threading.Tasks.Task<object>
 override Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext) -> System.Threading.Tasks.Task<object>
 override Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer.ReadAsync(Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext) -> System.Threading.Tasks.Task<object>
@@ -1319,8 +1330,6 @@ override Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter.CanWriteResul
 override Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter.GetSupportedContentTypes(string contentType, System.Type objectType) -> System.Collections.Generic.IReadOnlyList<string>
 override Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter.WriteResponseBodyAsync(Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context, System.Text.Encoding selectedEncoding) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter.WriteResponseHeaders(Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context) -> void
-override Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.GetEdmTypeSerializer(Microsoft.OData.Edm.IEdmTypeReference edmType) -> Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer
-override Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider.GetODataPayloadSerializer(System.Type type, Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer
 override Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer.WriteObjectAsync(object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.WriteObjectAsync(object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer.WriteObjectInlineAsync(object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> System.Threading.Tasks.Task
@@ -1485,7 +1494,7 @@ static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataFeature(
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.CreateETag(this Microsoft.AspNetCore.Http.HttpRequest request, System.Collections.Generic.IDictionary<string, object> properties, System.TimeZoneInfo timeZone = null) -> string
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.CreateSubServiceProvider(this Microsoft.AspNetCore.Http.HttpRequest request, string prefixName) -> System.IServiceProvider
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.DeleteSubRequestProvider(this Microsoft.AspNetCore.Http.HttpRequest request, bool dispose) -> void
-static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetDeserializerProvider(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider
+static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetDeserializerProvider(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetETagHandler(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Abstracts.IETagHandler
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetModel(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.OData.Edm.IEdmModel
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetNextPageLink(this Microsoft.AspNetCore.Http.HttpRequest request, int pageSize, object instance, System.Func<object, string> objectToSkipTokenValue) -> System.Uri

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DefaultODataDeserializerProviderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DefaultODataDeserializerProviderTests.cs
@@ -20,16 +20,16 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
 {
-    public class DefaultODataDeserializerProviderTests
+    public class ODataDeserializerProviderTests
     {
         private static IODataDeserializerProvider _deserializerProvider = GetServiceProvider().GetRequiredService<IODataDeserializerProvider>();
         private static IEdmModel _edmModel = GetEdmModel();
 
         [Fact]
-        public void DefaultODataDeserializerProvider_Ctor_ThrowsArgumentNull_ServiceProvider()
+        public void ODataDeserializerProvider_Ctor_ThrowsArgumentNull_ServiceProvider()
         {
             // Arrange & Act & Assert
-            ExceptionAssert.ThrowsArgumentNull(() => new DefaultODataDeserializerProvider(null), "serviceProvider");
+            ExceptionAssert.ThrowsArgumentNull(() => new ODataDeserializerProvider(null), "serviceProvider");
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(model: null);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Uri), request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Uri), request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(EdmCoreModel.Instance);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(type, request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(type, request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Address), request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(typeof(Address), request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(collectionType, request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(collectionType, request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(collectionType, request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(collectionType, request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(deltaType, request);
+            IODataDeserializer deserializer = _deserializerProvider.GetODataDeserializer(deltaType, request);
 
             // Assert
             Assert.NotNull(deserializer);
@@ -174,8 +174,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataDeserializer firstCallDeserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
-            ODataDeserializer secondCallDeserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
+            IODataDeserializer firstCallDeserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
+            IODataDeserializer secondCallDeserializer = _deserializerProvider.GetODataDeserializer(typeof(Product), request);
 
             // Assert
             Assert.Same(firstCallDeserializer, secondCallDeserializer);
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, ODataDeserializerProvider>();
 
             // Deserializers.
             services.AddSingleton<ODataResourceDeserializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DefaultODataDeserializerProviderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DefaultODataDeserializerProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
 {
     public class DefaultODataDeserializerProviderTests
     {
-        private static ODataDeserializerProvider _deserializerProvider = GetServiceProvider().GetRequiredService<ODataDeserializerProvider>();
+        private static IODataDeserializerProvider _deserializerProvider = GetServiceProvider().GetRequiredService<IODataDeserializerProvider>();
         private static IEdmModel _edmModel = GetEdmModel();
 
         [Fact]
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<ODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
 
             // Deserializers.
             services.AddSingleton<ODataResourceDeserializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationServiceProviderHelper.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationServiceProviderHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<ODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
 
             // Deserializers.
             services.AddSingleton<ODataResourceDeserializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationServiceProviderHelper.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationServiceProviderHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, ODataDeserializerProvider>();
 
             // Deserializers.
             services.AddSingleton<ODataResourceDeserializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
     {
         private static IEdmModel _model;
         private static IEdmEntityContainer _container;
-        private static ODataDeserializerProvider _deserializerProvider;
+        private static IODataDeserializerProvider _deserializerProvider;
         private static ODataActionPayloadDeserializer _deserializer;
         private const string _serviceRoot = "http://any/";
 
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             _model = GetModel();
             _container = _model.EntityContainer;
 
-            _deserializerProvider = DeserializationServiceProviderHelper.GetServiceProvider().GetRequiredService<ODataDeserializerProvider>();
+            _deserializerProvider = DeserializationServiceProviderHelper.GetServiceProvider().GetRequiredService<IODataDeserializerProvider>();
             _deserializer = new ODataActionPayloadDeserializer(_deserializerProvider);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void Ctor_SetsProperty_DeserializerProvider()
         {
             // Arrange
-            ODataDeserializerProvider deserializerProvider = new Mock<ODataDeserializerProvider>().Object;
+            IODataDeserializerProvider deserializerProvider = new Mock<IODataDeserializerProvider>().Object;
 
             // Act
             var deserializer = new ODataActionPayloadDeserializer(deserializerProvider);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void Ctor_SetsProperty_ODataPayloadKind()
         {
             // Arrange
-            ODataDeserializerProvider deserializerProvider = new Mock<ODataDeserializerProvider>().Object;
+            IODataDeserializerProvider deserializerProvider = new Mock<IODataDeserializerProvider>().Object;
 
             // Act
             var deserializer = new ODataActionPayloadDeserializer(deserializerProvider);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private static readonly IEdmModel Model = GetEdmModel();
 
         // private static readonly ODataSerializerProvider SerializerProvider = ODataSerializerProviderFactory.Create();
-        private static readonly ODataSerializerProvider SerializerProvider = ODataFormatterHelpers.GetSerializerProvider(); // TODO:
+        private static readonly IODataSerializerProvider SerializerProvider = ODataFormatterHelpers.GetSerializerProvider(); // TODO:
 
         // private static readonly ODataDeserializerProvider DeserializerProvider = ODataDeserializerProviderFactory.Create();
         private static readonly IODataDeserializerProvider DeserializerProvider = ODataFormatterHelpers.GetDeserializerProvider(); // TODO:

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private static readonly ODataSerializerProvider SerializerProvider = ODataFormatterHelpers.GetSerializerProvider(); // TODO:
 
         // private static readonly ODataDeserializerProvider DeserializerProvider = ODataDeserializerProviderFactory.Create();
-        private static readonly ODataDeserializerProvider DeserializerProvider = ODataFormatterHelpers.GetDeserializerProvider(); // TODO:
+        private static readonly IODataDeserializerProvider DeserializerProvider = ODataFormatterHelpers.GetDeserializerProvider(); // TODO:
 
         private static readonly IEdmEnumTypeReference ColorType =
             new EdmEnumTypeReference(Model.SchemaElements.OfType<IEdmEnumType>().First(c => c.Name == "Color"),
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadCollectionValue_Throws_IfElementTypeCannotBeDeserialized()
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             deserializerProvider.Setup(p => p.GetEdmTypeDeserializer(ColorType, false)).Returns<ODataResourceDeserializer>(null);
             var deserializer = new ODataCollectionDeserializer(deserializerProvider.Object);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataDeltaResourceSetDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataDeltaResourceSetDeserializerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public async Task ReadAsync_ThrowsArgumentNull_MessageReader()
         {
             // Arrange & Act & Assert
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
 
             await ExceptionAssert.ThrowsArgumentNullAsync(() => deserializer.ReadAsync(null, null, null), "messageReader");
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public async Task ReadAsync_ThrowsArgumentNull_ReadContext()
         {
             // Arrange & Act & Assert
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
             ODataMessageReader reader = new ODataMessageReader((IODataResponseMessage)new InMemoryMessage(), new ODataMessageReaderSettings());
 
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             ODataPath path = new ODataPath(new EntitySetSegment(entitySet));
             ODataDeserializerContext readerContext = new ODataDeserializerContext() { Path = path, Model = _model };
 
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             Mock<ODataDeltaResourceSetDeserializer> deserializer = new Mock<ODataDeltaResourceSetDeserializer>(deserializerProvider.Object);
 
             // Arrange & Act & Assert
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadInline_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
 
             // Arrange & Act & Assert
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IEdmEntityTypeReference entityTypeRef = new EdmEntityTypeReference(entityType, false);
             IEdmCollectionTypeReference collectionType = new EdmCollectionTypeReference(new EdmCollectionType(entityTypeRef));
 
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             Mock<ODataDeltaResourceSetDeserializer> deserializer = new Mock<ODataDeltaResourceSetDeserializer>(deserializerProvider.Object);
 
             ODataDeltaResourceSetWrapper wrapper = new ODataDeltaResourceSetWrapper(new ODataDeltaResourceSet());
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         [Fact]
         public void ReadInline_Calls_ReadInlineForEachDeltaItem()
         {
-            ODataDeserializerProvider provider = ODataFormatterHelpers.GetDeserializerProvider();
+            IODataDeserializerProvider provider = ODataFormatterHelpers.GetDeserializerProvider();
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IEdmEntityType customer = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
             IEdmStructuredTypeReference elementType = new EdmEntityTypeReference(customer, true);
 
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             Mock<ODataEdmTypeDeserializer> resourceDeserializer = new Mock<ODataEdmTypeDeserializer>(ODataPayloadKind.Resource);
 
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadDeltaResource_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange & Act & Assert
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
             ExceptionAssert.ThrowsArgumentNull(() => deserializer.ReadDeltaResource(null, null, null), "resource");
 
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             // Arrange & Act & Assert
             IEdmComplexType complex = new EdmComplexType("NS", "Complex");
             IEdmStructuredTypeReference typeRef = new EdmComplexTypeReference(complex, false);
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             deserializerProvider.Setup(s => s.GetEdmTypeDeserializer(typeRef, false)).Returns((ODataEdmTypeDeserializer)null);
 
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IEdmEntityType customer = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
             IEdmStructuredTypeReference elementType = new EdmEntityTypeReference(customer, true);
 
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataResourceDeserializer resourceDeserializer = new ODataResourceDeserializer(deserializerProvider.Object);
 
             Uri id = new Uri("Customers(8)", UriKind.RelativeOrAbsolute);
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadDeltaDeletedLink_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange & Act & Assert
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
             ExceptionAssert.ThrowsArgumentNull(() => deserializer.ReadDeltaDeletedLink(null, null, null), "deletedLink");
 
@@ -316,7 +316,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadDeltaDeletedLink_Returns_DeletedDeltaLink(bool typed)
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
 
             Uri source = new Uri("Customers(8)", UriKind.RelativeOrAbsolute);
@@ -367,7 +367,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadDeltaLink_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange & Act & Assert
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
             ExceptionAssert.ThrowsArgumentNull(() => deserializer.ReadDeltaLink(null, null, null), "link");
 
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadDeltaLink_Returns_DeltaLink(bool typed)
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataDeltaResourceSetDeserializer deserializer = new ODataDeltaResourceSetDeserializer(deserializerProvider.Object);
 
             Uri source = new Uri("Customers(8)", UriKind.RelativeOrAbsolute);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEdmTypeDeserializerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEdmTypeDeserializerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         [Fact]
         public void Ctor_SetsProperty_DeserializerProvider()
         {
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             var deserializer = new Mock<ODataEdmTypeDeserializer>(ODataPayloadKind.Unsupported, deserializerProvider.Object);
 
             Assert.Same(deserializerProvider.Object, deserializer.Object.DeserializerProvider);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceDeserializerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private readonly IEdmEntityTypeReference _productEdmType;
         private readonly IEdmEntityTypeReference _supplierEdmType;
         private readonly IEdmComplexTypeReference _addressEdmType;
-        private readonly ODataDeserializerProvider _deserializerProvider;
+        private readonly IODataDeserializerProvider _deserializerProvider;
         private readonly string _supplyRequestResource;
 
         public ODataResourceDeserializerTests()
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadResource_ThrowsSerializationException_TypeCannotBeDeserialized()
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             deserializerProvider.Setup(d => d.GetEdmTypeDeserializer(It.IsAny<IEdmTypeReference>(), false)).Returns<ODataEdmTypeDeserializer>(null);
             var deserializer = new ODataResourceDeserializer(deserializerProvider.Object);
             ODataResourceWrapper resourceWrapper = new ODataResourceWrapper(new ODataResource { TypeName = _supplierEdmType.FullName() });
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         {
             // Arrange
             Mock<ODataEdmTypeDeserializer> supplierDeserializer = new Mock<ODataEdmTypeDeserializer>(ODataPayloadKind.Resource);
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             var deserializer = new ODataResourceDeserializer(deserializerProvider.Object);
             ODataResourceWrapper resourceWrapper = new ODataResourceWrapper(new ODataResource { TypeName = _supplierEdmType.FullName() });
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceSetDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceSetDeserializerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private readonly IEdmCollectionTypeReference _customersType;
         private readonly IEdmEntityTypeReference _customerType;
         private readonly ODataSerializerProvider _serializerProvider;
-        private readonly ODataDeserializerProvider _deserializerProvider;
+        private readonly IODataDeserializerProvider _deserializerProvider;
 
         public ODataResourceSetDeserializerTests()
         {
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadInline_Calls_ReadResourceSet()
         {
             // Arrange
-            ODataDeserializerProvider deserializerProvider = _deserializerProvider;
+            IODataDeserializerProvider deserializerProvider = _deserializerProvider;
             Mock<ODataResourceSetDeserializer> deserializer = new Mock<ODataResourceSetDeserializer>(deserializerProvider);
             ODataResourceSetWrapper feedWrapper = new ODataResourceSetWrapper(new ODataResourceSet());
             ODataDeserializerContext readContext = new ODataDeserializerContext();
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         [Fact]
         public void ReadResourceSet_Throws_TypeCannotBeDeserialized()
         {
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             ODataResourceSetDeserializer deserializer = new ODataResourceSetDeserializer(deserializerProvider.Object);
             ODataResourceSetWrapper feedWrapper = new ODataResourceSetWrapper(new ODataResourceSet());
             ODataDeserializerContext readContext = new ODataDeserializerContext();
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         public void ReadResourceSet_Calls_ReadInlineForEachEntry()
         {
             // Arrange
-            Mock<ODataDeserializerProvider> deserializerProvider = new Mock<ODataDeserializerProvider>();
+            Mock<IODataDeserializerProvider> deserializerProvider = new Mock<IODataDeserializerProvider>();
             Mock<ODataEdmTypeDeserializer> entityDeserializer = new Mock<ODataEdmTypeDeserializer>(ODataPayloadKind.Resource);
             ODataResourceSetDeserializer deserializer = new ODataResourceSetDeserializer(deserializerProvider.Object);
             ODataResourceSetWrapper resourceSetWrapper = new ODataResourceSetWrapper(new ODataResourceSet());

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceSetDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceSetDeserializerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private readonly IEdmModel _model;
         private readonly IEdmCollectionTypeReference _customersType;
         private readonly IEdmEntityTypeReference _customerType;
-        private readonly ODataSerializerProvider _serializerProvider;
+        private readonly IODataSerializerProvider _serializerProvider;
         private readonly IODataDeserializerProvider _deserializerProvider;
 
         public ODataResourceSetDeserializerTests()

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataSingletonDeserializerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataSingletonDeserializerTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
         private IEdmModel _edmModel;
         private IEdmSingleton _singleton;
         private readonly ODataDeserializerContext _readContext;
-        private readonly ODataDeserializerProvider _deserializerProvider;
+        private readonly IODataDeserializerProvider _deserializerProvider;
 
         private sealed class EmployeeModel
         {
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
                 ResourceType = typeof(EmployeeModel)
             };
 
-            _deserializerProvider = DeserializationServiceProviderHelper.GetServiceProvider().GetRequiredService<ODataDeserializerProvider>();
+            _deserializerProvider = DeserializationServiceProviderHelper.GetServiceProvider().GetRequiredService<IODataDeserializerProvider>();
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             services.AddSingleton<ODataActionPayloadDeserializer>();
 
             // Serializers.
-            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             services.AddSingleton<ODataEnumSerializer>();
             services.AddSingleton<ODataPrimitiveSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             services.AddSingleton<ODataActionPayloadDeserializer>();
 
             // Serializers.
-            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
 
             services.AddSingleton<ODataEnumSerializer>();
             services.AddSingleton<ODataPrimitiveSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
@@ -111,12 +111,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
         }
 
         /// <summary>
-        /// Gets an <see cref="ODataDeserializerProvider"/>.
+        /// Gets an <see cref="IODataDeserializerProvider"/>.
         /// </summary>
         /// <returns>An ODataDeserializerProvider.</returns>
-        public static ODataDeserializerProvider GetDeserializerProvider()
+        public static IODataDeserializerProvider GetDeserializerProvider()
         {
-            return _serviceProvider.GetRequiredService<ODataDeserializerProvider>();
+            return _serviceProvider.GetRequiredService<IODataDeserializerProvider>();
         }
 
         public static ODataMessageWriter GetMockODataMessageWriter()
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             services.AddSingleton<IAssemblyResolver, DefaultAssemblyResolver>();
 
             // Deserializers.
-            services.AddSingleton<ODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
 
             services.AddSingleton<ODataResourceDeserializer>();
             services.AddSingleton<ODataEnumDeserializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataFormatterHelpers.cs
@@ -23,7 +23,7 @@ using Microsoft.OData.ModelBuilder;
 namespace Microsoft.AspNetCore.OData.Tests.Formatter
 {
     /// <summary>
-    /// A factory for creating <see cref="ODataSerializerProvider"/>.
+    /// A factory for creating <see cref="IODataSerializerProvider"/>.
     /// </summary>
     public static class ODataFormatterHelpers
     {
@@ -102,12 +102,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
         }
 
         /// <summary>
-        /// Gets an <see cref="ODataSerializerProvider"/>.
+        /// Gets an <see cref="IODataSerializerProvider"/>.
         /// </summary>
         /// <returns>An ODataSerializerProvider.</returns>
-        public static ODataSerializerProvider GetSerializerProvider()
+        public static IODataSerializerProvider GetSerializerProvider()
         {
-            return _serviceProvider.GetRequiredService<ODataSerializerProvider>();
+            return _serviceProvider.GetRequiredService<IODataSerializerProvider>();
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             services.AddSingleton<IAssemblyResolver, DefaultAssemblyResolver>();
 
             // Deserializers.
-            services.AddSingleton<IODataDeserializerProvider, DefaultODataDeserializerProvider>();
+            services.AddSingleton<IODataDeserializerProvider, ODataDeserializerProvider>();
 
             services.AddSingleton<ODataResourceDeserializer>();
             services.AddSingleton<ODataEnumDeserializer>();
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             services.AddSingleton<ODataActionPayloadDeserializer>();
 
             // Serializers.
-            services.AddSingleton<ODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             services.AddSingleton<ODataEnumSerializer>();
             services.AddSingleton<ODataPrimitiveSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataOutputFormatterHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataOutputFormatterHelperTests.cs
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             // Arrange
             Type intType = typeof(int);
             HttpRequest request = new DefaultHttpContext().Request;
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
-            provider.Setup(s => s.GetODataPayloadSerializer(intType, request)).Returns((ODataSerializer)null);
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
+            provider.Setup(s => s.GetODataPayloadSerializer(intType, request)).Returns((IODataSerializer)null);
 
             // Act & Assert
             ExceptionAssert.Throws<SerializationException>(
@@ -69,8 +69,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             Mock<IEdmObject> mock = new Mock<IEdmObject>();
             mock.Setup(s => s.GetEdmType()).Returns(intType);
 
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
-            provider.Setup(s => s.GetEdmTypeSerializer(intType)).Returns((ODataEdmTypeSerializer)null);
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
+            provider.Setup(s => s.GetEdmTypeSerializer(intType)).Returns((IODataEdmTypeSerializer)null);
 
             // Act & Assert
             ExceptionAssert.Throws<SerializationException>(

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataTestUtil.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataTestUtil.cs
@@ -26,9 +26,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter
             return new ODataMessageReader(requestMessage);
         }
 
-        public static ODataSerializerProvider GetMockODataSerializerProvider(ODataEdmTypeSerializer serializer)
+        public static IODataSerializerProvider GetMockODataSerializerProvider(ODataEdmTypeSerializer serializer)
         {
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(sp => sp.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(serializer);
             return serializerProvider.Object;
         }

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void DefaultOdataSerializerProvider_Ctor_ThrowsArgumentNull_ServiceProvider()
         {
             ExceptionAssert.ThrowsArgumentNull(
-                () => new ODataSerializerProvider(serviceProvider: null),
+                () => new DefaultODataSerializerProvider(serviceProvider: null),
                 "serviceProvider");
         }
 
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void DefaultOdataSerializerProvider_Ctor_ThrowsArgumentNull_ServiceProvider()
         {
             ExceptionAssert.ThrowsArgumentNull(
-                () => new DefaultODataSerializerProvider(serviceProvider: null),
+                () => new ODataSerializerProvider(serviceProvider: null),
                 "serviceProvider");
         }
 
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/DefaultODataSerializerProviderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 {
     public class DefaultODataSerializerProviderTests
     {
-        private static ODataSerializerProvider _serializerProvider = GetServiceProvider().GetRequiredService<ODataSerializerProvider>();
+        private static IODataSerializerProvider _serializerProvider = GetServiceProvider().GetRequiredService<IODataSerializerProvider>();
 
         private static IEdmModel _edmModel = GetEdmModel();
 
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(EdmCoreModel.Instance);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(type, request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(type, request);
 
             // Assert
             Assert.NotEqual(EdmPrimitiveTypeKind.None, edmPrimitiveTypeKind);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             request.ODataFeature().Path = odataPath;
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(type, request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(type, request);
 
             // Assert
             Assert.NotEqual(EdmPrimitiveTypeKind.None, edmPrimitiveTypeKind);
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(TestEnum), request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(TestEnum), request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             request.ODataFeature().Path = odataPath;
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(TestEnum), request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(TestEnum), request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(Address), request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(Address), request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(collectionType, request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(collectionType, request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -332,7 +332,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(collectionType, request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(collectionType, request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(EdmCoreModel.Instance);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(payloadType, request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(payloadType, request);
 
             // Assert
             Assert.NotNull(serializer);
@@ -369,8 +369,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer firstCallSerializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
-            ODataSerializer secondCallSerializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
+            IODataSerializer firstCallSerializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
+            IODataSerializer secondCallSerializer = _serializerProvider.GetODataPayloadSerializer(typeof(Product), request);
 
             // Assert
             Assert.Same(firstCallSerializer, secondCallSerializer);
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             HttpRequest request = GetRequest(_edmModel);
 
             // Act
-            ODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(UnknownEntityType), request);
+            IODataSerializer serializer = _serializerProvider.GetODataPayloadSerializer(typeof(UnknownEntityType), request);
 
             // Assert
             Assert.Null(serializer);
@@ -405,8 +405,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             IEdmTypeReference edmType = new Mock<IEdmTypeReference>().Object;
 
             // Act
-            ODataSerializer serializer1 = _serializerProvider.GetEdmTypeSerializer(edmType);
-            ODataSerializer serializer2 = _serializerProvider.GetEdmTypeSerializer(edmType);
+            IODataSerializer serializer1 = _serializerProvider.GetEdmTypeSerializer(edmType);
+            IODataSerializer serializer2 = _serializerProvider.GetEdmTypeSerializer(edmType);
 
             // Assert
             Assert.Same(serializer2, serializer1);
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<ODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataCollectionSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataCollectionSerializerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_Throws_ArgumentNull_MessageWriter()
         {
             // Arrange
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(provider);
 
             // Act & Assert
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             ODataMessageWriter messageWriter = ODataTestUtil.GetMockODataMessageWriter();
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(provider);
 
             // Act & Assert
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             settings.SetContentType(ODataFormat.Json);
 
             ODataMessageWriter messageWriter = new ODataMessageWriter(message, settings);
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             Mock<ODataCollectionSerializer> serializer = new Mock<ODataCollectionSerializer>(provider);
             ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "CollectionName", Model = EdmCoreModel.Instance };
             IEnumerable enumerable = new int[0];
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteCollectionAsync_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(provider);
 
             // Act & Assert
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataCollectionValue_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(provider);
 
             // Act & Assert
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             object nonEnumerable = new object();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             var serializer = new ODataCollectionSerializer(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns<IEdmTypeReference>(null);
 
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable enumerable = new[] { 0 };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             var serializer = new ODataCollectionSerializer(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns<IEdmTypeReference>(null);
 
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             ODataCollectionValue oDataCollectionValue = new ODataCollectionValue();
             var collection = new object[0];
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataCollectionSerializer> serializer = new Mock<ODataCollectionSerializer>(serializerProvider.Object);
             ODataSerializerContext writeContext = new ODataSerializerContext();
             serializer.CallBase = true;
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             ODataPrimitiveSerializer primitiveSerializer = new ODataPrimitiveSerializer();
             ODataSerializerContext writeContext = new ODataSerializerContext { Model = EdmCoreModel.Instance };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(primitiveSerializer);
 
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(serializerProvider.Object);
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             IEdmEnumTypeReference elementType = new EdmEnumTypeReference(new EdmEnumType("NS", "EnumType"), isNullable: true);
             edmEnumObject.Setup(s => s.GetEdmType()).Returns(elementType);
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataEnumSerializer> elementSerializer = new Mock<ODataEnumSerializer>(MockBehavior.Strict, serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(elementType)).Returns(elementSerializer.Object);
             elementSerializer.Setup(s => s.CreateODataEnumValue(collection[0], elementType, serializerContext)).Returns(new ODataEnumValue("1", "NS.EnumType")).Verifiable();
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataCollectionValue_Returns_EmptyODataCollectionValue_ForNull()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(serializerProvider.Object);
 
             // Act
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable enumerable = new int[] { 1, 2, 3 };
             ODataSerializerContext context = new ODataSerializerContext { Model = EdmCoreModel.Instance };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(new ODataPrimitiveSerializer());
             ODataCollectionSerializer serializer = new ODataCollectionSerializer(serializerProvider.Object);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataDeltaResourceSetSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataDeltaResourceSetSerializerTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_MessageWriter()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_WriteContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             object graph = new object();
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             object graph = new object();
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(provider.Object);
             serializer.CallBase = true;
             serializer
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsArgumentNull_Writer()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsArgumentNull_WriteContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsSerializationException_CannotSerializerNull()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsSerializationException_IfGraphIsNotEnumerable()
         {
             // Arrange
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act & Assert
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[] { null };
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(provider.Object);
 
             // Act
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_Throws_TypeCannotBeSerialized_IfFeedContainsEntityThatCannotBeSerialized()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             var request = RequestFactory.Create();
             serializerProvider.Setup(s => s.GetODataPayloadSerializer(typeof(int), request)).Returns<ODataSerializer>(null);
             IEnumerable instance = new object[] { 42 };
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[0];
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(provider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataDeltaResourceSet(instance, _customersType, _writeContext)).Returns(new ODataDeltaResourceSet()).Verifiable();
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[0];
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(provider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataDeltaResourceSet(instance, _customersType, _writeContext)).Returns<ODataDeltaResourceSet>(null);
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataDeltaResourceSet deltaResourceSet = new ODataDeltaResourceSet();
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(provider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataDeltaResourceSet(instance, _customersType, _writeContext)).Returns(deltaResourceSet);
@@ -297,11 +297,11 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 
             var mockWriter = new Mock<ODataWriter>();
 
-            Mock<ODataSerializerProvider> provider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> provider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> customerSerializer = new Mock<ODataResourceSerializer>(provider.Object);
             customerSerializer.Setup(s => s.WriteDeltaObjectInlineAsync(edmObject.Object, edmType, mockWriter.Object, _writeContext)).Verifiable();
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(edmType)).Returns(customerSerializer.Object);
 
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(serializerProvider.Object);
@@ -317,9 +317,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_WritesEachEntityInstance()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializeProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializeProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> customerSerializer = new Mock<ODataResourceSerializer>(serializeProvider.Object);
-            ODataSerializerProvider provider = ODataTestUtil.GetMockODataSerializerProvider(customerSerializer.Object);
+            IODataSerializerProvider provider = ODataTestUtil.GetMockODataSerializerProvider(customerSerializer.Object);
             var mockWriter = new Mock<ODataWriter>();
             customerSerializer.Setup(s => s.WriteDeltaObjectInlineAsync(_deltaResourceSetCustomers[0], _customersType.ElementType(), mockWriter.Object, _writeContext)).Verifiable();
             _serializer = new ODataDeltaResourceSetSerializer(provider);
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataDeltaResourceSet deltaResourceSet = new ODataDeltaResourceSet { NextPageLink = new Uri("http://nextlink.com/") };
-            Mock<ODataSerializerProvider> serializeProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializeProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(serializeProvider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataDeltaResourceSet(instance, _customersType, _writeContext)).Returns(deltaResourceSet);
@@ -366,7 +366,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataDeltaResourceSet deltaResourceSet = new ODataDeltaResourceSet { DeltaLink = new Uri("http://deltalink.com/") };
-            Mock<ODataSerializerProvider> serializeProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializeProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataDeltaResourceSetSerializer> serializer = new Mock<ODataDeltaResourceSetSerializer>(serializeProvider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataDeltaResourceSet(instance, _customersType, _writeContext)).Returns(deltaResourceSet);
@@ -393,7 +393,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataDeltaResourceSet_Sets_CountValueForPageResult()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializeProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializeProvider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(serializeProvider.Object);
             Uri expectedNextLink = new Uri("http://nextlink.com");
             const long ExpectedCountValue = 1000;
@@ -411,7 +411,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataDeltaResourceSet_Sets_NextPageLinkForPageResult()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializeProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializeProvider = new Mock<IODataSerializerProvider>();
             ODataDeltaResourceSetSerializer serializer = new ODataDeltaResourceSetSerializer(serializeProvider.Object);
             Uri expectedNextLink = new Uri("http://nextlink.com");
             const long ExpectedCountValue = 1000;

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEdmTypeSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEdmTypeSerializerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void Ctor_SetsProperty_SerializerProvider()
         {
             // Arrange & Act
-            ODataSerializerProvider serializerProvider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider serializerProvider = new Mock<IODataSerializerProvider>().Object;
             var serializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Unsupported, serializerProvider).Object;
 
             // Assert

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().Single();
 
             IServiceProvider serviceProvder = new Mock<IServiceProvider>().Object;
-            var provider = new DefaultODataSerializerProvider(serviceProvder);
+            var provider = new ODataSerializerProvider(serviceProvder);
             ODataEnumSerializer serializer = new ODataEnumSerializer(provider);
             ODataSerializerContext writeContext = new ODataSerializerContext
             {

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataEnumSerializer serializer = new ODataEnumSerializer(provider);
 
             // Act & Assert
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataValue_ThrowsInvalidOperation_NonEnumType()
         {
             // Arrange
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataEnumSerializer serializer = new ODataEnumSerializer(provider);
             IEdmTypeReference expectedType = EdmCoreModel.Instance.GetString(false);
 
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             ODataSerializerContext writeContext = new ODataSerializerContext();
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             ODataEnumSerializer serializer = new ODataEnumSerializer(provider);
             IEdmEnumType enumType = new EdmEnumType("NS", "Enum");
             IEdmTypeReference expectedType = new EdmEnumTypeReference(enumType, false);
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             ODataSerializerContext writeContext = new ODataSerializerContext();
-            ODataSerializerProvider provider = new Mock<ODataSerializerProvider>().Object;
+            IODataSerializerProvider provider = new Mock<IODataSerializerProvider>().Object;
             Mock<ODataEnumSerializer> serializer = new Mock<ODataEnumSerializer>(provider);
             ODataEnumValue enumValue = new ODataEnumValue("Cartoon");
             serializer.Setup(s => s.CreateODataEnumValue(null, It.IsAny<IEdmEnumTypeReference>(), writeContext)).Returns(enumValue);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -2226,7 +2226,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         private ODataResourceSerializer _serializer;
         private ODataSerializerContext _writeContext;
         private ResourceContext _entityContext;
-        private ODataSerializerProvider _serializerProvider;
+        private IODataSerializerProvider _serializerProvider;
         private IEdmEntityTypeReference _customerType;
         private IEdmEntityTypeReference _orderType;
         private IEdmEntityTypeReference _specialCustomerType;
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
                 ID = 20,
             };
 
-            _serializerProvider = GetServiceProvider().GetService<ODataSerializerProvider>();
+            _serializerProvider = GetServiceProvider().GetService<IODataSerializerProvider>();
             _customerType = _model.GetEdmTypeReference(typeof(Customer)).AsEntity();
             _orderType = _model.GetEdmTypeReference(typeof(Order)).AsEntity();
             _specialCustomerType = _model.GetEdmTypeReference(typeof(SpecialCustomer)).AsEntity();
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_MessageWriter()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Assert
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_WriteContext()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
             ODataMessageWriter messageWriter = new ODataMessageWriter(new Mock<IODataRequestMessage>().Object);
 
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_Calls_WriteObjectInline_WithRightEntityType()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializer
                 .Setup(s => s.WriteObjectInlineAsync(_customer, It.Is<IEdmTypeReference>(e => _customerType.Definition == e.Definition),
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsArgumentNull_Writer()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Assert
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsSerializationException_WhenGraphIsNull()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
             ODataWriter messageWriter = new Mock<ODataWriter>().Object;
 
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_Calls_CreateSelectExpandNode()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(new ODataPrimitiveSerializer());
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             ODataWriter writer = new Mock<ODataWriter>().Object;
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             ODataWriter writer = new Mock<ODataWriter>().Object;
 
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             ODataResource entry = new ODataResource();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             Mock<ODataWriter> writer = new Mock<ODataWriter>();
 
@@ -354,7 +354,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(ordersProperty.Type))
                 .Returns(innerSerializer.Object);
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
@@ -402,7 +402,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Mock<ODataEdmTypeSerializer> ordersSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
             ordersSerializer.Setup(s => s.WriteObjectInlineAsync(ordersValue, ordersProperty.Type, writer.Object, It.IsAny<ODataSerializerContext>())).Verifiable();
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(ordersProperty.Type)).Returns(ordersSerializer.Object);
 
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
@@ -450,7 +450,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
                     Assert.Null(feed.NextPageLink);
                 }).Returns(Task.CompletedTask).Verifiable();
             Mock<ODataEdmTypeSerializer> ordersSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(ordersProperty.Type)).Returns(ordersSerializer.Object);
 
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
@@ -491,7 +491,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 
             writer.Setup(w => w.WriteStartAsync(null as ODataResource)).Verifiable();
             Mock<ODataEdmTypeSerializer> ordersSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(customerProperty.Type))
                 .Returns(ordersSerializer.Object);
 
@@ -549,7 +549,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
                     Assert.Null(feed.NextPageLink);
                 }).Returns(Task.CompletedTask).Verifiable();
             Mock<ODataEdmTypeSerializer> ordersSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(specialOrdersProperty.Type))
                 .Returns(ordersSerializer.Object);
 
@@ -600,7 +600,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 
             writer.Setup(w => w.WriteStartAsync(null as ODataResource)).Verifiable();
             Mock<ODataEdmTypeSerializer> ordersSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(customerProperty.Type))
                 .Returns(ordersSerializer.Object);
 
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResource_ThrowsArgumentNull_SelectExpandNode()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -632,7 +632,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResource_ThrowsArgumentNull_EntityContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -1206,7 +1206,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateStructuralProperty_ThrowsArgumentNull_StructuralProperty()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -1219,7 +1219,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateStructuralProperty_ThrowsArgumentNull_EntityContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
             Mock<IEdmStructuralProperty> property = new Mock<IEdmStructuralProperty>();
 
@@ -1236,7 +1236,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Mock<IEdmTypeReference> propertyType = new Mock<IEdmTypeReference>();
             propertyType.Setup(t => t.Definition).Returns(new EdmEntityType("Namespace", "Name"));
             Mock<IEdmStructuralProperty> property = new Mock<IEdmStructuralProperty>();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>(MockBehavior.Strict);
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>(MockBehavior.Strict);
             IEdmEntityObject entity = new Mock<IEdmEntityObject>().Object;
             property.Setup(p => p.Type).Returns(propertyType.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(propertyType.Object)).Returns<ODataEdmTypeSerializer>(null);
@@ -1255,7 +1255,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             Mock<IEdmStructuralProperty> property = new Mock<IEdmStructuralProperty>();
             property.Setup(p => p.Name).Returns("PropertyName");
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>(MockBehavior.Strict);
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>(MockBehavior.Strict);
             var entity = new { PropertyName = 42 };
             Mock<ODataEdmTypeSerializer> innerSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Property);
             ODataValue propertyValue = new Mock<ODataValue>().Object;
@@ -1291,7 +1291,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateNavigationLink_ThrowsArgumentNull_NavigationProperty()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -1304,7 +1304,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateNavigationLink_ThrowsArgumentNull_EntityContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
             IEdmNavigationProperty navigationProperty = new Mock<IEdmNavigationProperty>().Object;
 
@@ -1357,7 +1357,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataAction_ThrowsArgumentNull_Action()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -1370,7 +1370,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataAction_ThrowsArgumentNull_EntityContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
             IEdmAction action = new Mock<IEdmAction>().Object;
 
@@ -1481,7 +1481,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateSelectExpandNode_ThrowsArgumentNull_EntityContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSerializer serializer = new ODataResourceSerializer(serializerProvider.Object);
 
             ExceptionAssert.ThrowsArgumentNull(
@@ -2001,7 +2001,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             ODataWriter mockWriter = new Mock<ODataWriter>().Object;
             IEdmNavigationProperty ordersProperty = _customerSet.EntityType().DeclaredNavigationProperties().Single();
             Mock<ODataEdmTypeSerializer> expandedItemSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.ResourceSet);
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(p => p.GetEdmTypeSerializer(ordersProperty.Type))
                 .Returns(expandedItemSerializer.Object);
 
@@ -2226,7 +2226,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<ODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
@@ -848,7 +848,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, ODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_MessageWriter()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Assert
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_ThrowsArgumentNull_WriteContext()
         {
             // Arrange & Act
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Assert
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             object graph = new object();//Enumerable.Empty<object>();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
             serializer.CallBase = true;
             serializer
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_CanWriteTopLevelResourceSetContainsNullComplexElement()
         {
             // Arrange
-            ODataSerializerProvider serializerProvider = GetServiceProvider().GetService<ODataSerializerProvider>();
+            IODataSerializerProvider serializerProvider = GetServiceProvider().GetService<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider);
             MemoryStream stream = new MemoryStream();
             IODataResponseMessageAsync message = new ODataMessageWrapper(stream);
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectAsync_CanWrite_TopLevelResourceSet_ContainsEmptyCollectionOfDynamicComplexElement()
         {
             // Arrange
-            ODataSerializerProvider serializerProvider = GetServiceProvider().GetService<ODataSerializerProvider>();
+            IODataSerializerProvider serializerProvider = GetServiceProvider().GetService<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider);
             MemoryStream stream = new MemoryStream();
             IODataResponseMessageAsync message = new ODataMessageWrapper(stream);
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsArgumentNull_Writer()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsArgumentNull_WriteContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsSerializationException_CannotSerializerNull()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_ThrowsSerializationException_IfGraphIsNotEnumerable()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[] { null };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[] { null };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public async Task WriteObjectInlineAsync_Throws_TypeCannotBeSerialized_IfResourceSetContainsEntityThatCannotBeSerialized()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             var request = RequestFactory.Create();
             serializerProvider.Setup(s => s.GetODataPayloadSerializer(typeof(int), request)).Returns<ODataSerializer>(null);
             IEnumerable instance = new object[] { 42 };
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[0];
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             IEnumerable instance = new object[0];
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateResourceSet(instance, _customersType, _writeContext)).Returns<ODataResourceSet>(null);
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataResourceSet resourceSet = new ODataResourceSet();
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
@@ -379,7 +379,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             Mock<ODataEdmTypeSerializer> customerSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
-            ODataSerializerProvider provider = ODataTestUtil.GetMockODataSerializerProvider(customerSerializer.Object);
+            IODataSerializerProvider provider = ODataTestUtil.GetMockODataSerializerProvider(customerSerializer.Object);
             var mockWriter = new Mock<ODataWriter>();
 
             customerSerializer.Setup(s => s.WriteObjectInlineAsync(_customers[0], _customersType.ElementType(), mockWriter.Object, _writeContext)).Verifiable();
@@ -408,7 +408,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Mock<ODataEdmTypeSerializer> customSerializer = new Mock<ODataEdmTypeSerializer>(ODataPayloadKind.Resource);
             customSerializer.Setup(s => s.WriteObjectInlineAsync(edmObject.Object, edmType, mockWriter.Object, _writeContext)).Verifiable();
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(edmType)).Returns(customSerializer.Object);
 
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
@@ -426,7 +426,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataResourceSet resourceSet = new ODataResourceSet { Count = 1000 };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
@@ -449,7 +449,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             // Arrange
             IEnumerable instance = new object[0];
             ODataResourceSet resourceSet = new ODataResourceSet { NextPageLink = new Uri("http://nextlink.com/") };
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             Mock<ODataResourceSerializer> resourceSerializer = new Mock<ODataResourceSerializer>(serializerProvider.Object);
             serializerProvider.Setup(s => s.GetEdmTypeSerializer(It.IsAny<IEdmTypeReference>())).Returns(resourceSerializer.Object);
             Mock<ODataResourceSetSerializer> serializer = new Mock<ODataResourceSetSerializer>(serializerProvider.Object);
@@ -478,7 +478,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResource_Sets_CountValueForPageResult()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             Uri expectedNextLink = new Uri("http://nextlink.com");
             const long ExpectedCountValue = 1000;
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResource_Sets_NextPageLinkForPageResult()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             Uri expectedNextLink = new Uri("http://nextlink.com");
             const long ExpectedCountValue = 1000;
@@ -514,7 +514,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResourceSet_Sets_CountValueFromContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             const long ExpectedCountValue = 1000;
             var request = RequestFactory.Create();
@@ -532,7 +532,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResourceSet_Sets_NextPageLinkFromContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             Uri expectedNextLink = new Uri("http://nextlink.com");
             var request = RequestFactory.Create();
@@ -550,7 +550,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataFeed_Sets_DeltaLinkFromContext()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             Uri expectedDeltaLink = new Uri("http://deltalink.com");
             var request = RequestFactory.Create();
@@ -568,7 +568,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResource_Ignores_NextPageLink_ForInnerResourceSets()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             Uri nextLink = new Uri("http://somelink");
             var request = RequestFactory.Create();
@@ -594,7 +594,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateResourceSet_Ignores_CountValue_ForInnerResourceSets()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             var request = RequestFactory.Create();
             request.ODataFeature().TotalCount = 42;
@@ -622,7 +622,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             IEdmModel model = GetEdmModelWithOperations(out IEdmEntityType customerType, out IEdmEntitySet customers);
             IEdmCollectionTypeReference customersType = new EdmCollectionTypeReference(new EdmCollectionType(customerType.AsReference()));
 
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             var request = RequestFactory.Create(method: "Get", uri: "http://IgnoreMetadataPath", opt => opt.AddModel(model));
 
@@ -707,7 +707,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void SetODataFeatureTotalCountValueNull()
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             var request = RequestFactory.Create();
             request.ODataFeature().TotalCount = null;
@@ -725,7 +725,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataOperation_ThrowsArgumentNull_ForInputParameters()
         {
             // Arrange & Act & Assert
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             // Act & Assert
@@ -746,7 +746,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         public void CreateODataOperation_OmitsOperations_WhenNonFullMetadata(ODataMetadataLevel metadataLevel)
         {
             // Arrange
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
 
             IEdmTypeReference returnType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
@@ -772,7 +772,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             // Arrange
             string expectedTarget = "aa://Target";
-            Mock<ODataSerializerProvider> serializerProvider = new Mock<ODataSerializerProvider>();
+            Mock<IODataSerializerProvider> serializerProvider = new Mock<IODataSerializerProvider>();
             ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(serializerProvider.Object);
             var builder = new ODataConventionModelBuilder();
             builder.EntitySet<FeedCustomer>("Customers");
@@ -848,7 +848,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         {
             IServiceCollection services = new ServiceCollection();
 
-            services.AddSingleton<ODataSerializerProvider, DefaultODataSerializerProvider>();
+            services.AddSingleton<IODataSerializerProvider, DefaultODataSerializerProvider>();
 
             // Serializers.
             services.AddSingleton<ODataEnumSerializer>();

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -794,7 +794,7 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider GetDeserializerProvider (Microsoft.AspNetCore.Http.HttpRequest request)
+	public static Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider GetDeserializerProvider (Microsoft.AspNetCore.Http.HttpRequest request)
 
 	[
 	ExtensionAttribute(),
@@ -1695,41 +1695,42 @@ public sealed class Microsoft.AspNetCore.OData.Routing.ODataRoutingMetadata : IO
 	Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate Template  { public virtual get; }
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer {
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public abstract get; }
+
+	System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider {
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer : IODataDeserializer {
+	object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
+}
+
+public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer : IODataDeserializer {
 	protected ODataDeserializer (Microsoft.OData.ODataPayloadKind payloadKind)
 
-	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public get; }
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public virtual get; }
 
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider {
-	protected ODataDeserializerProvider ()
-
-	public abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
-	public abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind)
-	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
-	Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider DeserializerProvider  { public get; }
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider DeserializerProvider  { public get; }
 
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider {
-	public DefaultODataDeserializerProvider (System.IServiceProvider serviceProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer {
+	public ODataActionPayloadDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
-	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
-	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
-	public ODataActionPayloadDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
-
-	Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider DeserializerProvider  { public get; }
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider DeserializerProvider  { public get; }
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1737,8 +1738,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPay
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataCollectionDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataCollectionDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1749,8 +1750,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectio
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataDeltaResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataDeltaResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1775,7 +1776,14 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeseriali
 	System.TimeZoneInfo TimeZone  { public get; public set; }
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider : IODataDeserializerProvider {
+	public ODataDeserializerProvider (System.IServiceProvider serviceProvider)
+
+	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
+	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer {
 	public ODataEntityReferenceLinkDeserializer ()
 
 	[
@@ -1784,7 +1792,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityRef
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	public ODataEnumDeserializer ()
 
 	[
@@ -1795,7 +1803,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeser
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	public ODataPrimitiveDeserializer ()
 
 	[
@@ -1807,8 +1815,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitive
 	public virtual object ReadPrimitive (Microsoft.OData.ODataProperty primitiveProperty, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataResourceDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataResourceDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	public virtual void ApplyDeletedResource (object resource, Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 	public virtual void ApplyNestedProperties (object resource, Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
@@ -1825,8 +1833,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceD
 	public virtual object ReadResource (Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1892,21 +1900,36 @@ public class Microsoft.AspNetCore.OData.Formatter.MediaType.QueryStringMediaType
 	public virtual double TryMatchMediaType (Microsoft.AspNetCore.Http.HttpRequest request)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
-	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
-	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer : IODataSerializer {
+	Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+	System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+}
 
-	Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider SerializerProvider  { public get; }
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer {
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public abstract get; }
+
+	System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider {
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
+	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
+
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider SerializerProvider  { public get; }
 
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
-	internal virtual Microsoft.OData.ODataProperty CreateProperty (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, string elementName, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer : IODataSerializer {
 	protected ODataSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
 
-	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public get; }
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public virtual get; }
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1914,27 +1937,12 @@ public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSe
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider {
-	protected ODataSerializerProvider ()
-
-	public abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
-	public abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider {
-	public DefaultODataSerializerProvider (System.IServiceProvider serviceProvider)
-
-	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
-	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataCollectionSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataCollectionSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	protected static void AddTypeNameAnnotationAsNeeded (Microsoft.OData.ODataCollectionValue value, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel)
 	public virtual Microsoft.OData.ODataCollectionValue CreateODataCollectionValue (System.Collections.IEnumerable enumerable, Microsoft.OData.Edm.IEdmTypeReference elementType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
-	internal virtual Microsoft.OData.ODataProperty CreateProperty (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, string elementName, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -1946,8 +1954,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionS
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataDeltaResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataDeltaResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataDeltaResourceSet CreateODataDeltaResourceSet (System.Collections.IEnumerable feedInstance, Microsoft.OData.Edm.IEdmCollectionTypeReference feedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	[
@@ -1976,7 +1984,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResour
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataEntityReferenceLinkSerializer ()
 
 	[
@@ -1985,7 +1993,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityRefer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataEntityReferenceLinksSerializer ()
 
 	[
@@ -1994,8 +2002,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityRefer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataEnumSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataEnumSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataEnumValue CreateODataEnumValue (object graph, Microsoft.OData.Edm.IEdmEnumTypeReference enumType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2005,7 +2013,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSeriali
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataErrorSerializer ()
 
 	[
@@ -2014,7 +2022,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerial
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataMetadataSerializer ()
 
 	[
@@ -2023,7 +2031,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
 	public ODataPrimitiveSerializer ()
 
 	public virtual Microsoft.OData.ODataPrimitiveValue CreateODataPrimitiveValue (object graph, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2034,7 +2042,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSe
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataRawValueSerializer ()
 
 	[
@@ -2043,8 +2051,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataResourceSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataResourceSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual void AppendDynamicProperties (Microsoft.OData.ODataResource resource, Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode selectExpandNode, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext)
 	public virtual string CreateETag (Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext)
@@ -2071,8 +2079,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSer
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataOperation CreateODataOperation (Microsoft.OData.Edm.IEdmOperation operation, Microsoft.AspNetCore.OData.Formatter.ResourceSetContext resourceSetContext, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataResourceSet CreateResourceSet (System.Collections.IEnumerable resourceSetInstance, Microsoft.OData.Edm.IEdmCollectionTypeReference resourceSetType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2108,7 +2116,14 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerC
 	System.TimeZoneInfo TimeZone  { public get; public set; }
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider : IODataSerializerProvider {
+	public ODataSerializerProvider (System.IServiceProvider serviceProvider)
+
+	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
+	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataServiceDocumentSerializer ()
 
 	[

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -794,7 +794,7 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider GetDeserializerProvider (Microsoft.AspNetCore.Http.HttpRequest request)
+	public static Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider GetDeserializerProvider (Microsoft.AspNetCore.Http.HttpRequest request)
 
 	[
 	ExtensionAttribute(),
@@ -1695,41 +1695,42 @@ public sealed class Microsoft.AspNetCore.OData.Routing.ODataRoutingMetadata : IO
 	Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate Template  { public virtual get; }
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer {
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public abstract get; }
+
+	System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider {
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer : IODataDeserializer {
+	object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
+}
+
+public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer : IODataDeserializer {
 	protected ODataDeserializer (Microsoft.OData.ODataPayloadKind payloadKind)
 
-	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public get; }
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public virtual get; }
 
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider {
-	protected ODataDeserializerProvider ()
-
-	public abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
-	public abstract Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public abstract class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind)
-	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+	protected ODataEdmTypeDeserializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
-	Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider DeserializerProvider  { public get; }
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider DeserializerProvider  { public get; }
 
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.DefaultODataDeserializerProvider : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider {
-	public DefaultODataDeserializerProvider (System.IServiceProvider serviceProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer {
+	public ODataActionPayloadDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
-	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
-	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPayloadDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
-	public ODataActionPayloadDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
-
-	Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider DeserializerProvider  { public get; }
+	Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider DeserializerProvider  { public get; }
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1737,8 +1738,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataActionPay
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataCollectionDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectionDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataCollectionDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1749,8 +1750,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataCollectio
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataDeltaResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeltaResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataDeltaResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1775,7 +1776,14 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeseriali
 	System.TimeZoneInfo TimeZone  { public get; public set; }
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider : IODataDeserializerProvider {
+	public ODataDeserializerProvider (System.IServiceProvider serviceProvider)
+
+	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataEdmTypeDeserializer GetEdmTypeDeserializer (Microsoft.OData.Edm.IEdmTypeReference edmType, params bool isDelta)
+	public virtual Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer GetODataDeserializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityReferenceLinkDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer, IODataDeserializer {
 	public ODataEntityReferenceLinkDeserializer ()
 
 	[
@@ -1784,7 +1792,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEntityRef
 	public virtual System.Threading.Tasks.Task`1[[System.Object]] ReadAsync (Microsoft.OData.ODataMessageReader messageReader, System.Type type, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	public ODataEnumDeserializer ()
 
 	[
@@ -1795,7 +1803,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeser
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
 	public ODataPrimitiveDeserializer ()
 
 	[
@@ -1807,8 +1815,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitive
 	public virtual object ReadPrimitive (Microsoft.OData.ODataProperty primitiveProperty, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataResourceDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataResourceDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	public virtual void ApplyDeletedResource (object resource, Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 	public virtual void ApplyNestedProperties (object resource, Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
@@ -1825,8 +1833,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceD
 	public virtual object ReadResource (Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper resourceWrapper, Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext readContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer {
-	public ODataResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerProvider deserializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataResourceSetDeserializer : Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEdmTypeDeserializer, IODataDeserializer, IODataEdmTypeDeserializer {
+	public ODataResourceSetDeserializer (Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializerProvider deserializerProvider)
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1892,21 +1900,36 @@ public class Microsoft.AspNetCore.OData.Formatter.MediaType.QueryStringMediaType
 	public virtual double TryMatchMediaType (Microsoft.AspNetCore.Http.HttpRequest request)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
-	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
-	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer : IODataSerializer {
+	Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+	System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+}
 
-	Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider SerializerProvider  { public get; }
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer {
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public abstract get; }
+
+	System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
+}
+
+public interface Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider {
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
+	protected ODataEdmTypeSerializer (Microsoft.OData.ODataPayloadKind payloadKind, Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
+
+	Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider SerializerProvider  { public get; }
 
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
-	internal virtual Microsoft.OData.ODataProperty CreateProperty (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, string elementName, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer : IODataSerializer {
 	protected ODataSerializer (Microsoft.OData.ODataPayloadKind payloadKind)
 
-	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public get; }
+	Microsoft.OData.ODataPayloadKind ODataPayloadKind  { public virtual get; }
 
 	[
 	AsyncStateMachineAttribute(),
@@ -1914,27 +1937,12 @@ public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSe
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public abstract class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider {
-	protected ODataSerializerProvider ()
-
-	public abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
-	public abstract Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.DefaultODataSerializerProvider : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider {
-	public DefaultODataSerializerProvider (System.IServiceProvider serviceProvider)
-
-	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
-	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
-}
-
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataCollectionSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataCollectionSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	protected static void AddTypeNameAnnotationAsNeeded (Microsoft.OData.ODataCollectionValue value, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel)
 	public virtual Microsoft.OData.ODataCollectionValue CreateODataCollectionValue (System.Collections.IEnumerable enumerable, Microsoft.OData.Edm.IEdmTypeReference elementType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
-	internal virtual Microsoft.OData.ODataProperty CreateProperty (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, string elementName, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -1946,8 +1954,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataCollectionS
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataDeltaResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataDeltaResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataDeltaResourceSet CreateODataDeltaResourceSet (System.Collections.IEnumerable feedInstance, Microsoft.OData.Edm.IEdmCollectionTypeReference feedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	[
@@ -1976,7 +1984,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataDeltaResour
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinkSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataEntityReferenceLinkSerializer ()
 
 	[
@@ -1985,7 +1993,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityRefer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityReferenceLinksSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataEntityReferenceLinksSerializer ()
 
 	[
@@ -1994,8 +2002,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEntityRefer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataEnumSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataEnumSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataEnumValue CreateODataEnumValue (object graph, Microsoft.OData.Edm.IEdmEnumTypeReference enumType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataValue CreateODataValue (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2005,7 +2013,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSeriali
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataErrorSerializer ()
 
 	[
@@ -2014,7 +2022,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerial
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataMetadataSerializer ()
 
 	[
@@ -2023,7 +2031,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataMetadataSer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
 	public ODataPrimitiveSerializer ()
 
 	public virtual Microsoft.OData.ODataPrimitiveValue CreateODataPrimitiveValue (object graph, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2034,7 +2042,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSe
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataRawValueSerializer ()
 
 	[
@@ -2043,8 +2051,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataRawValueSer
 	public virtual System.Threading.Tasks.Task WriteObjectAsync (object graph, System.Type type, Microsoft.OData.ODataMessageWriter messageWriter, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataResourceSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataResourceSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual void AppendDynamicProperties (Microsoft.OData.ODataResource resource, Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode selectExpandNode, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext)
 	public virtual string CreateETag (Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext)
@@ -2071,8 +2079,8 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSer
 	public virtual System.Threading.Tasks.Task WriteObjectInlineAsync (object graph, Microsoft.OData.Edm.IEdmTypeReference expectedType, Microsoft.OData.ODataWriter writer, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer {
-	public ODataResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider serializerProvider)
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerializer, IODataEdmTypeSerializer, IODataSerializer {
+	public ODataResourceSetSerializer (Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializerProvider serializerProvider)
 
 	public virtual Microsoft.OData.ODataOperation CreateODataOperation (Microsoft.OData.Edm.IEdmOperation operation, Microsoft.AspNetCore.OData.Formatter.ResourceSetContext resourceSetContext, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
 	public virtual Microsoft.OData.ODataResourceSet CreateResourceSet (System.Collections.IEnumerable resourceSetInstance, Microsoft.OData.Edm.IEdmCollectionTypeReference resourceSetType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext)
@@ -2108,7 +2116,14 @@ public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerC
 	System.TimeZoneInfo TimeZone  { public get; public set; }
 }
 
-public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer {
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerProvider : IODataSerializerProvider {
+	public ODataSerializerProvider (System.IServiceProvider serviceProvider)
+
+	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.IODataEdmTypeSerializer GetEdmTypeSerializer (Microsoft.OData.Edm.IEdmTypeReference edmType)
+	public virtual Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer GetODataPayloadSerializer (System.Type type, Microsoft.AspNetCore.Http.HttpRequest request)
+}
+
+public class Microsoft.AspNetCore.OData.Formatter.Serialization.ODataServiceDocumentSerializer : Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer, IODataSerializer {
 	public ODataServiceDocumentSerializer ()
 
 	[


### PR DESCRIPTION
- Create `IODataDeserializer` interface, (I kept the `ODataDeserializer` abstract class as well)
- Create `IODataEdmDeserializer` interface (also kept `ODataEdmDeserializer`)
- Create `IODataDeserializerProvider` interface and remove the `ODataDeserializerProvider` abstract class
- Rename `DefaultODataDeserializerProvider` to `ODataDeserializerProvider`
- Create `IODataSerializer` interface (I also kept the `ODataSerializer` abstract class)
- Create `IODataEdmTypeSerializer` interface (still kept the `ODataEdmTypeSerializer` abstract class)
- Move `ODataEdmTypeSerializer.CreateProperty` to an internal helper extension method `ODataSerializerPropertyHelper.CreateProperty`. Moving it to the interface would require it to be public and I didn't want to add it to the public API (it also complicated some of the tests that rely on mocking `CreateODataValue()`). I could also have kept it internal to the abstract class and not move it to the interface, but that would mean that `serializerProvider.GetEdmTypeSerializer()` would need to return the abstract class instead of the interface in order to work, which would make the interface useless. I figure moving it to a helper extension method would have less impact on the code that used the method and would still keep it internal. The downside is that the extensions contain the base implementation for `ODataEdmTypeSerializer` as well as the overridden implementation for `ODataCollectionSerializer` and uses an if statement with type matching to decide which implementation to call. Not sure if this a clean approach.
- Create `IODataSerializerProvider` interface and remove the `ODataSerializerProvider` abstract class
- Rename `DefaultODataSerializerProvider` to `ODataSerializerProvider`
- Updated public API files (.bsl)
- Updated PublicAPI.Unshipped.txt