### PR TITLE
Enable nested resource case insensitive when readuntypedasvalue

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -146,7 +146,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 throw new ArgumentNullException(nameof(readContext));
             }
 
-            if (!String.IsNullOrEmpty(resourceWrapper.Resource.TypeName) && structuredType.FullName() != resourceWrapper.Resource.TypeName)
+            if (!String.IsNullOrEmpty(resourceWrapper.Resource.TypeName) &&
+                structuredType.FullName() != resourceWrapper.Resource.TypeName &&
+                resourceWrapper.Resource.TypeName != "Edm.Untyped")
             {
                 // received a derived type in a base type deserializer. delegate it to the appropriate derived type deserializer.
                 IEdmModel model = readContext.Model;
@@ -360,7 +362,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 throw Error.ArgumentNull(nameof(resourceInfoWrapper));
             }
 
-            IEdmProperty edmProperty = structuredType.FindProperty(resourceInfoWrapper.NestedResourceInfo.Name);
+            // ODL has "FindProperty" method to find property using property name case-sensitive.
+            // We use "ResolveProperty" method to support case-insensitive
+            IEdmProperty edmProperty = structuredType.StructuredDefinition().ResolveProperty(resourceInfoWrapper.NestedResourceInfo.Name);
             if (edmProperty == null)
             {
                 if (!structuredType.IsOpen())

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedControllers.cs
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------------------------
+// <copyright file="EdmUntypedControllers.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.EdmUntyped
+{
+    public class BillsController : ODataController
+    {
+        [EnableQuery]
+        public IActionResult Post([FromBody]Bill bill)
+        {
+            Assert.NotNull(bill);
+
+            // Let's verify the 'bill' from the "Post" test case
+            Assert.Equal(921, bill.ID);
+            Assert.Equal("Fan", bill.Name);
+            Assert.Equal(Frequency.BiWeekly, bill.Frequency);
+            Assert.Equal(3.14, bill.Weight);
+
+            Assert.NotNull(bill.HomeAddress);
+            Assert.Equal("MyStreet", bill.HomeAddress.Street);
+            Assert.Equal("MyCity", bill.HomeAddress.City);
+
+            Assert.NotNull(bill.Addresses);
+            Assert.Equal(2, bill.Addresses.Count);
+
+            Assert.Equal("Street-1", bill.Addresses[0].Street);
+            Assert.Equal("City-1", bill.Addresses[0].City);
+
+            Assert.Equal("Street-2", bill.Addresses[1].Street);
+            Assert.Equal("City-2", bill.Addresses[1].City);
+
+            return Ok(true);
+        }
+
+        [EnableQuery]
+        public IActionResult Patch(int key, Delta<Bill> delta)
+        {
+            Assert.Equal(2, key);
+
+            // Let's verify the 'delta' from the "Patch" test case
+            delta.TryGetPropertyValue("Frequency", out object frequency);
+            Assert.Equal(Frequency.BiWeekly, frequency);
+            delta.TryGetPropertyValue("Weight", out object weight);
+            Assert.Equal(6.24, weight);
+
+            delta.TryGetPropertyValue("HomeAddress", out object homeAddressObj);
+            Address homeAddress = Assert.IsType<Address>(homeAddressObj);
+            Assert.Equal("YouStreet", homeAddress.Street);
+            Assert.Equal("YouCity", homeAddress.City);
+
+            delta.TryGetPropertyValue("Addresses", out object addressesObj);
+            Assert.Collection((IList<Address>)addressesObj,
+                e =>
+                {
+                    Assert.Equal("Street-3", e.Street);
+                    Assert.Equal("City-3", e.City);
+                },
+                e =>
+                {
+                    Assert.Equal("Street-4", e.Street);
+                    Assert.Equal("City-4", e.City);
+                });
+
+            return Ok(false);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedDataModel.cs
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+// <copyright file="EdmUntypedDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.EdmUntyped
+{
+    public class Bill
+    {
+        public int ID { get; set; }
+
+        public string Name { get; set; }
+
+        public Frequency Frequency { get; set; }
+
+        public Double Weight { get; set; }
+
+        public Address HomeAddress { get; set; }
+
+        public IList<Address> Addresses { get; set; }
+
+        public BillDetail BillDetail { get; set; }
+
+        public IList<BillDetail> Details { get; set; }
+    }
+
+    public enum Frequency
+    {
+        Once,
+
+        BiWeekly,
+
+        Monthly,
+
+        Yealy
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+
+        public string City { get; set; }
+    }
+
+    public class BillDetail
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public IList<int> DimensionInCentimeter { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EdmUntyped/EdmUntypedTest.cs
@@ -1,0 +1,161 @@
+//-----------------------------------------------------------------------------
+// <copyright file="EdmUntypedTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.EdmUntyped
+{
+    /// <summary>
+    /// EdmUntyped here means the property type is "Edm.Untyped" type.
+    /// All properties defined using "Edm.Untyped" type are un-declared properties.
+    /// </summary>
+    public class EdmUntypedTest : WebApiTestBase<EdmUntypedTest>
+    {
+        public EdmUntypedTest(WebApiTestFixture<EdmUntypedTest> fixture)
+           : base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            IEdmModel edmModel = GetEdmModel();
+            services.ConfigureControllers(typeof(MetadataController), typeof(BillsController));
+            services.AddControllers().AddOData(opt => opt.AddRouteComponents("odata", edmModel));
+        }
+
+        public static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Bill>("Bills");
+            var edmModel = builder.GetEdmModel();
+            return edmModel;
+        }
+
+        [Fact]
+        public async Task EdmUntyped_QueryMetadata_WorksAsExpected()
+        {
+            // Arrange
+            var requestUri = "odata/$metadata";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.True(HttpStatusCode.OK == response.StatusCode,
+                string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+                HttpStatusCode.OK, response.StatusCode, requestUri));
+
+            Assert.Contains("<Property Name=\"HomeAddress\" Type=\"Microsoft.AspNetCore.OData.E2E.Tests.EdmUntyped.Address\" />", responseString);
+            Assert.Contains("<Property Name=\"Addresses\" Type=\"Collection(Microsoft.AspNetCore.OData.E2E.Tests.EdmUntyped.Address)\" />", responseString);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task EdmUntyped_Post_UsingDifferentCase_WorksAsExpected(bool caseSensitive)
+        {
+            // Arrange
+            string id = caseSensitive ? "ID" : "id";
+            string name = caseSensitive ? "Name" : "nAme";
+            string frequency = caseSensitive ? "Frequency" : "frequency";
+            string weight = caseSensitive ? "Weight" : "weight";
+            string homeAddress = caseSensitive ? "HomeAddress" : "homeADDRESS";
+            string addresses = caseSensitive ? "Addresses" : "addresses";
+
+            // in the controller, we will verify the following content to make sure it works fine.
+            // if you change the content, please change the verification codes in the controller as well.
+            string content = $@"
+{{
+    '{id}':921,
+    '{name}':'Fan',
+    '{frequency}': 'BiWeekly',
+    '{weight}': 3.14,
+    '{homeAddress}': {{ 'Street':'MyStreet','City':'MyCity'}},
+    '{addresses}':[
+        {{ 'Street':'Street-1','City':'City-1'}},
+        {{ 'Street':'Street-2','City':'City-2'}}
+    ]
+}}";
+            var requestUri = "odata/Bills";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = new StringContent(content);
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = content.Length;
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(HttpStatusCode.OK == response.StatusCode,
+                string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+                HttpStatusCode.OK, response.StatusCode, requestUri));
+
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#Edm.Boolean\",\"value\":true}", responseString);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task EdmUntyped_Patch_UsingDifferentCase_WorksAsExpected(bool caseSensitive)
+        {
+            // Arrange
+            string frequency = caseSensitive ? "Frequency" : "frequency";
+            string weight = caseSensitive ? "Weight" : "weight";
+            string homeAddress = caseSensitive ? "HomeAddress" : "homeADDRESS";
+            string addresses = caseSensitive ? "Addresses" : "addresses";
+
+            // in the controller, we will verify the following content to make sure it works fine.
+            // if you change the content, please change the verification codes in the controller as well.
+            string content = $@"
+{{
+    '{frequency}': 'BiWeekly',
+    '{weight}': 6.24,
+    '{homeAddress}': {{ 'Street':'YouStreet','City':'YouCity'}},
+    '{addresses}':[
+        {{ 'Street':'Street-3','City':'City-3'}},
+        {{ 'Street':'Street-4','City':'City-4'}}
+    ]
+}}";
+            var requestUri = "odata/Bills/2";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, requestUri);
+            request.Content = new StringContent(content);
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = content.Length;
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(HttpStatusCode.OK == response.StatusCode,
+                string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+                HttpStatusCode.OK, response.StatusCode, requestUri));
+
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#Edm.Boolean\",\"value\":false}", responseString);
+        }
+    }
+}


### PR DESCRIPTION
Since ODL now supports to read the property with different cases as "Edm.Untyped" in 7.9.2, this PR is to enable "Edm.Untyped" nested resource deserialization.

1) Enable the "Edm.Untyped" in resource deserialization
2) Add the test cases