### PR TITLE
DeltaOfT out of sync with WebAPI: missing UpdatableProperties

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1615,6 +1615,13 @@
         <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.ExpectedClrType">
             <inheritdoc/>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.UpdatableProperties">
+            <summary>
+            The list of property names that can be updated.
+            </summary>
+            <remarks>When the list is modified, any modified properties that were removed from the list are no longer
+            considered to be changed.</remarks>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.Clear">
             <inheritdoc/>
         </member>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -180,6 +180,7 @@ Microsoft.AspNetCore.OData.Deltas.Delta<T>.Delta(System.Type structuralType, Sys
 Microsoft.AspNetCore.OData.Deltas.Delta<T>.GetInstance() -> T
 Microsoft.AspNetCore.OData.Deltas.Delta<T>.Patch(T original) -> void
 Microsoft.AspNetCore.OData.Deltas.Delta<T>.Put(T original) -> void
+Microsoft.AspNetCore.OData.Deltas.Delta<T>.UpdatableProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource<T>
 Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource<T>.DeltaDeletedResource() -> void
 Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource<T>.DeltaDeletedResource(System.Type structuralType) -> void

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -488,6 +488,7 @@ public class Microsoft.AspNetCore.OData.Deltas.Delta`1 : Microsoft.AspNetCore.OD
 	System.Type ExpectedClrType  { public virtual get; }
 	Microsoft.AspNetCore.OData.Deltas.DeltaItemKind Kind  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
+	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (T original)

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -488,6 +488,7 @@ public class Microsoft.AspNetCore.OData.Deltas.Delta`1 : Microsoft.AspNetCore.OD
 	System.Type ExpectedClrType  { public virtual get; }
 	Microsoft.AspNetCore.OData.Deltas.DeltaItemKind Kind  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
+	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (T original)


### PR DESCRIPTION
Recent PR to WebAPI added the new `Delta<T>` property `UpdateableProperties`.

AspNetCoreOData should have a consistent API surface area with WebAPI.

Fix:

- Diff `DeltaOfT.cs` and `DeltaOfTStructuredType.cs` and apply all new src changes, fix new code warnings
- Diff `DeltaTest.cs` and apply all new test changes, fix new code warnings
- Full test runs and fix: xmldocs, PublicAPI files
