### PR TITLE
Redesign SelectExpandBinder to allow customizations

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
             // Binders.
             builder.AddService<ODataQuerySettings>(ServiceLifetime.Scoped);
             builder.AddService<FilterBinder>(ServiceLifetime.Transient);
-            builder.AddService<ISelectExpandBinder, SelectExpandBinder>(ServiceLifetime.Scoped);
+            builder.AddService<ISelectExpandBinder, SelectExpandBinder>(ServiceLifetime.Singleton);
 
             // HttpRequestScope.
             builder.AddService<HttpRequestScope>(ServiceLifetime.Scoped);

--- a/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ContainerBuilderExtensions.cs
@@ -100,6 +100,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
             // Binders.
             builder.AddService<ODataQuerySettings>(ServiceLifetime.Scoped);
             builder.AddService<FilterBinder>(ServiceLifetime.Transient);
+            builder.AddService<ISelectExpandBinder, SelectExpandBinder>(ServiceLifetime.Scoped);
 
             // HttpRequestScope.
             builder.AddService<HttpRequestScope>(ServiceLifetime.Scoped);

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8303,14 +8303,6 @@
             <param name="context">An instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/>.</param>
             <returns>The new <see cref="T:System.Object"/> after the select/expand query has been applied.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
-            <summary>
-            Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
-            an <see cref="T:System.Linq.Expressions.Expression"/>
-            </summary>
-            <param name="selectExpandQuery">The <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
-            <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
-        </member>
         <member name="F:Microsoft.AspNetCore.OData.Query.Expressions.Linq2ObjectsComparisonMethods.AreByteArraysEqualMethodInfo">
             <summary>Method info for byte array comparison.</summary>
         </member>
@@ -8351,7 +8343,12 @@
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
-            <inheritdoc/>
+            <summary>
+            Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
+            an <see cref="T:System.Linq.Expressions.Expression"/>
+            </summary>
+            <param name="selectExpandQuery">The <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+            <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetSelectExpandProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationSource,Microsoft.OData.UriParser.SelectExpandClause,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem}@,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem}@,System.Collections.Generic.ISet{Microsoft.OData.Edm.IEdmStructuralProperty}@)">
             <summary>
@@ -8429,11 +8426,6 @@
         <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.SelectExpandQuery">
             <summary>
             Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.
-            </summary>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext">
-            <summary>
-            Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.TransformationBinderBase.ResultClrType">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8292,7 +8292,7 @@
             </summary>
             <param name="source">The original <see cref="T:System.Linq.IQueryable"/>.</param>
             <param name="context">An instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/>.</param>
-            <returns>The new <see cref="T:System.Linq.IQueryable"/> after the select/expand query has been applied to.</returns>
+            <returns>The new <see cref="T:System.Linq.IQueryable"/> after the select/expand query has been applied.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Object,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <summary>
@@ -8301,7 +8301,7 @@
             </summary>
             <param name="source">The original <see cref="T:System.Object"/>.</param>
             <param name="context">An instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/>.</param>
-            <returns>The new <see cref="T:System.Object"/> after the select/expand query has been applied to.</returns>
+            <returns>The new <see cref="T:System.Object"/> after the select/expand query has been applied.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
             <summary>
@@ -8309,7 +8309,7 @@
             an <see cref="T:System.Linq.Expressions.Expression"/>
             </summary>
             <param name="selectExpandQuery">The <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
-            <returns>An <see cref="T:System.Linq.Expressions.Expression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
+            <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
         </member>
         <member name="F:Microsoft.AspNetCore.OData.Query.Expressions.Linq2ObjectsComparisonMethods.AreByteArraysEqualMethodInfo">
             <summary>Method info for byte array comparison.</summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8331,23 +8331,18 @@
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/> class.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.#ctor(Microsoft.AspNetCore.OData.Query.ODataQuerySettings,Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
-            <summary>
-            For testing purposes only.
-            </summary>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Object,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <inheritdoc/>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <summary>
             Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
             an <see cref="T:System.Linq.Expressions.Expression"/>
             </summary>
-            <param name="selectExpandQuery">The <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+            <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/> which is a wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
             <returns>A <see cref="T:System.Linq.Expressions.LambdaExpression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetSelectExpandProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationSource,Microsoft.OData.UriParser.SelectExpandClause,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem}@,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem}@,System.Collections.Generic.ISet{Microsoft.OData.Edm.IEdmStructuralProperty}@)">
@@ -8381,36 +8376,36 @@
             <param name="currentLevelPropertiesInclude">The current level properties included.</param>
             <returns>true if it's dynamic property selection, false if it's not.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildExpandedProperty(System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildExpandedProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the navigation property <see cref="T:Microsoft.OData.Edm.IEdmNavigationProperty"/> into the included properties.
             The property name is the navigation property name.
             The property value is the navigation property value from the source and applied the nested query options.
             </summary>
             <param name="source">The source contains the navigation property.</param>
-            <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
+            <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
             <param name="navigationProperty">The expanded navigation property.</param>
             <param name="expandedItem">The expanded navigation select item. It may contain the nested query options.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildSelectedProperty(System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildSelectedProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the structural property <see cref="T:Microsoft.OData.Edm.IEdmStructuralProperty"/> into the included properties.
             The property name is the structural property name.
             The property value is the structural property value from the source and applied the nested query options.
             </summary>
             <param name="source">The source contains the structural property.</param>
-            <param name="structuredType">The structured type or its derived type contains the structural property.</param>
+            <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
             <param name="structuralProperty">The selected structural property.</param>
             <param name="pathSelectItem">The selected item. It may contain the nested query options and could be null.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildDynamicProperty(System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildDynamicProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the dynamic properties into the included properties.
             </summary>
             <param name="source">The source contains the dynamic property.</param>
-            <param name="structuredType">The structured type contains the dynamic property.</param>
+            <param name="context">The wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext">
@@ -8768,7 +8763,6 @@
             Gets the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.
             </summary>
             <param name="context">The query context.</param>
-            <param name="querySettings">The query settings.</param>
             <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8334,6 +8334,11 @@
             Applies the given <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> to the given <see cref="T:System.Linq.IQueryable"/>.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/> class.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.#ctor(Microsoft.AspNetCore.OData.Query.ODataQuerySettings,Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
             <summary>
             For testing purposes only.
@@ -8766,7 +8771,7 @@
             <param name="querySettings">The query setting.</param>
             <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder"/>.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryContextExtensions.GetSelectExpandBinder(Microsoft.AspNetCore.OData.Query.ODataQueryContext,Microsoft.AspNetCore.OData.Query.ODataQuerySettings)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryContextExtensions.GetSelectExpandBinder(Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
             <summary>
             Gets the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.
             </summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8334,6 +8334,11 @@
             Applies the given <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> to the given <see cref="T:System.Linq.IQueryable"/>.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.#ctor(Microsoft.AspNetCore.OData.Query.ODataQuerySettings,Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
+            <summary>
+            For testing purposes only.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <inheritdoc/>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8279,6 +8279,38 @@
             <param name="node">The node to bind.</param>
             <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder">
+            <summary>
+            Exposes the ability to translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
+            an <see cref="T:System.Linq.Expressions.Expression"/> and applies it to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
+            <summary>
+            Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
+            an <see cref="T:System.Linq.Expressions.Expression"/> and applies it to an <see cref="T:System.Linq.IQueryable"/>.
+            </summary>
+            <param name="source">The original <see cref="T:System.Linq.IQueryable"/>.</param>
+            <param name="context">An instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/>.</param>
+            <returns>The new <see cref="T:System.Linq.IQueryable"/> after the select/expand query has been applied to.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Object,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
+            <summary>
+            Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
+            an <see cref="T:System.Linq.Expressions.Expression"/> and applies it to an <see cref="T:System.Object"/>.
+            </summary>
+            <param name="source">The original <see cref="T:System.Object"/>.</param>
+            <param name="context">An instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext"/>.</param>
+            <returns>The new <see cref="T:System.Object"/> after the select/expand query has been applied to.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
+            <summary>
+            Translate an OData $select or $expand parse tree represented by <see cref="T:Microsoft.OData.UriParser.SelectExpandClause"/> to
+            an <see cref="T:System.Linq.Expressions.Expression"/>
+            </summary>
+            <param name="selectExpandQuery">The <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+            <returns>An <see cref="T:System.Linq.Expressions.Expression"/> which can be later applied to an <see cref="T:System.Linq.IQueryable"/> or an <see cref="T:System.Object"/>.</returns>
+        </member>
         <member name="F:Microsoft.AspNetCore.OData.Query.Expressions.Linq2ObjectsComparisonMethods.AreByteArraysEqualMethodInfo">
             <summary>Method info for byte array comparison.</summary>
         </member>
@@ -8301,6 +8333,15 @@
             <summary>
             Applies the given <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> to the given <see cref="T:System.Linq.IQueryable"/>.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Object,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption)">
+            <inheritdoc/>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetSelectExpandProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationSource,Microsoft.OData.UriParser.SelectExpandClause,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem}@,System.Collections.Generic.IDictionary{Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem}@,System.Collections.Generic.ISet{Microsoft.OData.Edm.IEdmStructuralProperty}@)">
             <summary>
@@ -8364,6 +8405,26 @@
             <param name="source">The source contains the dynamic property.</param>
             <param name="structuredType">The structured type contains the dynamic property.</param>
             <param name="includedProperties">The container to hold the created property.</param>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext">
+            <summary>
+            Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QuerySettings">
+            <summary>
+            Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQuerySettings"/> that contains all the query application related settings.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.SelectExpandQuery">
+            <summary>
+            Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> which contains the $select and $expand query options.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext">
+            <summary>
+            Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information.
+            </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.Expressions.TransformationBinderBase.ResultClrType">
             <summary>
@@ -8699,6 +8760,14 @@
             <param name="context">The query context.</param>
             <param name="querySettings">The query setting.</param>
             <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryContextExtensions.GetSelectExpandBinder(Microsoft.AspNetCore.OData.Query.ODataQueryContext,Microsoft.AspNetCore.OData.Query.ODataQuerySettings)">
+            <summary>
+            Gets the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.
+            </summary>
+            <param name="context">The query context.</param>
+            <param name="querySettings">The query settings.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder"/>.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8326,11 +8326,6 @@
             Applies the given <see cref="T:Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption"/> to the given <see cref="T:System.Linq.IQueryable"/>.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.#ctor">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/> class.
-            </summary>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext)">
             <inheritdoc/>
         </member>
@@ -8384,6 +8379,7 @@
             </summary>
             <param name="source">The source contains the navigation property.</param>
             <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
             <param name="navigationProperty">The expanded navigation property.</param>
             <param name="expandedItem">The expanded navigation select item. It may contain the nested query options.</param>
             <param name="includedProperties">The container to hold the created property.</param>
@@ -8396,6 +8392,7 @@
             </summary>
             <param name="source">The source contains the structural property.</param>
             <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="structuredType">The structured type or its derived type contains the structural property.</param>
             <param name="structuralProperty">The selected structural property.</param>
             <param name="pathSelectItem">The selected item. It may contain the nested query options and could be null.</param>
             <param name="includedProperties">The container to hold the created property.</param>
@@ -8406,6 +8403,7 @@
             </summary>
             <param name="source">The source contains the dynamic property.</param>
             <param name="context">The wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="structuredType">The structured type contains the dynamic property.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8371,38 +8371,38 @@
             <param name="currentLevelPropertiesInclude">The current level properties included.</param>
             <returns>true if it's dynamic property selection, false if it's not.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildExpandedProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildExpandedProperty(Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.OData.UriParser.ExpandedReferenceSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the navigation property <see cref="T:Microsoft.OData.Edm.IEdmNavigationProperty"/> into the included properties.
             The property name is the navigation property name.
             The property value is the navigation property value from the source and applied the nested query options.
             </summary>
-            <param name="source">The source contains the navigation property.</param>
             <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="source">The source contains the navigation property.</param>
             <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
             <param name="navigationProperty">The expanded navigation property.</param>
             <param name="expandedItem">The expanded navigation select item. It may contain the nested query options.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildSelectedProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildSelectedProperty(Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the structural property <see cref="T:Microsoft.OData.Edm.IEdmStructuralProperty"/> into the included properties.
             The property name is the structural property name.
             The property value is the structural property value from the source and applied the nested query options.
             </summary>
-            <param name="source">The source contains the structural property.</param>
             <param name="context">Wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="source">The source contains the structural property.</param>
             <param name="structuredType">The structured type or its derived type contains the structural property.</param>
             <param name="structuralProperty">The selected structural property.</param>
             <param name="pathSelectItem">The selected item. It may contain the nested query options and could be null.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildDynamicProperty(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,Microsoft.OData.Edm.IEdmStructuredType,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.BuildDynamicProperty(Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext,System.Linq.Expressions.Expression,Microsoft.OData.Edm.IEdmStructuredType,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Query.Container.NamedPropertyExpression})">
             <summary>
             Build the dynamic properties into the included properties.
             </summary>
-            <param name="source">The source contains the dynamic property.</param>
             <param name="context">The wrapper for properties used by the <see cref="T:Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder"/>.</param>
+            <param name="source">The source contains the dynamic property.</param>
             <param name="structuredType">The structured type contains the dynamic property.</param>
             <param name="includedProperties">The container to hold the created property.</param>
         </member>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -836,7 +836,7 @@ Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.FilterBinder(System.IS
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
-Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.Expression
+Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.LambdaExpression
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.SelectExpandBinder() -> void
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext
@@ -1632,7 +1632,7 @@ virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindSingleReso
 virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode) -> System.Linq.Expressions.Expression
 virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
 virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
-virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.Expression
+virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.LambdaExpression
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings, Microsoft.AspNetCore.OData.Query.AllowedQueryOptions ignoreQueryOptions) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(System.Linq.IQueryable query) -> System.Linq.IQueryable

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -837,6 +837,8 @@ Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.Expression
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.SelectExpandBinder() -> void
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext.get -> Microsoft.AspNetCore.OData.Query.ODataQueryContext
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext.set -> void

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -833,6 +833,18 @@ Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase.GetDynamicProp
 Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase.GetFlattenedPropertyExpression(string propertyPath) -> System.Linq.Expressions.Expression
 Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder
 Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.FilterBinder(System.IServiceProvider requestContainer) -> void
+Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder
+Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
+Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
+Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.Expression
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext.get -> Microsoft.AspNetCore.OData.Query.ODataQueryContext
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QueryContext.set -> void
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QuerySettings.get -> Microsoft.AspNetCore.OData.Query.ODataQuerySettings
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.QuerySettings.set -> void
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.SelectExpandBinderContext() -> void
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.SelectExpandQuery.get -> Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption
+Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext.SelectExpandQuery.set -> void
 Microsoft.AspNetCore.OData.Query.FilterQueryOption
 Microsoft.AspNetCore.OData.Query.FilterQueryOption.ApplyTo(System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> System.Linq.IQueryable
 Microsoft.AspNetCore.OData.Query.FilterQueryOption.Context.get -> Microsoft.AspNetCore.OData.Query.ODataQueryContext
@@ -1616,6 +1628,9 @@ virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindSingleComp
 virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindSingleResourceCastNode(Microsoft.OData.UriParser.SingleResourceCastNode node) -> System.Linq.Expressions.Expression
 virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindSingleResourceFunctionCallNode(Microsoft.OData.UriParser.SingleResourceFunctionCallNode node) -> System.Linq.Expressions.Expression
 virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode) -> System.Linq.Expressions.Expression
+virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
+virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
+virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.Expression
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings, Microsoft.AspNetCore.OData.Query.AllowedQueryOptions ignoreQueryOptions) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(System.Linq.IQueryable query) -> System.Linq.IQueryable

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -836,7 +836,6 @@ Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.FilterBinder(System.IS
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
 Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
-Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.LambdaExpression
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.SelectExpandBinder() -> void
 Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1631,7 +1631,7 @@ virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindSingleReso
 virtual Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder.BindUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode) -> System.Linq.Expressions.Expression
 virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> object
 virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.Bind(System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.IQueryable
-virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery) -> System.Linq.Expressions.LambdaExpression
+virtual Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder.GetProjectionLambda(Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context) -> System.Linq.Expressions.LambdaExpression
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(object entity, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings, Microsoft.AspNetCore.OData.Query.AllowedQueryOptions ignoreQueryOptions) -> object
 virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ApplyTo(System.Linq.IQueryable query) -> System.Linq.IQueryable

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ISelectExpandBinder.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNetCore.OData.Query.Expressions
+{
+    /// <summary>
+    /// Exposes the ability to translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
+    /// an <see cref="Expression"/> and applies it to an <see cref="IQueryable"/> or an <see cref="object"/>.
+    /// </summary>
+    public interface ISelectExpandBinder
+    {
+        /// <summary>
+        /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
+        /// an <see cref="Expression"/> and applies it to an <see cref="IQueryable"/>.
+        /// </summary>
+        /// <param name="source">The original <see cref="IQueryable"/>.</param>
+        /// <param name="context">An instance of the <see cref="SelectExpandBinderContext"/>.</param>
+        /// <returns>The new <see cref="IQueryable"/> after the select/expand query has been applied to.</returns>
+        IQueryable Bind(IQueryable source, SelectExpandBinderContext context);
+
+        /// <summary>
+        /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
+        /// an <see cref="Expression"/> and applies it to an <see cref="object"/>.
+        /// </summary>
+        /// <param name="source">The original <see cref="object"/>.</param>
+        /// <param name="context">An instance of the <see cref="SelectExpandBinderContext"/>.</param>
+        /// <returns>The new <see cref="object"/> after the select/expand query has been applied to.</returns>
+        object Bind(object source, SelectExpandBinderContext context);
+
+        /// <summary>
+        /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
+        /// an <see cref="Expression"/>
+        /// </summary>
+        /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+        /// <returns>An <see cref="Expression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
+        Expression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
@@ -34,13 +34,5 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// <param name="context">An instance of the <see cref="SelectExpandBinderContext"/>.</param>
         /// <returns>The new <see cref="object"/> after the select/expand query has been applied.</returns>
         object Bind(object source, SelectExpandBinderContext context);
-
-        /// <summary>
-        /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
-        /// an <see cref="Expression"/>
-        /// </summary>
-        /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
-        /// <returns>A <see cref="LambdaExpression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
-        LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="source">The original <see cref="IQueryable"/>.</param>
         /// <param name="context">An instance of the <see cref="SelectExpandBinderContext"/>.</param>
-        /// <returns>The new <see cref="IQueryable"/> after the select/expand query has been applied to.</returns>
+        /// <returns>The new <see cref="IQueryable"/> after the select/expand query has been applied.</returns>
         IQueryable Bind(IQueryable source, SelectExpandBinderContext context);
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="source">The original <see cref="object"/>.</param>
         /// <param name="context">An instance of the <see cref="SelectExpandBinderContext"/>.</param>
-        /// <returns>The new <see cref="object"/> after the select/expand query has been applied to.</returns>
+        /// <returns>The new <see cref="object"/> after the select/expand query has been applied.</returns>
         object Bind(object source, SelectExpandBinderContext context);
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ISelectExpandBinder.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// an <see cref="Expression"/>
         /// </summary>
         /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
-        /// <returns>An <see cref="Expression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
-        Expression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery);
+        /// <returns>A <see cref="LambdaExpression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
+        LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         }
 
         /// <inheritdoc/>
-        public virtual Expression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery)
+        public virtual LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery)
         {
             Contract.Assert(selectExpandQuery != null);
             Type elementType = selectExpandQuery.Context.ElementClrType;
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         private object Bind(object entity, SelectExpandQueryOption selectExpandQuery)
         {
             // Needn't to verify the input, that's done at upper level.
-            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery) as LambdaExpression;
+            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
 
             // TODO: cache this ?
             return projectionLambda.Compile().DynamicInvoke(entity);
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             // Needn't to verify the input, that's done at upper level.
             Type elementType = selectExpandQuery.Context.ElementClrType;
 
-            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery) as LambdaExpression;
+            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
 
             MethodInfo selectMethod = ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(elementType, projectionLambda.Body.Type);
             return selectMethod.Invoke(null, new object[] { queryable, projectionLambda }) as IQueryable;

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="context">The <see cref="SelectExpandBinderContext"/> which is a wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
         /// <returns>A <see cref="LambdaExpression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
-        public virtual LambdaExpression GetProjectionLambda(SelectExpandBinderContext context)
+        protected virtual LambdaExpression GetProjectionLambda(SelectExpandBinderContext context)
         {
             Contract.Assert(context != null);
             Type elementType = context.SelectExpandQuery.Context.ElementClrType;
@@ -332,7 +332,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 if (propertiesToExpand != null || propertiesToInclude != null || autoSelectedProperties != null || isSelectingOpenTypeSegments)
                 {
                     Expression propertyContainerCreation =
-                        BuildPropertyContainer(source, context, structuredType, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
+                        BuildPropertyContainer(context, source, structuredType, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
 
                     if (propertyContainerCreation != null)
                     {
@@ -625,7 +625,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             }
         }
 
-        private Expression BuildPropertyContainer(Expression source, SelectExpandBinderContext context,
+        private Expression BuildPropertyContainer(SelectExpandBinderContext context, Expression source,
             IEdmStructuredType structuredType,
             IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand,
             IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude,

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -33,7 +33,13 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         private IEdmModel _model;
         private ODataQuerySettings _settings;
 
-        public SelectExpandBinder(ODataQuerySettings settings, ODataQueryContext context)
+        public SelectExpandBinder() {  }
+
+        /// <summary>
+        /// For testing purposes only.
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        internal SelectExpandBinder(ODataQuerySettings settings, ODataQueryContext context)
         {
             Contract.Assert(settings != null);
             Contract.Assert(context != null);
@@ -51,6 +57,14 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(source != null);
             Contract.Assert(context != null);
             Contract.Assert(context.SelectExpandQuery != null);
+            Contract.Assert(context.QueryContext != null);
+            Contract.Assert(context.QueryContext.Model != null);
+            Contract.Assert(context.QuerySettings != null);
+            Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
+
+            _context = context.QueryContext;
+            _model = _context.Model;
+            _settings = context.QuerySettings;
 
             return Bind(source, context.SelectExpandQuery);
         }
@@ -61,6 +75,14 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(source != null);
             Contract.Assert(context != null);
             Contract.Assert(context.SelectExpandQuery != null);
+            Contract.Assert(context.QueryContext != null);
+            Contract.Assert(context.QueryContext.Model != null);
+            Contract.Assert(context.QuerySettings != null);
+            Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
+
+            _context = context.QueryContext;
+            _model = _context.Model;
+            _settings = context.QuerySettings;
 
             return Bind(source, context.SelectExpandQuery);
         }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -60,12 +60,12 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(source != null);
             Contract.Assert(context != null);
             Contract.Assert(context.SelectExpandQuery != null);
-            Contract.Assert(context.QueryContext != null);
-            Contract.Assert(context.QueryContext.Model != null);
+            Contract.Assert(context.SelectExpandQuery.Context != null);
+            Contract.Assert(context.SelectExpandQuery.Context.Model != null);
             Contract.Assert(context.QuerySettings != null);
             Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
 
-            _context = context.QueryContext;
+            _context = context.SelectExpandQuery.Context;
             _model = _context.Model;
             _settings = context.QuerySettings;
 
@@ -78,19 +78,24 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(source != null);
             Contract.Assert(context != null);
             Contract.Assert(context.SelectExpandQuery != null);
-            Contract.Assert(context.QueryContext != null);
-            Contract.Assert(context.QueryContext.Model != null);
+            Contract.Assert(context.SelectExpandQuery.Context != null);
+            Contract.Assert(context.SelectExpandQuery.Context.Model != null);
             Contract.Assert(context.QuerySettings != null);
             Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
 
-            _context = context.QueryContext;
+            _context = context.SelectExpandQuery.Context;
             _model = _context.Model;
             _settings = context.QuerySettings;
 
             return Bind(source, context.SelectExpandQuery);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
+        /// an <see cref="Expression"/>
+        /// </summary>
+        /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+        /// <returns>A <see cref="LambdaExpression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
         public virtual LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery)
         {
             Contract.Assert(selectExpandQuery != null);

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -29,31 +29,6 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Class coupling acceptable.")]
     public class SelectExpandBinder : ISelectExpandBinder
     {
-        private ODataQueryContext _context;
-        private IEdmModel _model;
-        private ODataQuerySettings _settings;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SelectExpandBinder"/> class.
-        /// </summary>
-        public SelectExpandBinder() {  }
-
-        /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [ExcludeFromCodeCoverage]
-        internal SelectExpandBinder(ODataQuerySettings settings, ODataQueryContext context)
-        {
-            Contract.Assert(settings != null);
-            Contract.Assert(context != null);
-            Contract.Assert(context.Model != null);
-            Contract.Assert(settings.HandleNullPropagation != HandleNullPropagationOption.Default);
-
-            _context = context;
-            _model = _context.Model;
-            _settings = settings;
-        }
-
         /// <inheritdoc/>
         public virtual IQueryable Bind(IQueryable source, SelectExpandBinderContext context)
         {
@@ -65,11 +40,12 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(context.QuerySettings != null);
             Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
 
-            _context = context.SelectExpandQuery.Context;
-            _model = _context.Model;
-            _settings = context.QuerySettings;
+            Type elementType = context.SelectExpandQuery.Context.ElementClrType;
 
-            return Bind(source, context.SelectExpandQuery);
+            LambdaExpression projectionLambda = GetProjectionLambda(context);
+
+            MethodInfo selectMethod = ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(elementType, projectionLambda.Body.Type);
+            return selectMethod.Invoke(null, new object[] { source, projectionLambda }) as IQueryable;
         }
 
         /// <inheritdoc/>
@@ -83,28 +59,29 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Contract.Assert(context.QuerySettings != null);
             Contract.Assert(context.QuerySettings.HandleNullPropagation != HandleNullPropagationOption.Default);
 
-            _context = context.SelectExpandQuery.Context;
-            _model = _context.Model;
-            _settings = context.QuerySettings;
+            LambdaExpression projectionLambda = GetProjectionLambda(context);
 
-            return Bind(source, context.SelectExpandQuery);
+            // TODO: cache this ?
+            return projectionLambda.Compile().DynamicInvoke(source);
         }
 
         /// <summary>
         /// Translate an OData $select or $expand parse tree represented by <see cref="SelectExpandClause"/> to
         /// an <see cref="Expression"/>
         /// </summary>
-        /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.</param>
+        /// <param name="context">The <see cref="SelectExpandBinderContext"/> which is a wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
         /// <returns>A <see cref="LambdaExpression"/> which can be later applied to an <see cref="IQueryable"/> or an <see cref="object"/>.</returns>
-        public virtual LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery)
+        public virtual LambdaExpression GetProjectionLambda(SelectExpandBinderContext context)
         {
-            Contract.Assert(selectExpandQuery != null);
-            Type elementType = selectExpandQuery.Context.ElementClrType;
-            IEdmNavigationSource navigationSource = selectExpandQuery.Context.NavigationSource;
+            Contract.Assert(context != null);
+            Type elementType = context.SelectExpandQuery.Context.ElementClrType;
+            IEdmStructuredType structuredType = context.SelectExpandQuery.Context.ElementType as IEdmStructuredType;
+            IEdmNavigationSource navigationSource = context.SelectExpandQuery.Context.NavigationSource;
+            SelectExpandClause selectExpandClause = context.SelectExpandQuery.SelectExpandClause;
             ParameterExpression source = Expression.Parameter(elementType, "$it");
 
             // expression looks like -> new Wrapper { Instance = source , Properties = "...", Container = new PropertyContainer { ... } }
-            Expression projectionExpression = ProjectElement(source, selectExpandQuery.SelectExpandClause, selectExpandQuery.Context.ElementType as IEdmStructuredType, navigationSource);
+            Expression projectionExpression = ProjectElement(source, context, selectExpandClause, structuredType, navigationSource);
 
             // expression looks like -> source => new Wrapper { Instance = source .... }
             LambdaExpression projectionLambdaExpression = Expression.Lambda(projectionExpression, source);
@@ -112,27 +89,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             return projectionLambdaExpression;
         }
 
-        private object Bind(object entity, SelectExpandQueryOption selectExpandQuery)
-        {
-            // Needn't to verify the input, that's done at upper level.
-            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
-
-            // TODO: cache this ?
-            return projectionLambda.Compile().DynamicInvoke(entity);
-        }
-
-        private IQueryable Bind(IQueryable queryable, SelectExpandQueryOption selectExpandQuery)
-        {
-            // Needn't to verify the input, that's done at upper level.
-            Type elementType = selectExpandQuery.Context.ElementClrType;
-
-            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
-
-            MethodInfo selectMethod = ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(elementType, projectionLambda.Body.Type);
-            return selectMethod.Invoke(null, new object[] { queryable, projectionLambda }) as IQueryable;
-        }
-
-        internal Expression ProjectAsWrapper(Expression source, SelectExpandClause selectExpandClause,
+        internal Expression ProjectAsWrapper(SelectExpandBinderContext context, Expression source, SelectExpandClause selectExpandClause,
             IEdmStructuredType structuredType, IEdmNavigationSource navigationSource, OrderByClause orderByClause = null,
             long? topOption = null,
             long? skipOption = null,
@@ -142,7 +99,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             if (TypeHelper.IsCollection(source.Type, out elementType))
             {
                 // new CollectionWrapper<ElementType> { Instance = source.Select(s => new Wrapper { ... }) };
-                return ProjectCollection(source, elementType, selectExpandClause, structuredType, navigationSource, orderByClause,
+                return ProjectCollection(context, source, elementType, selectExpandClause, structuredType, navigationSource, orderByClause,
                     topOption,
                     skipOption,
                     modelBoundPageSize);
@@ -150,23 +107,24 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             else
             {
                 // new Wrapper { v1 = source.property ... }
-                return ProjectElement(source, selectExpandClause, structuredType, navigationSource);
+                return ProjectElement(source, context, selectExpandClause, structuredType, navigationSource);
             }
         }
 
-        internal Expression CreatePropertyNameExpression(IEdmStructuredType elementType, IEdmProperty property, Expression source)
+        internal Expression CreatePropertyNameExpression(SelectExpandBinderContext context, IEdmStructuredType elementType, IEdmProperty property, Expression source)
         {
             Contract.Assert(elementType != null);
             Contract.Assert(property != null);
             Contract.Assert(source != null);
 
             IEdmStructuredType declaringType = property.DeclaringType;
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
 
             // derived property using cast
             if (elementType != declaringType)
             {
-                Type originalType = _model.GetClrType(elementType);
-                Type castType = _model.GetClrType(declaringType);
+                Type originalType = model.GetClrType(elementType);
+                Type castType = model.GetClrType(declaringType);
                 if (castType == null)
                 {
                     throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType, declaringType.FullTypeName()));
@@ -188,16 +146,20 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             return Expression.Constant(property.Name);
         }
 
-        internal Expression CreatePropertyValueExpression(IEdmStructuredType elementType, IEdmProperty property, Expression source, FilterClause filterClause)
+        internal Expression CreatePropertyValueExpression(SelectExpandBinderContext context, IEdmStructuredType elementType, IEdmProperty property, Expression source, FilterClause filterClause)
         {
             Contract.Assert(elementType != null);
             Contract.Assert(property != null);
             Contract.Assert(source != null);
 
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
+            ODataQueryContext queryContext = context.SelectExpandQuery.Context;
+            ODataQuerySettings settings = context.QuerySettings;
+
             // Expression: source = source as propertyDeclaringType
             if (elementType != property.DeclaringType)
             {
-                Type castType = _model.GetClrType(property.DeclaringType);
+                Type castType = model.GetClrType(property.DeclaringType);
                 if (castType == null)
                 {
                     throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType, property.DeclaringType.FullTypeName()));
@@ -207,7 +169,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             }
 
             // Expression:  source.Property
-            string propertyName = _model.GetClrPropertyName(property);
+            string propertyName = model.GetClrPropertyName(property);
             
             PropertyInfo propertyInfo = source.Type.GetProperty(propertyName, BindingFlags.DeclaredOnly);
             if (propertyInfo == null)
@@ -224,7 +186,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 bool isCollection = property.Type.IsCollection();
 
                 IEdmTypeReference edmElementType = (isCollection ? property.Type.AsCollection().ElementType() : property.Type);
-                Type clrElementType = _model.GetClrType(edmElementType);
+                Type clrElementType = model.GetClrType(edmElementType);
                 if (clrElementType == null)
                 {
                     throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType, edmElementType.FullName()));
@@ -242,7 +204,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                     Expression filterSource = nullablePropertyValue;
 
                     // TODO: Implement proper support for $select/$expand after $apply
-                    Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context, querySettings);
+                    Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, queryContext, querySettings);
                     filterResult = Expression.Call(
                         ExpressionHelperMethods.EnumerableWhereGeneric.MakeGenericMethod(clrElementType),
                         filterSource,
@@ -250,9 +212,9 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
                     nullablePropertyType = filterResult.Type;
                 }
-                else if (_settings.HandleReferenceNavigationPropertyExpandFilter)
+                else if (settings.HandleReferenceNavigationPropertyExpandFilter)
                 {
-                    LambdaExpression filterLambdaExpression = FilterBinder.Bind(null, filterClause, clrElementType, _context, querySettings) as LambdaExpression;
+                    LambdaExpression filterLambdaExpression = FilterBinder.Bind(null, filterClause, clrElementType, queryContext, querySettings) as LambdaExpression;
                     if (filterLambdaExpression == null)
                     {
                         throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionNotLambdaExpression, property.Name, "LambdaExpression"));
@@ -268,7 +230,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                         ifFalse: Expression.Constant(value: null, type: nullablePropertyType));
                 }
 
-                if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                if (settings.HandleNullPropagation == HandleNullPropagationOption.True)
                 {
                     // create expression similar to: 'nullablePropertyValue == null ? null : filterResult'
                     nullablePropertyValue = Expression.Condition(
@@ -282,7 +244,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 }
             }
 
-            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+            if (settings.HandleNullPropagation == HandleNullPropagationOption.True)
             {
                 // create expression similar to: 'source == null ? null : propertyValue'
                 propertyValue = Expression.Condition(
@@ -301,9 +263,11 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
         // Generates the expression
         //      source => new Wrapper { Instance = source, Container = new PropertyContainer { ..expanded properties.. } }
-        internal Expression ProjectElement(Expression source, SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource)
+        internal Expression ProjectElement(Expression source, SelectExpandBinderContext context, SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource)
         {
             Contract.Assert(source != null);
+
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
 
             // If it's not a structural type, just return the source.
             if (structuredType == null)
@@ -325,7 +289,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             // source = new Wrapper { Model = parameterized(a-edm-model) }
             // Always parameterize as EntityFramework does not let you inject non primitive constant values (like IEdmModel).
             wrapperProperty = wrapperType.GetProperty("Model");
-            wrapperPropertyValueExpression = LinqParameterContainer.Parameterize(typeof(IEdmModel), _model);
+            wrapperPropertyValueExpression = LinqParameterContainer.Parameterize(typeof(IEdmModel), model);
             wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, wrapperPropertyValueExpression));
 
             if (IsSelectAll(selectExpandClause))
@@ -341,7 +305,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             else
             {
                 // Initialize property 'TypeName' on the wrapper class as we don't have the instance.
-                Expression typeName = CreateTypeNameExpression(source, structuredType, _model);
+                Expression typeName = CreateTypeNameExpression(source, structuredType, model);
                 if (typeName != null)
                 {
                     isTypeNamePropertySet = true;
@@ -358,7 +322,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
                 ISet<IEdmStructuralProperty> autoSelectedProperties;
 
-                bool isContainDynamicPropertySelection = GetSelectExpandProperties(_model, structuredType, navigationSource, selectExpandClause,
+                bool isContainDynamicPropertySelection = GetSelectExpandProperties(model, structuredType, navigationSource, selectExpandClause,
                     out propertiesToInclude,
                     out propertiesToExpand,
                     out autoSelectedProperties);
@@ -368,7 +332,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 if (propertiesToExpand != null || propertiesToInclude != null || autoSelectedProperties != null || isSelectingOpenTypeSegments)
                 {
                     Expression propertyContainerCreation =
-                        BuildPropertyContainer(source, structuredType, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
+                        BuildPropertyContainer(source, context, structuredType, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
 
                     if (propertyContainerCreation != null)
                     {
@@ -620,7 +584,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             return false;
         }
 
-        private Expression CreateTotalCountExpression(Expression source, bool? countOption)
+        private Expression CreateTotalCountExpression(SelectExpandBinderContext context, Expression source, bool? countOption)
         {
             Expression countExpression = Expression.Constant(null, typeof(long?));
             if (countOption == null || !countOption.Value)
@@ -647,7 +611,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             // call Count() method.
             countExpression = Expression.Call(null, countMethod, new[] { source });
 
-            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+            if (context.QuerySettings.HandleNullPropagation == HandleNullPropagationOption.True)
             {
                 // source == null ? null : countExpression
                 return Expression.Condition(
@@ -661,7 +625,8 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             }
         }
 
-        private Expression BuildPropertyContainer(Expression source, IEdmStructuredType structuredType,
+        private Expression BuildPropertyContainer(Expression source, SelectExpandBinderContext context,
+            IEdmStructuredType structuredType,
             IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand,
             IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude,
             ISet<IEdmStructuralProperty> autoSelectedProperties,
@@ -674,7 +639,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 foreach (var propertyToExpand in propertiesToExpand)
                 {
                     // $expand=abc or $expand=abc/$ref
-                    BuildExpandedProperty(source, structuredType, propertyToExpand.Key, propertyToExpand.Value, includedProperties);
+                    BuildExpandedProperty(source, context, structuredType, propertyToExpand.Key, propertyToExpand.Value, includedProperties);
                 }
             }
 
@@ -683,7 +648,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 foreach (var propertyToInclude in propertiesToInclude)
                 {
                     // $select=abc($select=...,$filter=...,$compute=...)....
-                    BuildSelectedProperty(source, structuredType, propertyToInclude.Key, propertyToInclude.Value, includedProperties);
+                    BuildSelectedProperty(source, context, structuredType, propertyToInclude.Key, propertyToInclude.Value, includedProperties);
                 }
             }
 
@@ -691,8 +656,8 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             {
                 foreach (IEdmStructuralProperty propertyToInclude in autoSelectedProperties)
                 {
-                    Expression propertyName = CreatePropertyNameExpression(structuredType, propertyToInclude, source);
-                    Expression propertyValue = CreatePropertyValueExpression(structuredType, propertyToInclude, source, filterClause: null);
+                    Expression propertyName = CreatePropertyNameExpression(context, structuredType, propertyToInclude, source);
+                    Expression propertyValue = CreatePropertyValueExpression(context, structuredType, propertyToInclude, source, filterClause: null);
                     includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue)
                     {
                         AutoSelected = true
@@ -702,7 +667,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             if (isSelectingOpenTypeSegments)
             {
-                BuildDynamicProperty(source, structuredType, includedProperties);
+                BuildDynamicProperty(source, context, structuredType, includedProperties);
             }
 
             // create a property container that holds all these property names and values.
@@ -715,44 +680,47 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// The property value is the navigation property value from the source and applied the nested query options.
         /// </summary>
         /// <param name="source">The source contains the navigation property.</param>
-        /// <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
+        /// <param name="context">Wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
         /// <param name="navigationProperty">The expanded navigation property.</param>
         /// <param name="expandedItem">The expanded navigation select item. It may contain the nested query options.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
-        internal void BuildExpandedProperty(Expression source, IEdmStructuredType structuredType,
+        internal void BuildExpandedProperty(Expression source, SelectExpandBinderContext context, IEdmStructuredType structuredType,
             IEdmNavigationProperty navigationProperty, ExpandedReferenceSelectItem expandedItem,
             IList<NamedPropertyExpression> includedProperties)
         {
             Contract.Assert(source != null);
+            Contract.Assert(context != null);
             Contract.Assert(structuredType != null);
             Contract.Assert(navigationProperty != null);
             Contract.Assert(expandedItem != null);
             Contract.Assert(includedProperties != null);
 
             IEdmEntityType edmEntityType = navigationProperty.ToEntityType();
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
+            ODataQuerySettings settings = context.QuerySettings;
 
-            ModelBoundQuerySettings querySettings = EdmHelpers.GetModelBoundQuerySettings(navigationProperty, edmEntityType, _model);
+            ModelBoundQuerySettings querySettings = EdmHelpers.GetModelBoundQuerySettings(navigationProperty, edmEntityType, model);
 
             // TODO: Process $apply and $compute in the $expand here, will support later.
             // $apply=...; $compute=...
 
             // Expression:
             //       "navigation property name"
-            Expression propertyName = CreatePropertyNameExpression(structuredType, navigationProperty, source);
+            Expression propertyName = CreatePropertyNameExpression(context, structuredType, navigationProperty, source);
 
             // Expression:
             //        source.NavigationProperty
-            Expression propertyValue = CreatePropertyValueExpression(structuredType, navigationProperty, source, expandedItem.FilterOption);
+            Expression propertyValue = CreatePropertyValueExpression(context, structuredType, navigationProperty, source, expandedItem.FilterOption);
 
             // Sub select and expand could be null if the expanded navigation property is not further projected or expanded.
             SelectExpandClause subSelectExpandClause = GetOrCreateSelectExpandClause(navigationProperty, expandedItem);
 
-            Expression nullCheck = GetNullCheckExpression(navigationProperty, propertyValue, subSelectExpandClause);
+            Expression nullCheck = GetNullCheckExpression(context, navigationProperty, propertyValue, subSelectExpandClause);
 
-            Expression countExpression = CreateTotalCountExpression(propertyValue, expandedItem.CountOption);
+            Expression countExpression = CreateTotalCountExpression(context, propertyValue, expandedItem.CountOption);
 
             int? modelBoundPageSize = querySettings == null ? null : querySettings.PageSize;
-            propertyValue = ProjectAsWrapper(propertyValue, subSelectExpandClause, edmEntityType, expandedItem.NavigationSource,
+            propertyValue = ProjectAsWrapper(context, propertyValue, subSelectExpandClause, edmEntityType, expandedItem.NavigationSource,
                 expandedItem.OrderByOption, // $orderby=...
                 expandedItem.TopOption, // $top=...
                 expandedItem.SkipOption, // $skip=...
@@ -765,9 +733,9 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 {
                     propertyExpression.NullCheck = nullCheck;
                 }
-                else if (_settings.PageSize.HasValue)
+                else if (settings.PageSize.HasValue)
                 {
-                    propertyExpression.PageSize = _settings.PageSize.Value;
+                    propertyExpression.PageSize = settings.PageSize.Value;
                 }
                 else
                 {
@@ -790,29 +758,33 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// The property value is the structural property value from the source and applied the nested query options.
         /// </summary>
         /// <param name="source">The source contains the structural property.</param>
-        /// <param name="structuredType">The structured type or its derived type contains the structural property.</param>
+        /// <param name="context">Wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
         /// <param name="structuralProperty">The selected structural property.</param>
         /// <param name="pathSelectItem">The selected item. It may contain the nested query options and could be null.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
-        internal void BuildSelectedProperty(Expression source, IEdmStructuredType structuredType,
+        internal void BuildSelectedProperty(Expression source, SelectExpandBinderContext context, IEdmStructuredType structuredType,
             IEdmStructuralProperty structuralProperty, PathSelectItem pathSelectItem,
             IList<NamedPropertyExpression> includedProperties)
         {
             Contract.Assert(source != null);
+            Contract.Assert(context != null);
             Contract.Assert(structuredType != null);
             Contract.Assert(structuralProperty != null);
             Contract.Assert(includedProperties != null);
 
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
+            ODataQuerySettings settings = context.QuerySettings;
+
             // // Expression:
             //       "navigation property name"
-            Expression propertyName = CreatePropertyNameExpression(structuredType, structuralProperty, source);
+            Expression propertyName = CreatePropertyNameExpression(context, structuredType, structuralProperty, source);
 
             // Expression:
             //        source.NavigationProperty
             Expression propertyValue;
             if (pathSelectItem == null)
             {
-                propertyValue = CreatePropertyValueExpression(structuredType, structuralProperty, source, filterClause: null);
+                propertyValue = CreatePropertyValueExpression(context, structuredType, structuralProperty, source, filterClause: null);
                 includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
                 return;
             }
@@ -822,7 +794,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             // TODO: Process $compute in the $select ahead.
             // $compute=...
 
-            propertyValue = CreatePropertyValueExpression(structuredType, structuralProperty, source, pathSelectItem.FilterOption);
+            propertyValue = CreatePropertyValueExpression(context, structuredType, structuralProperty, source, pathSelectItem.FilterOption);
             Type propertyValueType = propertyValue.Type;
             if (propertyValueType == typeof(char[]) || propertyValueType == typeof(byte[]))
             {
@@ -832,18 +804,18 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);
 
-            Expression countExpression = CreateTotalCountExpression(propertyValue, pathSelectItem.CountOption);
+            Expression countExpression = CreateTotalCountExpression(context, propertyValue, pathSelectItem.CountOption);
 
             // be noted: the property structured type could be null, because the property maybe not a complex property.
             IEdmStructuredType propertyStructuredType = structuralProperty.Type.ToStructuredType();
             ModelBoundQuerySettings querySettings = null;
             if (propertyStructuredType != null)
             {
-                querySettings = EdmHelpers.GetModelBoundQuerySettings(structuralProperty, propertyStructuredType, _context.Model);
+                querySettings = EdmHelpers.GetModelBoundQuerySettings(structuralProperty, propertyStructuredType, model);
             }
 
             int? modelBoundPageSize = querySettings == null ? null : querySettings.PageSize;
-            propertyValue = ProjectAsWrapper(propertyValue, subSelectExpandClause, structuralProperty.Type.ToStructuredType(), pathSelectItem.NavigationSource,
+            propertyValue = ProjectAsWrapper(context, propertyValue, subSelectExpandClause, structuralProperty.Type.ToStructuredType(), pathSelectItem.NavigationSource,
                 pathSelectItem.OrderByOption, // $orderby=...
                 pathSelectItem.TopOption, // $top=...
                 pathSelectItem.SkipOption, // $skip=...
@@ -856,9 +828,9 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 {
                     propertyExpression.NullCheck = nullCheck;
                 }
-                else if (_settings.PageSize.HasValue)
+                else if (settings.PageSize.HasValue)
                 {
-                    propertyExpression.PageSize = _settings.PageSize.Value;
+                    propertyExpression.PageSize = settings.PageSize.Value;
                 }
                 else
                 {
@@ -879,22 +851,26 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// Build the dynamic properties into the included properties.
         /// </summary>
         /// <param name="source">The source contains the dynamic property.</param>
-        /// <param name="structuredType">The structured type contains the dynamic property.</param>
+        /// <param name="context">The wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
-        internal void BuildDynamicProperty(Expression source, IEdmStructuredType structuredType,
+        internal void BuildDynamicProperty(Expression source, SelectExpandBinderContext context, IEdmStructuredType structuredType,
             IList<NamedPropertyExpression> includedProperties)
         {
             Contract.Assert(source != null);
+            Contract.Assert(context != null);
             Contract.Assert(structuredType != null);
             Contract.Assert(includedProperties != null);
 
-            PropertyInfo dynamicPropertyDictionary = _model.GetDynamicPropertyDictionary(structuredType);
+            IEdmModel model = context.SelectExpandQuery.Context.Model;
+            ODataQuerySettings settings = context.QuerySettings;
+
+            PropertyInfo dynamicPropertyDictionary = model.GetDynamicPropertyDictionary(structuredType);
             if (dynamicPropertyDictionary != null)
             {
                 Expression propertyName = Expression.Constant(dynamicPropertyDictionary.Name);
                 Expression propertyValue = Expression.Property(source, dynamicPropertyDictionary.Name);
                 Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
-                if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                if (settings.HandleNullPropagation == HandleNullPropagationOption.True)
                 {
                     // source == null ? null : propertyValue
                     propertyValue = Expression.Condition(
@@ -930,7 +906,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             return new SelectExpandClause(selectItems, false);
         }
 
-        private Expression AddOrderByQueryForSource(Expression source, OrderByClause orderbyClause, Type elementType)
+        private Expression AddOrderByQueryForSource(SelectExpandBinderContext context, Expression source, OrderByClause orderbyClause, Type elementType)
         {
             if (orderbyClause != null)
             {
@@ -941,7 +917,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 };
 
                 LambdaExpression orderByExpression =
-                    FilterBinder.Bind(null, orderbyClause, elementType, _context, querySettings);
+                    FilterBinder.Bind(null, orderbyClause, elementType, context.SelectExpandQuery.Context, querySettings);
                 source = ExpressionHelpers.OrderBy(source, orderByExpression, elementType, orderbyClause.Direction);
             }
 
@@ -965,7 +941,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             return null;
         }
 
-        private Expression GetNullCheckExpression(IEdmNavigationProperty propertyToExpand, Expression propertyValue,
+        private Expression GetNullCheckExpression(SelectExpandBinderContext context, IEdmNavigationProperty propertyToExpand, Expression propertyValue,
             SelectExpandClause projection)
         {
             if (projection == null || propertyToExpand.Type.IsCollection())
@@ -981,7 +957,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Expression keysNullCheckExpression = null;
             foreach (var key in propertyToExpand.ToEntityType().Key())
             {
-                var propertyValueExpression = CreatePropertyValueExpression(propertyToExpand.ToEntityType(), key, propertyValue, filterClause: null);
+                var propertyValueExpression = CreatePropertyValueExpression(context, propertyToExpand.ToEntityType(), key, propertyValue, filterClause: null);
                 var keyExpression = Expression.Equal(
                     propertyValueExpression,
                     Expression.Constant(null, propertyValueExpression.Type));
@@ -996,13 +972,15 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
         // new CollectionWrapper<ElementType> { Instance = source.Select((ElementType element) => new Wrapper { }) }
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "These are simple conversion function and cannot be split up.")]
-        private Expression ProjectCollection(Expression source, Type elementType,
+        private Expression ProjectCollection(SelectExpandBinderContext context, Expression source, Type elementType,
             SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource,
             OrderByClause orderByClause,
             long? topOption,
             long? skipOption,
             int? modelBoundPageSize)
         {
+            ODataQuerySettings settings = context.QuerySettings;
+
             // structuralType could be null, because it can be primitive collection.
 
             ParameterExpression element = Expression.Parameter(elementType, "$it");
@@ -1012,7 +990,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             //      new Wrapper { }
             if (structuredType != null)
             {
-                projection = ProjectElement(element, selectExpandClause, structuredType, navigationSource);
+                projection = ProjectElement(element, context, selectExpandClause, structuredType, navigationSource);
             }
             else
             {
@@ -1025,7 +1003,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             if (orderByClause != null)
             {
-                source = AddOrderByQueryForSource(source, orderByClause, elementType);
+                source = AddOrderByQueryForSource(context, source, orderByClause, elementType);
             }
 
             bool hasTopValue = topOption != null && topOption.HasValue;
@@ -1034,7 +1012,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             IEdmEntityType entityType = structuredType as IEdmEntityType;
             if (entityType != null)
             {
-                if (_settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
+                if (settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
                 {
                     // nested paging. Need to apply order by first, and take one more than page size as we need to know
                     // whether the collection was truncated or not while generating next page links.
@@ -1066,30 +1044,30 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             {
                 Contract.Assert(skipOption.Value <= Int32.MaxValue);
                 source = ExpressionHelpers.Skip(source, (int)skipOption.Value, elementType,
-                    _settings.EnableConstantParameterization);
+                    settings.EnableConstantParameterization);
             }
 
             if (hasTopValue)
             {
                 Contract.Assert(topOption.Value <= Int32.MaxValue);
                 source = ExpressionHelpers.Take(source, (int)topOption.Value, elementType,
-                    _settings.EnableConstantParameterization);
+                    settings.EnableConstantParameterization);
             }
 
-            if (_settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
+            if (settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
             {
                 // don't page nested collections if EnableCorrelatedSubqueryBuffering is enabled
-                if (!_settings.EnableCorrelatedSubqueryBuffering)
+                if (!settings.EnableCorrelatedSubqueryBuffering)
                 {
-                    if (_settings.PageSize.HasValue)
+                    if (settings.PageSize.HasValue)
                     {
-                        source = ExpressionHelpers.Take(source, _settings.PageSize.Value + 1, elementType,
-                            _settings.EnableConstantParameterization);
+                        source = ExpressionHelpers.Take(source, settings.PageSize.Value + 1, elementType,
+                            settings.EnableConstantParameterization);
                     }
-                    else if (_settings.ModelBoundPageSize.HasValue)
+                    else if (settings.ModelBoundPageSize.HasValue)
                     {
                         source = ExpressionHelpers.Take(source, modelBoundPageSize.Value + 1, elementType,
-                            _settings.EnableConstantParameterization);
+                            settings.EnableConstantParameterization);
                     }
                 }
             }
@@ -1100,12 +1078,12 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             Expression selectedExpresion = Expression.Call(selectMethod, source, selector);
 
             // Append ToList() to collection as a hint to LINQ provider to buffer correlated sub-queries in memory and avoid executing N+1 queries
-            if (_settings.EnableCorrelatedSubqueryBuffering)
+            if (settings.EnableCorrelatedSubqueryBuffering)
             {
                 selectedExpresion = Expression.Call(ExpressionHelperMethods.QueryableToList.MakeGenericMethod(projection.Type), selectedExpresion);
             }
 
-            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+            if (settings.HandleNullPropagation == HandleNullPropagationOption.True)
             {
                 // source == null ? null : projectedCollection
                 return Expression.Condition(

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -681,6 +681,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="source">The source contains the navigation property.</param>
         /// <param name="context">Wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
+        /// <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
         /// <param name="navigationProperty">The expanded navigation property.</param>
         /// <param name="expandedItem">The expanded navigation select item. It may contain the nested query options.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
@@ -759,6 +760,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="source">The source contains the structural property.</param>
         /// <param name="context">Wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
+        /// <param name="structuredType">The structured type or its derived type contains the structural property.</param>
         /// <param name="structuralProperty">The selected structural property.</param>
         /// <param name="pathSelectItem">The selected item. It may contain the nested query options and could be null.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
@@ -852,6 +854,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// </summary>
         /// <param name="source">The source contains the dynamic property.</param>
         /// <param name="context">The wrapper for properties used by the <see cref="SelectExpandBinder"/>.</param>
+        /// <param name="structuredType">The structured type contains the dynamic property.</param>
         /// <param name="includedProperties">The container to hold the created property.</param>
         internal void BuildDynamicProperty(Expression source, SelectExpandBinderContext context, IEdmStructuredType structuredType,
             IList<NamedPropertyExpression> includedProperties)

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -33,6 +33,9 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         private IEdmModel _model;
         private ODataQuerySettings _settings;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectExpandBinder"/> class.
+        /// </summary>
         public SelectExpandBinder() {  }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             ParameterExpression source = Expression.Parameter(elementType, "$it");
 
             // expression looks like -> new Wrapper { Instance = source , Properties = "...", Container = new PropertyContainer { ... } }
-            Expression projectionExpression = ProjectElement(source, selectExpandQuery.SelectExpandClause, _context.ElementType as IEdmStructuredType, navigationSource);
+            Expression projectionExpression = ProjectElement(source, selectExpandQuery.SelectExpandClause, selectExpandQuery.Context.ElementType as IEdmStructuredType, navigationSource);
 
             // expression looks like -> source => new Wrapper { Instance = source .... }
             LambdaExpression projectionLambdaExpression = Expression.Lambda(projectionExpression, source);

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinderContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinderContext.cs
@@ -1,0 +1,32 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="SelectExpandBinderContext.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Query.Expressions
+{
+    /// <summary>
+    /// Wrapper for properties used by the <see cref="ISelectExpandBinder"/>.
+    /// </summary>
+    public class SelectExpandBinderContext
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ODataQuerySettings"/> that contains all the query application related settings.
+        /// </summary>
+        public ODataQuerySettings QuerySettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.
+        /// </summary>
+        public SelectExpandQueryOption SelectExpandQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ODataQueryContext"/> which contains the <see cref="IEdmModel"/> and some type information.
+        /// </summary>
+        public ODataQueryContext QueryContext { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinderContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinderContext.cs
@@ -23,10 +23,5 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         /// Gets or sets the <see cref="SelectExpandQueryOption"/> which contains the $select and $expand query options.
         /// </summary>
         public SelectExpandQueryOption SelectExpandQuery { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ODataQueryContext"/> which contains the <see cref="IEdmModel"/> and some type information.
-        /// </summary>
-        public ODataQueryContext QueryContext { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -67,5 +67,32 @@ namespace Microsoft.AspNetCore.OData.Query
 
             return binder ?? new FilterBinder(querySettings, AssemblyResolverHelper.Default, context.Model);
         }
+
+        /// <summary>
+        /// Gets the <see cref="ISelectExpandBinder"/>.
+        /// </summary>
+        /// <param name="context">The query context.</param>
+        /// <param name="querySettings">The query settings.</param>
+        /// <returns>The built <see cref="ISelectExpandBinder"/>.</returns>
+        public static ISelectExpandBinder GetSelectExpandBinder(this ODataQueryContext context, ODataQuerySettings querySettings)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (querySettings == null)
+            {
+                throw Error.ArgumentNull(nameof(querySettings));
+            }
+
+            ISelectExpandBinder binder = null;
+            if (context.RequestContainer != null)
+            {
+                binder = context.RequestContainer.GetService<ISelectExpandBinder>();
+            }
+
+            return binder ?? new SelectExpandBinder(querySettings, context);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -72,7 +72,6 @@ namespace Microsoft.AspNetCore.OData.Query
         /// Gets the <see cref="ISelectExpandBinder"/>.
         /// </summary>
         /// <param name="context">The query context.</param>
-        /// <param name="querySettings">The query settings.</param>
         /// <returns>The built <see cref="ISelectExpandBinder"/>.</returns>
         public static ISelectExpandBinder GetSelectExpandBinder(this ODataQueryContext context)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -74,16 +74,11 @@ namespace Microsoft.AspNetCore.OData.Query
         /// <param name="context">The query context.</param>
         /// <param name="querySettings">The query settings.</param>
         /// <returns>The built <see cref="ISelectExpandBinder"/>.</returns>
-        public static ISelectExpandBinder GetSelectExpandBinder(this ODataQueryContext context, ODataQuerySettings querySettings)
+        public static ISelectExpandBinder GetSelectExpandBinder(this ODataQueryContext context)
         {
             if (context == null)
             {
                 throw Error.ArgumentNull(nameof(context));
-            }
-
-            if (querySettings == null)
-            {
-                throw Error.ArgumentNull(nameof(querySettings));
             }
 
             ISelectExpandBinder binder = null;
@@ -92,7 +87,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 binder = context.RequestContainer.GetService<ISelectExpandBinder>();
             }
 
-            return binder ?? new SelectExpandBinder(querySettings, context);
+            return binder ?? new SelectExpandBinder();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -80,11 +80,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 throw Error.ArgumentNull(nameof(context));
             }
 
-            ISelectExpandBinder binder = null;
-            if (context.RequestContainer != null)
-            {
-                binder = context.RequestContainer.GetService<ISelectExpandBinder>();
-            }
+            ISelectExpandBinder binder = context.RequestContainer?.GetService<ISelectExpandBinder>();
 
             return binder ?? new SelectExpandBinder();
         }

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 QueryContext = Context
             };
 
-            ISelectExpandBinder binder = Context.GetSelectExpandBinder(updatedSettings);
+            ISelectExpandBinder binder = Context.GetSelectExpandBinder();
 
             return binder.Bind(queryable, selectExpandBinderContext);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 QueryContext = Context
             };
 
-            ISelectExpandBinder binder = Context.GetSelectExpandBinder(updatedSettings);
+            ISelectExpandBinder binder = Context.GetSelectExpandBinder();
 
             return binder.Bind(entity, selectExpandBinderContext);
         }

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -213,8 +213,7 @@ namespace Microsoft.AspNetCore.OData.Query
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = this,
-                QuerySettings = updatedSettings,
-                QueryContext = Context
+                QuerySettings = updatedSettings
             };
 
             ISelectExpandBinder binder = Context.GetSelectExpandBinder();
@@ -248,8 +247,7 @@ namespace Microsoft.AspNetCore.OData.Query
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = this,
-                QuerySettings = updatedSettings,
-                QueryContext = Context
+                QuerySettings = updatedSettings
             };
 
             ISelectExpandBinder binder = Context.GetSelectExpandBinder();

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -210,7 +210,16 @@ namespace Microsoft.AspNetCore.OData.Query
 
             ODataQuerySettings updatedSettings = Context.UpdateQuerySettings(settings, queryable);
 
-            return SelectExpandBinder.Bind(queryable, updatedSettings, this);
+            SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = this,
+                QuerySettings = updatedSettings,
+                QueryContext = Context
+            };
+
+            ISelectExpandBinder binder = Context.GetSelectExpandBinder(updatedSettings);
+
+            return binder.Bind(queryable, selectExpandBinderContext);
         }
 
         /// <summary>
@@ -236,7 +245,16 @@ namespace Microsoft.AspNetCore.OData.Query
 
             ODataQuerySettings updatedSettings = Context.UpdateQuerySettings(settings, query: null);
 
-            return SelectExpandBinder.Bind(entity, updatedSettings, this);
+            SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = this,
+                QuerySettings = updatedSettings,
+                QueryContext = Context
+            };
+
+            ISelectExpandBinder binder = Context.GetSelectExpandBinder(updatedSettings);
+
+            return binder.Bind(entity, selectExpandBinderContext);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ConcurrentQuery/ConcurrentQueryController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ConcurrentQuery/ConcurrentQueryController.cs
@@ -13,13 +13,18 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ConcurrentQuery
 {
     public class CustomersController : Controller
     {
-        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Count | AllowedQueryOptions.Filter)]
+        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Count | AllowedQueryOptions.Filter | AllowedQueryOptions.Expand)]
         public IQueryable<Customer> GetCustomers()
         {
             return Enumerable.Range(1, 100)
                 .Select(i => new Customer
                 {
                     Id = i,
+                    Orders = Enumerable.Range(1, 5)
+                    .Select(x => new Order
+                    {
+                        Id = x
+                    })
                 }).AsQueryable();
         }
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ConcurrentQuery/ConcurrentQueryODataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ConcurrentQuery/ConcurrentQueryODataModel.cs
@@ -5,9 +5,19 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using Microsoft.OData.ModelBuilder;
+
 namespace Microsoft.AspNetCore.OData.E2E.Tests.ConcurrentQuery
 {
     public class Customer
+    {
+        public int Id { get; set; }
+        [Contained]
+        public IEnumerable<Order> Orders { get; set; }
+    }
+
+    public class Order
     {
         public int Id { get; set; }
     }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2492,7 +2492,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder : Microso
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : ISelectExpandBinder {
-	public SelectExpandBinder (Microsoft.AspNetCore.OData.Query.ODataQuerySettings settings, Microsoft.AspNetCore.OData.Query.ODataQueryContext context)
+	public SelectExpandBinder ()
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2495,7 +2495,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	protected virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2448,7 +2448,6 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
 	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
@@ -2502,7 +2501,6 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {
 	public SelectExpandBinderContext ()
 
-	Microsoft.AspNetCore.OData.Query.ODataQueryContext QueryContext  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.ODataQuerySettings QuerySettings  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption SelectExpandQuery  { public get; public set; }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2445,6 +2445,12 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 	System.Nullable`1[[System.Int64]] TotalCount  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
+	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+}
+
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
 	protected ExpressionBinderBase (System.IServiceProvider requestContainer)
 
@@ -2483,6 +2489,22 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder : Microso
 	public virtual System.Linq.Expressions.Expression BindSingleResourceCastNode (Microsoft.OData.UriParser.SingleResourceCastNode node)
 	public virtual System.Linq.Expressions.Expression BindSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : ISelectExpandBinder {
+	public SelectExpandBinder (Microsoft.AspNetCore.OData.Query.ODataQuerySettings settings, Microsoft.AspNetCore.OData.Query.ODataQueryContext context)
+
+	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	public virtual System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {
+	public SelectExpandBinderContext ()
+
+	Microsoft.AspNetCore.OData.Query.ODataQueryContext QueryContext  { public get; public set; }
+	Microsoft.AspNetCore.OData.Query.ODataQuerySettings QuerySettings  { public get; public set; }
+	Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption SelectExpandQuery  { public get; public set; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.Validator.CountQueryValidator {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2448,7 +2448,7 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
 	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
@@ -2496,7 +2496,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -2495,7 +2495,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2492,7 +2492,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder : Microso
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : ISelectExpandBinder {
-	public SelectExpandBinder (Microsoft.AspNetCore.OData.Query.ODataQuerySettings settings, Microsoft.AspNetCore.OData.Query.ODataQueryContext context)
+	public SelectExpandBinder ()
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2495,7 +2495,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	protected virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2448,7 +2448,6 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
 	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
@@ -2502,7 +2501,6 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {
 	public SelectExpandBinderContext ()
 
-	Microsoft.AspNetCore.OData.Query.ODataQueryContext QueryContext  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.ODataQuerySettings QuerySettings  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption SelectExpandQuery  { public get; public set; }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2445,6 +2445,12 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 	System.Nullable`1[[System.Int64]] TotalCount  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
+	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+}
+
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
 	protected ExpressionBinderBase (System.IServiceProvider requestContainer)
 
@@ -2483,6 +2489,22 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.FilterBinder : Microso
 	public virtual System.Linq.Expressions.Expression BindSingleResourceCastNode (Microsoft.OData.UriParser.SingleResourceCastNode node)
 	public virtual System.Linq.Expressions.Expression BindSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : ISelectExpandBinder {
+	public SelectExpandBinder (Microsoft.AspNetCore.OData.Query.ODataQuerySettings settings, Microsoft.AspNetCore.OData.Query.ODataQueryContext context)
+
+	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
+	public virtual System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {
+	public SelectExpandBinderContext ()
+
+	Microsoft.AspNetCore.OData.Query.ODataQueryContext QueryContext  { public get; public set; }
+	Microsoft.AspNetCore.OData.Query.ODataQuerySettings QuerySettings  { public get; public set; }
+	Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption SelectExpandQuery  { public get; public set; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.Validator.CountQueryValidator {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2448,7 +2448,7 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 public interface Microsoft.AspNetCore.OData.Query.Expressions.ISelectExpandBinder {
 	System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Query.Expressions.ExpressionBinderBase {
@@ -2496,7 +2496,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.Expression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2495,7 +2495,7 @@ public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinder : I
 
 	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 	public virtual object Bind (object source, Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
-	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQuery)
+	public virtual System.Linq.Expressions.LambdaExpression GetProjectionLambda (Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext context)
 }
 
 public class Microsoft.AspNetCore.OData.Query.Expressions.SelectExpandBinderContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -90,8 +90,6 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: select, expand: null, context: _context);
 
             // Act
-            //IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
-
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = selectExpand,

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -93,8 +93,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = selectExpand,
-                QuerySettings = _settings,
-                QueryContext = selectExpand.Context
+                QuerySettings = _settings
             };
 
             SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
@@ -118,8 +117,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = selectExpand,
-                QuerySettings = _settings,
-                QueryContext = selectExpand.Context
+                QuerySettings = _settings
             };
 
             SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
@@ -152,8 +150,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
             {
                 SelectExpandQuery = selectExpand,
-                QuerySettings = _settings,
-                QueryContext = selectExpand.Context
+                QuerySettings = _settings
             };
 
             SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
         private readonly IQueryable<QueryCustomer> _queryable;
         private readonly ODataQueryContext _context;
         private readonly ODataQuerySettings _settings;
+        private readonly SelectExpandBinderContext _selectExpandBinderContext;
 
         private readonly IEdmModel _model;
         private readonly IEdmEntityType _customer;
@@ -52,7 +53,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
 
             _settings = new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False };
             _context = new ODataQueryContext(_model, typeof(QueryCustomer)) { RequestContainer = new MockServiceProvider() };
-            _binder = new SelectExpandBinder(_settings, _context);
+            _binder = new SelectExpandBinder();
 
             QueryCustomer customer = new QueryCustomer
             {
@@ -62,6 +63,13 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             customer.Orders.Add(order);
 
             _queryable = new[] { customer }.AsQueryable();
+
+            SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption("Orders", expand: null, context: _context);
+            _selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = selectExpandQueryOption,
+                QuerySettings = _settings
+            };
         }
 
         private static SelectExpandBinder GetBinder<T>(IEdmModel model, HandleNullPropagationOption nullPropagation = HandleNullPropagationOption.False)
@@ -70,7 +78,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
 
             var context = new ODataQueryContext(model, typeof(T)) { RequestContainer = new MockServiceProvider() };
 
-            return new SelectExpandBinder(settings, context);
+            return new SelectExpandBinder();
         }
 
         //[Fact]
@@ -96,7 +104,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
                 QuerySettings = _settings
             };
 
-            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            SelectExpandBinder binder = new SelectExpandBinder();
             IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
@@ -120,7 +128,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
                 QuerySettings = _settings
             };
 
-            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            SelectExpandBinder binder = new SelectExpandBinder();
             IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
@@ -153,7 +161,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
                 QuerySettings = _settings
             };
 
-            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            SelectExpandBinder binder = new SelectExpandBinder();
             IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
@@ -171,7 +179,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(order);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
@@ -192,7 +200,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(null, typeof(QueryOrder));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
@@ -218,7 +226,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(null, typeof(QueryOrder));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             var e = ExceptionAssert.Throws<TargetInvocationException>(() => Expression.Lambda(projection).Compile().DynamicInvoke());
@@ -234,7 +242,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(orders);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
@@ -256,7 +264,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             _settings.PageSize = pageSize;
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
@@ -279,7 +287,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(order);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
@@ -301,7 +309,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(order);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
@@ -323,7 +331,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(null, typeof(QueryOrder[]));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
@@ -341,7 +349,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(null, typeof(QueryOrder[]));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _order, _orders);
 
             // Assert
             var e = ExceptionAssert.Throws<TargetInvocationException>(() => Expression.Lambda(projection).Compile().DynamicInvoke());
@@ -357,7 +365,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Constant(aCustomer);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpand, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -392,7 +400,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.Call, projection.NodeType);
@@ -439,7 +447,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.Call, projection.NodeType);
@@ -473,7 +481,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
@@ -498,7 +506,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
@@ -526,7 +534,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -552,7 +560,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -579,7 +587,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -617,7 +625,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -652,7 +660,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -690,7 +698,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -733,7 +741,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -768,7 +776,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -798,7 +806,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
@@ -831,7 +839,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
@@ -896,7 +904,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -926,7 +934,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
@@ -965,7 +973,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+            Expression projection = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, selectExpandClause, _customer, _customers);
 
             // Assert
             SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
@@ -1349,25 +1357,25 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
 
             // Act & Assert
             // #1. Base property on base type
-            Expression property = binder.CreatePropertyNameExpression(_customer, baseProperty, source);
+            Expression property = binder.CreatePropertyNameExpression(_selectExpandBinderContext, _customer, baseProperty, source);
             Assert.Equal(ExpressionType.Constant, property.NodeType);
             Assert.Equal(typeof(string), property.Type);
             Assert.Equal("PrivateOrder", (property as ConstantExpression).Value);
 
             // #2. Base property on derived type
-            property = binder.CreatePropertyNameExpression(vipCustomer, baseProperty, source);
+            property = binder.CreatePropertyNameExpression(_selectExpandBinderContext, vipCustomer, baseProperty, source);
             Assert.Equal(ExpressionType.Constant, property.NodeType);
             Assert.Equal(typeof(string), property.Type);
             Assert.Equal("PrivateOrder", (property as ConstantExpression).Value);
 
             // #3. Derived property on base type
-            property = binder.CreatePropertyNameExpression(_customer, derivedProperty, source);
+            property = binder.CreatePropertyNameExpression(_selectExpandBinderContext, _customer, derivedProperty, source);
             Assert.Equal(ExpressionType.Conditional, property.NodeType);
             Assert.Equal(typeof(string), property.Type);
             Assert.Equal("IIF((aCustomer Is QueryVipCustomer), \"Birthday\", null)", property.ToString());
 
             // #4. Derived property on derived type.
-            property = binder.CreatePropertyNameExpression(vipCustomer, derivedProperty, source);
+            property = binder.CreatePropertyNameExpression(_selectExpandBinderContext, vipCustomer, derivedProperty, source);
             Assert.Equal(ExpressionType.Constant, property.NodeType);
             Assert.Equal(typeof(string), property.Type);
             Assert.Equal("Birthday", (property as ConstantExpression).Value);
@@ -1386,7 +1394,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Expression source = Expression.Parameter(typeof(QueryCustomer), "aCustomer");
 
             // Act
-            Expression property = _binder.CreatePropertyNameExpression(_customer, edmProperty, source);
+            Expression property = _binder.CreatePropertyNameExpression(_selectExpandBinderContext, _customer, edmProperty, source);
 
             // Assert
             Assert.Equal(ExpressionType.Constant, property.NodeType);
@@ -1409,7 +1417,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandBinder binder = GetBinder<QueryCustomer>(model);
 
             // Act & Assert
-            ExceptionAssert.Throws<ODataException>(() => binder.CreatePropertyNameExpression(_customer, subNameProperty, source),
+            ExceptionAssert.Throws<ODataException>(() => binder.CreatePropertyNameExpression(_selectExpandBinderContext, _customer, subNameProperty, source),
                 "The provided mapping does not contain a resource for the resource type 'NS.SubCustomer'.");
         }
         #endregion
@@ -1427,7 +1435,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(navProperty);
 
             // Act
-            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, navProperty, source, null);
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, navProperty, source, null);
 
             // Assert
             Assert.Equal(ExpressionType.MemberAccess, propertyValue.NodeType);
@@ -1450,7 +1458,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(specialProperty);
 
             // Act
-            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, specialProperty, source, null);
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, specialProperty, source, null);
 
             // Assert
             Assert.Equal(String.Format("({0} As QueryVipCustomer).{1}", source.ToString(), property), propertyValue.ToString());
@@ -1472,7 +1480,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(vipCustomer);
 
             // Act
-            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, edmProperty, source, null);
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, edmProperty, source, null);
 
             // Assert
             Assert.Equal(String.Format("Convert(({0} As QueryVipCustomer).{1}, Nullable`1)", source.ToString(), property), propertyValue.ToString());
@@ -1494,7 +1502,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(vipCustomer);
 
             // Act
-            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, edmProperty, source, null);
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, edmProperty, source, null);
 
             // Assert
             Assert.Equal(String.Format("({0} As QueryVipCustomer).{1}", source.ToString(), property), propertyValue.ToString());
@@ -1509,7 +1517,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             IEdmProperty idProperty = _customer.StructuralProperties().Single(p => p.Name == "Id");
 
             // Act
-            Expression property = _binder.CreatePropertyValueExpression(_customer, idProperty, source, null);
+            Expression property = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, idProperty, source, null);
 
             // Assert
             // NetFx and NetCore differ in the way Expression is converted to a string.
@@ -1546,7 +1554,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             IEdmProperty idProperty = _customer.StructuralProperties().Single(p => p.Name == "Id");
 
             // Act
-            Expression property = _binder.CreatePropertyValueExpression(_customer, idProperty, source, filterClause: null);
+            Expression property = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, idProperty, source, filterClause: null);
 
             // Assert
             Assert.Equal(String.Format("Convert({0}.Id, Nullable`1)", source.ToString()), property.ToString());
@@ -1579,7 +1587,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
 
             // Act & Assert
             ExceptionAssert.Throws<ODataException>(
-                () => _binder.CreatePropertyValueExpression(_customer, ordersProperty, source, expandItem.FilterOption),
+                () => _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, ordersProperty, source, expandItem.FilterOption),
                 String.Format("The provided mapping does not contain a resource for the resource type '{0}'.",
                 ordersProperty.Type.Definition.AsElementType().FullTypeName()));
         }
@@ -1608,7 +1616,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(expandItem.FilterOption);
 
             // Act
-            var filterInExpand = _binder.CreatePropertyValueExpression(_customer, ordersProperty, source, expandItem.FilterOption);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _customer, ordersProperty, source, expandItem.FilterOption);
 
             // Assert
             if (nullOption == HandleNullPropagationOption.True)
@@ -1683,7 +1691,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(expandItem.FilterOption);
 
             // Act 
-            var filterInExpand = _binder.CreatePropertyValueExpression(_order, customerProperty, order, expandItem.FilterOption);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _order, customerProperty, order, expandItem.FilterOption);
 
             // Assert
             var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as QueryCustomer;
@@ -1717,7 +1725,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             Assert.NotNull(expandItem.FilterOption);
 
             // Act
-            var filterInExpand = _binder.CreatePropertyValueExpression(_order, customerProperty, source, expandItem.FilterOption);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_selectExpandBinderContext, _order, customerProperty, source, expandItem.FilterOption);
 
             // Assert
             if (nullOption == HandleNullPropagationOption.True)
@@ -1828,7 +1836,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             var expandClause = ParseSelectExpand(null, "Orders", _model, _customer, _customers);
 
             // Act
-            var expand = _binder.ProjectAsWrapper(source, expandClause, _customer, _customers);
+            var expand = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, expandClause, _customer, _customers);
 
             // Assert
             Assert.True(expand.ToString().Contains("ToList") == enableOptimization);
@@ -1854,7 +1862,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             var expandClause = ParseSelectExpand(null, "Orders", _model, _customer, _customers);
 
             // Act
-            var expand = _binder.ProjectAsWrapper(source, expandClause, _customer, _customers);
+            var expand = _binder.ProjectAsWrapper(_selectExpandBinderContext, source, expandClause, _customer, _customers);
 
             // Assert
             Assert.True(expand.ToString().Contains("ToList") == enableOptimization);

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -90,7 +90,17 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: select, expand: null, context: _context);
 
             // Act
-            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            //IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+
+            SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = selectExpand,
+                QuerySettings = _settings,
+                QueryContext = selectExpand.Context
+            };
+
+            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
             Assert.NotNull(queryable);
@@ -107,7 +117,15 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption("Orders", "Orders,Orders($expand=Customer)", _context);
 
             // Act
-            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = selectExpand,
+                QuerySettings = _settings,
+                QueryContext = selectExpand.Context
+            };
+
+            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
             IEnumerator enumerator = queryable.GetEnumerator();
@@ -133,7 +151,15 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(null, "Orders($expand=Customer($select=City))", _context);
 
             // Act
-            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            SelectExpandBinderContext selectExpandBinderContext = new SelectExpandBinderContext()
+            {
+                SelectExpandQuery = selectExpand,
+                QuerySettings = _settings,
+                QueryContext = selectExpand.Context
+            };
+
+            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand.Context);
+            IQueryable queryable = binder.Bind(_queryable, selectExpandBinderContext);
 
             // Assert
             var unaryExpression = (UnaryExpression)((MethodCallExpression)queryable.Expression).Arguments.Single(a => a is UnaryExpression);


### PR DESCRIPTION
Fixes #304 

The main changes:
- Make `SelectExpandBinder` public.
- Add a new interface `ISelectExpandBinder` and make `SelectExpandBinder` inherit the interface.
- Add a new class `SelectExpandBinderContext` to wrap all properties needed by the `ISelectExpandBinder`.
- Register `ISelectExpandBinder` to the dependency injection container.

If a customer has their own custom implementation e.g `MySelectExpandBinder`, 
The `MySelectExpandBinder`  class should implement  `ISelectExpandBinder` directly or inherit from `SelectExpandBinder`.

*First option:*
```
public class MySelectExpandBinder : ISelectExpandBinder
{ 
} 
``` 
*Second option:*
```
public class MySelectExpandBinder : SelectExpandBinder
{ 
} 
```
In the first option, the customer will write their own implementation of all methods.
In the second option, the customer can choose the specific method to override and use the default implementation of the SelectExpandBinder for the other methods. 