### PR TITLE
Add IODataTypeMapper

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Abstracts/ETagActionFilterAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ETagActionFilterAttribute.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.OData.Abstracts
                 return edmTypeReference.AsEntity();
             }
 
-            IEdmTypeReference reference = model.GetTypeMappingCache().GetEdmType(value.GetType(), model);
+            IEdmTypeReference reference = model.GetEdmTypeReference(value.GetType());
             if (reference != null && reference.Definition.IsOrInheritsFrom(edmType))
             {
                 return (IEdmEntityTypeReference)reference;

--- a/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Deltas;
 using Microsoft.AspNetCore.OData.Query.Wrapper;
 using Microsoft.OData.ModelBuilder;
 
@@ -30,6 +31,29 @@ namespace Microsoft.AspNetCore.OData.Common
         public static bool IsDynamicTypeWrapper(this Type type)
         {
             return (type != null && typeof(DynamicTypeWrapper).IsAssignableFrom(type));
+        }
+
+        public static bool IsDeltaSetWrapper(this Type type, out Type entityType) => IsTypeWrapper(typeof(DeltaSet<>), type, out entityType);
+
+        public static bool IsSelectExpandWrapper(this Type type, out Type entityType) => IsTypeWrapper(typeof(SelectExpandWrapper<>), type, out entityType);
+
+        public static bool IsComputeWrapper(this Type type, out Type entityType) => IsTypeWrapper(typeof(ComputeWrapper<>), type, out entityType);
+
+        private static bool IsTypeWrapper(Type wrappedType, Type type, out Type entityType)
+        {
+            if (type == null)
+            {
+                entityType = null;
+                return false;
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == wrappedType)
+            {
+                entityType = type.GetGenericArguments()[0];
+                return true;
+            }
+
+            return IsTypeWrapper(wrappedType, type.BaseType, out entityType);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -1,0 +1,444 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DefaultODataTypeMapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Common;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Microsoft.Spatial;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    /// <summary>
+    /// The default implementation for <see cref="IODataTypeMapper"/>.
+    /// </summary>
+    public class DefaultODataTypeMapper : IODataTypeMapper
+    {
+        /// <summary>
+        /// Creates a static instance for the Default type mapper.
+        /// </summary>
+        internal static DefaultODataTypeMapper Default = new DefaultODataTypeMapper();
+
+        #region Default_PrimitiveTypeMapping
+        /// <summary>
+        /// The default mapping between Edm primitive type and Clr primitive type.
+        /// Primitive types are cross Edm models.
+        /// </summary>
+        private static ConcurrentDictionary<Type, IEdmPrimitiveTypeReference> ClrPrimitiveTypes
+            = new ConcurrentDictionary<Type, IEdmPrimitiveTypeReference>();
+
+        /// <summary>
+        /// Item1 --> non-nullable
+        /// Item2 --> nullable
+        /// </summary>
+        private static ConcurrentDictionary<IEdmPrimitiveType, (Type, Type)> EdmPrimitiveTypes
+            = new ConcurrentDictionary<IEdmPrimitiveType, (Type, Type)>();
+
+        static DefaultODataTypeMapper()
+        {
+            // Do not change the order for the nullable or non-nullable. Put nullable ahead of non-nullable.
+            // By design: non-nullable will overwrite the item1.
+            BuildTypeMapping<string>(EdmPrimitiveTypeKind.String);
+            BuildTypeMapping<bool?>(EdmPrimitiveTypeKind.Boolean);
+            BuildTypeMapping<bool>(EdmPrimitiveTypeKind.Boolean);
+            BuildTypeMapping<byte?>(EdmPrimitiveTypeKind.Byte);
+            BuildTypeMapping<byte>(EdmPrimitiveTypeKind.Byte);
+            BuildTypeMapping<decimal?>(EdmPrimitiveTypeKind.Decimal);
+            BuildTypeMapping<decimal>(EdmPrimitiveTypeKind.Decimal);
+            BuildTypeMapping<double?>(EdmPrimitiveTypeKind.Double);
+            BuildTypeMapping<double>(EdmPrimitiveTypeKind.Double);
+            BuildTypeMapping<Guid?>(EdmPrimitiveTypeKind.Guid);
+            BuildTypeMapping<Guid>(EdmPrimitiveTypeKind.Guid);
+            BuildTypeMapping<short?>(EdmPrimitiveTypeKind.Int16);
+            BuildTypeMapping<short>(EdmPrimitiveTypeKind.Int16);
+            BuildTypeMapping<int?>(EdmPrimitiveTypeKind.Int32);
+            BuildTypeMapping<int>(EdmPrimitiveTypeKind.Int32);
+            BuildTypeMapping<long?>(EdmPrimitiveTypeKind.Int64);
+            BuildTypeMapping<long>(EdmPrimitiveTypeKind.Int64);
+            BuildTypeMapping<sbyte?>(EdmPrimitiveTypeKind.SByte);
+            BuildTypeMapping<sbyte>(EdmPrimitiveTypeKind.SByte);
+            BuildTypeMapping<float?>(EdmPrimitiveTypeKind.Single);
+            BuildTypeMapping<float>(EdmPrimitiveTypeKind.Single);
+            BuildTypeMapping<byte[]>(EdmPrimitiveTypeKind.Binary);
+            BuildTypeMapping<Stream>(EdmPrimitiveTypeKind.Stream);
+            BuildTypeMapping<DateTimeOffset?>(EdmPrimitiveTypeKind.DateTimeOffset);
+            BuildTypeMapping<DateTimeOffset>(EdmPrimitiveTypeKind.DateTimeOffset);
+            BuildTypeMapping<TimeSpan?>(EdmPrimitiveTypeKind.Duration);
+            BuildTypeMapping<TimeSpan>(EdmPrimitiveTypeKind.Duration);
+            BuildTypeMapping<Date?>(EdmPrimitiveTypeKind.Date);
+            BuildTypeMapping<Date>(EdmPrimitiveTypeKind.Date);
+            BuildTypeMapping<TimeOfDay?>(EdmPrimitiveTypeKind.TimeOfDay);
+            BuildTypeMapping<TimeOfDay>(EdmPrimitiveTypeKind.TimeOfDay);
+
+            BuildTypeMapping<Geography>(EdmPrimitiveTypeKind.Geography);
+            BuildTypeMapping<GeographyPoint>(EdmPrimitiveTypeKind.GeographyPoint);
+            BuildTypeMapping<GeographyLineString>(EdmPrimitiveTypeKind.GeographyLineString);
+            BuildTypeMapping<GeographyPolygon>(EdmPrimitiveTypeKind.GeographyPolygon);
+            BuildTypeMapping<GeographyCollection>(EdmPrimitiveTypeKind.GeographyCollection);
+            BuildTypeMapping<GeographyMultiLineString>(EdmPrimitiveTypeKind.GeographyMultiLineString);
+            BuildTypeMapping<GeographyMultiPoint>(EdmPrimitiveTypeKind.GeographyMultiPoint);
+            BuildTypeMapping<GeographyMultiPolygon>(EdmPrimitiveTypeKind.GeographyMultiPolygon);
+            BuildTypeMapping<Geometry>(EdmPrimitiveTypeKind.Geometry);
+            BuildTypeMapping<GeometryPoint>(EdmPrimitiveTypeKind.GeometryPoint);
+            BuildTypeMapping<GeometryLineString>(EdmPrimitiveTypeKind.GeometryLineString);
+            BuildTypeMapping<GeometryPolygon>(EdmPrimitiveTypeKind.GeometryPolygon);
+            BuildTypeMapping<GeometryCollection>(EdmPrimitiveTypeKind.GeometryCollection);
+            BuildTypeMapping<GeometryMultiLineString>(EdmPrimitiveTypeKind.GeometryMultiLineString);
+            BuildTypeMapping<GeometryMultiPoint>(EdmPrimitiveTypeKind.GeometryMultiPoint);
+            BuildTypeMapping<GeometryMultiPolygon>(EdmPrimitiveTypeKind.GeometryMultiPolygon);
+
+            // non-standard mappings
+            BuildTypeMapping<XElement>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildTypeMapping<ushort?>(EdmPrimitiveTypeKind.Int32, isStandard: false);
+            BuildTypeMapping<ushort>(EdmPrimitiveTypeKind.Int32, isStandard: false);
+            BuildTypeMapping<uint?>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildTypeMapping<uint>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildTypeMapping<ulong?>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildTypeMapping<ulong>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildTypeMapping<char[]>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildTypeMapping<char?>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildTypeMapping<char>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildTypeMapping<DateTime?>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
+            BuildTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
+        }
+        #endregion
+
+        #region IODataTypeMapper.GetPrimitiveType
+        /// <summary>
+        /// Gets the corresponding Edm primitive type <see cref="IEdmPrimitiveTypeReference"/> for a given <see cref="Type"/> type.
+        /// </summary>
+        /// <param name="clrType">The given CLR type.</param>
+        /// <returns>Null or the Edm primitive type.</returns>
+        public virtual IEdmPrimitiveTypeReference GetPrimitiveType(Type clrType)
+        {
+            if (clrType == null)
+            {
+                return null;
+            }
+
+            return ClrPrimitiveTypes.TryGetValue(clrType, out IEdmPrimitiveTypeReference primitive) ? primitive : null;
+        }
+
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> type for a given Edm primitive type <see cref="IEdmPrimitiveTypeReference"/>.
+        /// </summary>
+        /// <param name="primitiveType">The given Edm primitive type.</param>
+        /// <param name="nullable">The nullable or not.</param>
+        /// <returns>Null or the CLR type.</returns>
+        public virtual Type GetPrimitiveType(IEdmPrimitiveType primitiveType, bool nullable)
+        {
+            if (primitiveType == null)
+            {
+                return null;
+            }
+
+            if (EdmPrimitiveTypes.TryGetValue(primitiveType, out (Type, Type) types))
+            {
+                if (nullable)
+                {
+                    return types.Item2;
+                }
+                else
+                {
+                    return types.Item1;
+                }
+            }
+
+            return null;
+        }
+        #endregion
+
+        /// <summary>
+        /// The cache used to hold the type mapping between <see cref="Type"/> and <see cref="IEdmTypeReference"/>.
+        /// </summary>
+        private ConcurrentDictionary<IEdmModel, TypeCacheItem> _cache = new ConcurrentDictionary<IEdmModel, TypeCacheItem>();
+
+        #region ClrType -> EdmType
+        /// <summary>
+        /// Gets the corresponding Edm type <see cref="IEdmTypeReference"/> for the given CLR type <see cref="Type"/>.
+        /// </summary>
+        /// <param name="edmModel">The given Edm model.</param>
+        /// <param name="clrType">The given CLR type.</param>
+        /// <returns>Null or the corresponding Edm type reference.</returns>
+        public virtual IEdmTypeReference GetEdmTypeReference(IEdmModel edmModel, Type clrType)
+        {
+            if (clrType == null)
+            {
+                throw Error.ArgumentNull(nameof(clrType));
+            }
+
+            IEdmPrimitiveTypeReference primitiveType = GetPrimitiveType(clrType);
+            if (primitiveType != null)
+            {
+                return primitiveType;
+            }
+
+            if (edmModel == null)
+            {
+                throw Error.ArgumentNull(nameof(edmModel));
+            }
+
+            TypeCacheItem map = GetOrCreateCacheItem(edmModel);
+            // Search from cache
+            if (map.TryFindEdmType(clrType, out IEdmTypeReference edmTypeRef))
+            {
+                return edmTypeRef;
+            }
+
+            // Not in the cache, let's build the Edm type reference.
+            IEdmType edmType = GetEdmType(edmModel, clrType, testCollections: true);
+            if (edmType != null)
+            {
+                bool isNullable = clrType.IsNullable();
+                edmTypeRef = edmType.ToEdmTypeReference(isNullable);
+            }
+            else
+            {
+                edmTypeRef = null;
+            }
+
+            map.AddClrToEdmMap(clrType, edmTypeRef);
+            return edmTypeRef;
+        }
+
+        private IEdmType GetEdmType(IEdmModel edmModel, Type clrType, bool testCollections)
+        {
+            Contract.Assert(edmModel != null);
+            Contract.Assert(clrType != null);
+
+            IEdmPrimitiveTypeReference primitiveType = GetPrimitiveType(clrType);
+            if (primitiveType != null)
+            {
+                return primitiveType.Definition;
+            }
+            else
+            {
+                if (testCollections)
+                {
+                    Type entityType;
+                    if (clrType.IsDeltaSetWrapper(out entityType))
+                    {
+                        IEdmType elementType = GetEdmType(edmModel, entityType, testCollections: false);
+                        if (elementType != null)
+                        {
+                            return new EdmCollectionType(elementType.ToEdmTypeReference(entityType.IsNullable()));
+                        }
+                    }
+
+                    Type enumerableOfT = ExtractGenericInterface(clrType, typeof(IEnumerable<>));
+                    if (enumerableOfT != null)
+                    {
+                        Type elementClrType = enumerableOfT.GetGenericArguments()[0];
+
+                        // IEnumerable<SelectExpandWrapper<T>> is a collection of T.
+                        if (elementClrType.IsSelectExpandWrapper(out entityType))
+                        {
+                            elementClrType = entityType;
+                        }
+
+                        if (elementClrType.IsComputeWrapper(out entityType))
+                        {
+                            elementClrType = entityType;
+                        }
+
+                        IEdmType elementType = GetEdmType(edmModel, elementClrType, testCollections: false);
+                        if (elementType != null)
+                        {
+                            return new EdmCollectionType(elementType.ToEdmTypeReference(elementClrType.IsNullable()));
+                        }
+                    }
+                }
+
+                Type underlyingType = TypeHelper.GetUnderlyingTypeOrSelf(clrType);
+                if (TypeHelper.IsEnum(underlyingType))
+                {
+                    clrType = underlyingType;
+                }
+
+                // search for the ClrTypeAnnotation and return it if present
+                IEdmType returnType =
+                    edmModel
+                    .SchemaElements
+                    .OfType<IEdmType>()
+                    .Select(edmType => new { EdmType = edmType, Annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmType) })
+                    .Where(tuple => tuple.Annotation != null && tuple.Annotation.ClrType == clrType)
+                    .Select(tuple => tuple.EdmType)
+                    .SingleOrDefault();
+
+                // default to the EdmType with the same name as the ClrType name
+                returnType = returnType ?? edmModel.FindType(clrType.EdmFullName());
+
+                if (clrType.BaseType != null)
+                {
+                    // go up the inheritance tree to see if we have a mapping defined for the base type.
+                    returnType = returnType ?? GetEdmType(edmModel, clrType.BaseType, testCollections);
+                }
+
+                return returnType;
+            }
+        }
+        #endregion
+
+        #region EdmType -> ClrType
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm type <see cref="IEdmType"/>.
+        /// </summary>
+        /// <param name="edmModel">The Edm model.</param>
+        /// <param name="edmType">The Edm type.</param>
+        /// <param name="nullable">The nullable or not.</param>
+        /// <param name="assembliesResolver">The assembly resolver. if it's null, will use the default resolver.</param>
+        /// <returns>Null or the CLR type.</returns>
+        public virtual Type GetClrType(IEdmModel edmModel, IEdmType edmType, bool nullable, IAssemblyResolver assembliesResolver)
+        {
+            if (edmType == null)
+            {
+                throw Error.ArgumentNull(nameof(edmType));
+            }
+
+            if (edmType.TypeKind == EdmTypeKind.Primitive)
+            {
+                return GetPrimitiveType((IEdmPrimitiveType)edmType, nullable);
+            }
+
+            if (edmModel == null)
+            {
+                throw Error.ArgumentNull(nameof(edmModel));
+            }
+
+            assembliesResolver = assembliesResolver ?? AssemblyResolverHelper.Default;
+
+            // Let's search from cache
+            TypeCacheItem map = GetOrCreateCacheItem(edmModel);
+            if (map.TryFindClrType(edmType, nullable, out Type clrType))
+            {
+                return clrType;
+            }
+
+            // If not cached, find the CLR type from the model.
+            clrType = FindClrType(edmModel, edmType, assembliesResolver);
+
+            if (clrType != null && nullable && clrType.IsEnum)
+            {
+                clrType = TypeHelper.ToNullable(clrType);
+            }
+
+            map.AddEdmToClrMap(edmType, nullable, clrType);
+
+            return clrType;
+        }
+
+        /// <summary>
+        /// Finds the corresponding CLR type for a given Edm type reference.
+        /// </summary>
+        /// <param name="edmModel">The Edm model.</param>
+        /// <param name="edmType">The Edm type.</param>
+        /// <param name="assembliesResolver">The assembly resolver.</param>
+        /// <returns>Null or the CLR type.</returns>
+        internal static Type FindClrType(IEdmModel edmModel, IEdmType edmType, IAssemblyResolver assembliesResolver)
+        {
+            if (edmModel == null)
+            {
+                throw Error.ArgumentNull(nameof(edmModel));
+            }
+
+            if (edmType == null)
+            {
+                throw Error.ArgumentNull(nameof(edmType));
+            }
+
+            if (assembliesResolver == null)
+            {
+                throw Error.ArgumentNull(nameof(assembliesResolver));
+            }
+
+            IEdmSchemaType edmSchemaType = edmType as IEdmSchemaType;
+            if (edmSchemaType == null)
+            {
+                return null;
+            }
+
+            // by default, retrieve it from Clr type annotation.
+            ClrTypeAnnotation annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmSchemaType);
+            if (annotation != null)
+            {
+                return annotation.ClrType;
+            }
+
+            string typeName = edmSchemaType.FullName();
+            IEnumerable<Type> matchingTypes = GetMatchingTypes(typeName, assembliesResolver);
+
+            if (matchingTypes.Count() > 1)
+            {
+                throw Error.Argument("edmTypeReference", SRResources.MultipleMatchingClrTypesForEdmType,
+                    typeName, string.Join(",", matchingTypes.Select(type => type.AssemblyQualifiedName)));
+            }
+
+            Type clrType = matchingTypes.SingleOrDefault();
+
+            // TODO: shall we save it back to model because we will cache it?
+            // I think we should not save it back to model, since we will cache it
+            // edmModel.SetAnnotationValue(edmSchemaType, new ClrTypeAnnotation(clrType));
+            return clrType;
+        }
+        #endregion
+
+        private TypeCacheItem GetOrCreateCacheItem(IEdmModel model)
+        {
+            if (!_cache.TryGetValue(model, out TypeCacheItem map))
+            {
+                map = new TypeCacheItem();
+                _cache[model] = map;
+            }
+
+            return map;
+        }
+
+        private static Type ExtractGenericInterface(Type queryType, Type interfaceType)
+        {
+            Func<Type, bool> matchesInterface = t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType;
+            return matchesInterface(queryType) ? queryType : queryType.GetInterfaces().FirstOrDefault(matchesInterface);
+        }
+
+        private static IEnumerable<Type> GetMatchingTypes(string edmFullName, IAssemblyResolver assembliesResolver)
+            => TypeHelper.GetLoadedTypes(assembliesResolver).Where(t => t.IsPublic && t.EdmFullName() == edmFullName);
+
+        private static KeyValuePair<Type, IEdmPrimitiveTypeReference> BuildTypeMapping1<T>(EdmPrimitiveTypeKind primitiveKind)
+            => new KeyValuePair<Type, IEdmPrimitiveTypeReference>(typeof(T), EdmCoreModel.Instance.GetPrimitive(primitiveKind, typeof(T).IsNullable()));
+
+        private static void BuildTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind, bool isStandard = true)
+        {
+            Type type = typeof(T);
+            bool isNullable = type.IsNullable();
+            IEdmPrimitiveTypeReference edmPrimitiveTypeReference = EdmCoreModel.Instance.GetPrimitive(primitiveKind, isNullable);
+            ClrPrimitiveTypes[type] = edmPrimitiveTypeReference;
+
+            if (isStandard)
+            {
+                IEdmPrimitiveType primitiveType = edmPrimitiveTypeReference.PrimitiveDefinition();
+                if (isNullable)
+                {
+                    // for nullable, for example System.String, we don't have non-nullable string.
+                    // so, let's save it for both.
+                    // And since we make the order un-changable, it means 'nullable' coming first.
+                    // Therefore, for simplicity, we can safe call "TryAdd".
+                    EdmPrimitiveTypes.TryAdd(primitiveType, (type, type));
+                }
+                else
+                {
+                    EdmPrimitiveTypes.AddOrUpdate(primitiveType, t => (type, null), (t, o) => (type, o.Item2));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmClrTypeMapExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmClrTypeMapExtensions.cs
@@ -6,19 +6,12 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 using Microsoft.AspNetCore.OData.Abstracts;
-using Microsoft.AspNetCore.OData.Common;
-using Microsoft.AspNetCore.OData.Deltas;
-using Microsoft.AspNetCore.OData.Query.Wrapper;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
-using Microsoft.Spatial;
 
 namespace Microsoft.AspNetCore.OData.Edm
 {
@@ -27,134 +20,75 @@ namespace Microsoft.AspNetCore.OData.Edm
     /// </summary>
     internal static class EdmClrTypeMapExtensions
     {
-        #region PrimitiveTypeMapping
         /// <summary>
-        /// The mapping between Edm primitive type and Clr primitive type.
-        /// </summary>
-        private static IDictionary<Type, IEdmPrimitiveTypeReference> _builtInPrimitiveTypes = new[]
-        {
-            BuildTypeMapping<string>(EdmPrimitiveTypeKind.String),
-            BuildTypeMapping<bool>(EdmPrimitiveTypeKind.Boolean),
-            BuildTypeMapping<bool?>(EdmPrimitiveTypeKind.Boolean),
-            BuildTypeMapping<byte>(EdmPrimitiveTypeKind.Byte),
-            BuildTypeMapping<byte?>(EdmPrimitiveTypeKind.Byte),
-            BuildTypeMapping<decimal>(EdmPrimitiveTypeKind.Decimal),
-            BuildTypeMapping<decimal?>(EdmPrimitiveTypeKind.Decimal),
-            BuildTypeMapping<double>(EdmPrimitiveTypeKind.Double),
-            BuildTypeMapping<double?>(EdmPrimitiveTypeKind.Double),
-            BuildTypeMapping<Guid>(EdmPrimitiveTypeKind.Guid),
-            BuildTypeMapping<Guid?>(EdmPrimitiveTypeKind.Guid),
-            BuildTypeMapping<short>(EdmPrimitiveTypeKind.Int16),
-            BuildTypeMapping<short?>(EdmPrimitiveTypeKind.Int16),
-            BuildTypeMapping<int>(EdmPrimitiveTypeKind.Int32),
-            BuildTypeMapping<int?>(EdmPrimitiveTypeKind.Int32),
-            BuildTypeMapping<long>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<long?>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<sbyte>(EdmPrimitiveTypeKind.SByte),
-            BuildTypeMapping<sbyte?>(EdmPrimitiveTypeKind.SByte),
-            BuildTypeMapping<float>(EdmPrimitiveTypeKind.Single),
-            BuildTypeMapping<float?>(EdmPrimitiveTypeKind.Single),
-            BuildTypeMapping<byte[]>(EdmPrimitiveTypeKind.Binary),
-            BuildTypeMapping<Stream>(EdmPrimitiveTypeKind.Stream),
-            BuildTypeMapping<DateTimeOffset>(EdmPrimitiveTypeKind.DateTimeOffset),
-            BuildTypeMapping<DateTimeOffset?>(EdmPrimitiveTypeKind.DateTimeOffset),
-            BuildTypeMapping<TimeSpan>(EdmPrimitiveTypeKind.Duration),
-            BuildTypeMapping<TimeSpan?>(EdmPrimitiveTypeKind.Duration),
-            BuildTypeMapping<Date>(EdmPrimitiveTypeKind.Date),
-            BuildTypeMapping<Date?>(EdmPrimitiveTypeKind.Date),
-            BuildTypeMapping<TimeOfDay>(EdmPrimitiveTypeKind.TimeOfDay),
-            BuildTypeMapping<TimeOfDay?>(EdmPrimitiveTypeKind.TimeOfDay),
-            BuildTypeMapping<Geography>(EdmPrimitiveTypeKind.Geography),
-            BuildTypeMapping<GeographyPoint>(EdmPrimitiveTypeKind.GeographyPoint),
-            BuildTypeMapping<GeographyLineString>(EdmPrimitiveTypeKind.GeographyLineString),
-            BuildTypeMapping<GeographyPolygon>(EdmPrimitiveTypeKind.GeographyPolygon),
-            BuildTypeMapping<GeographyCollection>(EdmPrimitiveTypeKind.GeographyCollection),
-            BuildTypeMapping<GeographyMultiLineString>(EdmPrimitiveTypeKind.GeographyMultiLineString),
-            BuildTypeMapping<GeographyMultiPoint>(EdmPrimitiveTypeKind.GeographyMultiPoint),
-            BuildTypeMapping<GeographyMultiPolygon>(EdmPrimitiveTypeKind.GeographyMultiPolygon),
-            BuildTypeMapping<Geometry>(EdmPrimitiveTypeKind.Geometry),
-            BuildTypeMapping<GeometryPoint>(EdmPrimitiveTypeKind.GeometryPoint),
-            BuildTypeMapping<GeometryLineString>(EdmPrimitiveTypeKind.GeometryLineString),
-            BuildTypeMapping<GeometryPolygon>(EdmPrimitiveTypeKind.GeometryPolygon),
-            BuildTypeMapping<GeometryCollection>(EdmPrimitiveTypeKind.GeometryCollection),
-            BuildTypeMapping<GeometryMultiLineString>(EdmPrimitiveTypeKind.GeometryMultiLineString),
-            BuildTypeMapping<GeometryMultiPoint>(EdmPrimitiveTypeKind.GeometryMultiPoint),
-            BuildTypeMapping<GeometryMultiPolygon>(EdmPrimitiveTypeKind.GeometryMultiPolygon),
-
-            // non-standard mappings
-            BuildTypeMapping<XElement>(EdmPrimitiveTypeKind.String),
-            BuildTypeMapping<ushort>(EdmPrimitiveTypeKind.Int32),
-            BuildTypeMapping<ushort?>(EdmPrimitiveTypeKind.Int32),
-            BuildTypeMapping<uint>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<uint?>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<ulong>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<ulong?>(EdmPrimitiveTypeKind.Int64),
-            BuildTypeMapping<char[]>(EdmPrimitiveTypeKind.String),
-            BuildTypeMapping<char>(EdmPrimitiveTypeKind.String),
-            BuildTypeMapping<char?>(EdmPrimitiveTypeKind.String),
-            BuildTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset),
-            BuildTypeMapping<DateTime?>(EdmPrimitiveTypeKind.DateTimeOffset)
-        }
-        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-        /// <summary>
-        /// Gets the corresponding Edm primitive type for the given CLR type.
+        /// Gets the corresponding Edm primitive type <see cref="IEdmPrimitiveTypeReference"/> for a given <see cref="Type"/> type.
         /// </summary>
         /// <param name="clrType">The given CLR type.</param>
         /// <returns>Null or the Edm primitive type.</returns>
         public static IEdmPrimitiveTypeReference GetEdmPrimitiveTypeReference(this Type clrType)
         {
-            return _builtInPrimitiveTypes.TryGetValue(clrType, out IEdmPrimitiveTypeReference primitive) ? primitive : null;
+            return DefaultODataTypeMapper.Default.GetPrimitiveType(clrType);
         }
 
         /// <summary>
-        /// Gets the corresponding Edm primitive type for the given CLR type.
+        /// Gets the corresponding Edm primitive type <see cref="IEdmPrimitiveTypeReference"/> for a given <see cref="Type"/> type.
         /// </summary>
+        /// <param name="edmModel">The Edm model.</param>
         /// <param name="clrType">The given CLR type.</param>
         /// <returns>Null or the Edm primitive type.</returns>
-        public static IEdmPrimitiveType GetEdmPrimitiveType(this Type clrType)
+        public static IEdmPrimitiveTypeReference GetEdmPrimitiveTypeReference(this IEdmModel edmModel, Type clrType)
         {
-            return _builtInPrimitiveTypes.TryGetValue(clrType, out IEdmPrimitiveTypeReference primitive) ?
-                (IEdmPrimitiveType)primitive.Definition : null;
+            if (edmModel == null || edmModel is EdmCoreModel)
+            {
+                return DefaultODataTypeMapper.Default.GetPrimitiveType(clrType);
+            }
+
+            return edmModel.GetTypeMapper().GetPrimitiveType(clrType);
         }
 
         /// <summary>
         /// Gets the corresponding CLR type for a given Edm primitive type.
         /// </summary>
+        /// <param name="edmModel">The Edm model.</param>
         /// <param name="edmPrimitiveType">The given Edm primitive type.</param>
         /// <returns>Null or the CLR type.</returns>
-        public static Type GetClrPrimitiveType(this IEdmPrimitiveTypeReference edmPrimitiveType)
+        public static Type GetClrPrimitiveType(this IEdmModel edmModel, IEdmPrimitiveTypeReference edmPrimitiveType)
         {
-            return _builtInPrimitiveTypes
-                .Where(kvp => edmPrimitiveType.Definition.IsEquivalentTo(kvp.Value.Definition) && (!edmPrimitiveType.IsNullable || IsNullable(kvp.Key)))
-                .Select(kvp => kvp.Key)
-                .FirstOrDefault();
+            if (edmPrimitiveType == null)
+            {
+                return null;
+            }
+
+            if (edmModel == null || edmModel is EdmCoreModel)
+            {
+                return DefaultODataTypeMapper.Default.GetPrimitiveType(edmPrimitiveType.PrimitiveDefinition(), edmPrimitiveType.IsNullable);
+            }
+
+            return edmModel.GetTypeMapper().GetPrimitiveType(edmPrimitiveType);
         }
 
         /// <summary>
         /// Figures out if the given clr type is nonstandard edm primitive like uint, ushort, char[] etc.
         /// and returns the corresponding clr type to which we map like uint => long.
         /// </summary>
+        /// <param name="edmModel">The Edm model.</param>
         /// <param name="clrType">The potential non-standard CLR type.</param>
         /// <param name="isNonstandardEdmPrimitive">A boolean value out to indicate whether the input CLR type is standard OData primitive type.</param>
         /// <returns>The standard CLR type or the input CLR type itself.</returns>
-        public static Type IsNonstandardEdmPrimitive(this Type clrType, out bool isNonstandardEdmPrimitive)
+        public static Type IsNonstandardEdmPrimitive(this IEdmModel edmModel, Type clrType, out bool isNonstandardEdmPrimitive)
         {
-            IEdmPrimitiveTypeReference edmType = clrType?.GetEdmPrimitiveTypeReference();
+            IEdmPrimitiveTypeReference edmType = edmModel.GetEdmPrimitiveTypeReference(clrType);
             if (edmType == null)
             {
                 isNonstandardEdmPrimitive = false;
                 return clrType;
             }
 
-            Type reverseLookupClrType = edmType.GetClrPrimitiveType();
+            Type reverseLookupClrType = edmModel.GetClrPrimitiveType(edmType);
             isNonstandardEdmPrimitive = (clrType != reverseLookupClrType);
 
             return reverseLookupClrType;
         }
-        #endregion
-
-        #region ClrType -> EdmType
 
         /// <summary>
         /// Gets the Edm type reference from the CLR type.
@@ -164,14 +98,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <returns>null or the Edm type reference.</returns>
         public static IEdmTypeReference GetEdmTypeReference(this IEdmModel edmModel, Type clrType)
         {
-            IEdmType edmType = edmModel.GetEdmType(clrType);
-            if (edmType != null)
-            {
-                bool isNullable = IsNullable(clrType);
-                return edmType.ToEdmTypeReference(isNullable);
-            }
-
-            return null;
+            return edmModel.GetTypeMapper().GetEdmTypeReference(edmModel, clrType);
         }
 
         /// <summary>
@@ -182,97 +109,8 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <returns>null or the Edm type.</returns>
         public static IEdmType GetEdmType(this IEdmModel edmModel, Type clrType)
         {
-            if (edmModel == null)
-            {
-                throw Error.ArgumentNull(nameof(edmModel));
-            }
-
-            if (clrType == null)
-            {
-                throw Error.ArgumentNull(nameof(clrType));
-            }
-
-            return GetEdmType(edmModel, clrType, testCollections: true);
+            return edmModel.GetEdmTypeReference(clrType)?.Definition;
         }
-
-        private static IEdmType GetEdmType(IEdmModel edmModel, Type clrType, bool testCollections)
-        {
-            Contract.Assert(edmModel != null);
-            Contract.Assert(clrType != null);
-
-            IEdmPrimitiveType primitiveType = clrType.GetEdmPrimitiveType();
-            if (primitiveType != null)
-            {
-                return primitiveType;
-            }
-            else
-            {
-                if (testCollections)
-                {
-                    Type entityType;
-                    if (IsDeltaSetWrapper(clrType, out entityType))
-                    {
-                        IEdmType elementType = GetEdmType(edmModel, entityType, testCollections: false);
-                        if (elementType != null)
-                        {
-                            return new EdmCollectionType(elementType.ToEdmTypeReference(IsNullable(entityType)));
-                        }
-                    }
-
-                    Type enumerableOfT = ExtractGenericInterface(clrType, typeof(IEnumerable<>));
-                    if (enumerableOfT != null)
-                    {
-                        Type elementClrType = enumerableOfT.GetGenericArguments()[0];
-
-                        // IEnumerable<SelectExpandWrapper<T>> is a collection of T.
-                        if (IsSelectExpandWrapper(elementClrType, out entityType))
-                        {
-                            elementClrType = entityType;
-                        }
-
-                        if (IsComputeWrapper(elementClrType, out entityType))
-                        {
-                            elementClrType = entityType;
-                        }
-
-                        IEdmType elementType = GetEdmType(edmModel, elementClrType, testCollections: false);
-                        if (elementType != null)
-                        {
-                            return new EdmCollectionType(elementType.ToEdmTypeReference(IsNullable(elementClrType)));
-                        }
-                    }
-                }
-
-                Type underlyingType = TypeHelper.GetUnderlyingTypeOrSelf(clrType);
-                if (TypeHelper.IsEnum(underlyingType))
-                {
-                    clrType = underlyingType;
-                }
-
-                // search for the ClrTypeAnnotation and return it if present
-                IEdmType returnType =
-                    edmModel
-                    .SchemaElements
-                    .OfType<IEdmType>()
-                    .Select(edmType => new { EdmType = edmType, Annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmType) })
-                    .Where(tuple => tuple.Annotation != null && tuple.Annotation.ClrType == clrType)
-                    .Select(tuple => tuple.EdmType)
-                    .SingleOrDefault();
-
-                // default to the EdmType with the same name as the ClrType name
-                returnType = returnType ?? edmModel.FindType(clrType.EdmFullName());
-
-                if (clrType.BaseType != null)
-                {
-                    // go up the inheritance tree to see if we have a mapping defined for the base type.
-                    returnType = returnType ?? GetEdmType(edmModel, clrType.BaseType, testCollections);
-                }
-                return returnType;
-            }
-        }
-        #endregion
-
-        #region EdmType -> ClrType
 
         /// <summary>
         /// Gets the corresponding CLR type for a given Edm type reference.
@@ -282,7 +120,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <returns>Null or the CLR type.</returns>
         public static Type GetClrType(this IEdmModel edmModel, IEdmTypeReference edmTypeReference)
         {
-            return edmModel.GetClrType(edmTypeReference, AssemblyResolverHelper.Default);
+            return edmModel.GetTypeMapper().GetClrType(edmModel, edmTypeReference, AssemblyResolverHelper.Default);
         }
 
         /// <summary>
@@ -294,99 +132,30 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <returns>Null or the CLR type.</returns>
         public static Type GetClrType(this IEdmModel edmModel, IEdmTypeReference edmTypeReference, IAssemblyResolver assembliesResolver)
         {
-            if (edmTypeReference == null)
-            {
-                throw Error.ArgumentNull(nameof(edmTypeReference));
-            }
-
-            if (edmTypeReference.IsPrimitive())
-            {
-                return GetClrPrimitiveType((IEdmPrimitiveTypeReference)edmTypeReference);
-            }
-            else
-            {
-                Type clrType = edmModel.GetClrType(edmTypeReference.Definition, assembliesResolver);
-                if (clrType != null  && clrType.IsEnum && edmTypeReference.IsNullable)
-                {
-                    return TypeHelper.ToNullable(clrType);
-                }
-
-                return clrType;
-            }
+            return edmModel.GetTypeMapper().GetClrType(edmModel, edmTypeReference, assembliesResolver);
         }
 
         /// <summary>
-        /// Gets the corresponding CLR type for a given Edm type reference.
+        /// Gets the corresponding CLR type for a given Edm type.
         /// </summary>
         /// <param name="edmModel">The Edm model.</param>
         /// <param name="edmType">The Edm type.</param>
         /// <returns>Null or the CLR type.</returns>
-        internal static Type GetClrType(this IEdmModel edmModel, IEdmType edmType)
+        public static Type GetClrType(this IEdmModel edmModel, IEdmType edmType)
         {
             return edmModel.GetClrType(edmType, AssemblyResolverHelper.Default);
         }
 
         /// <summary>
-        /// Gets the corresponding CLR type for a given Edm type reference.
+        /// Gets the corresponding CLR type for a given Edm type.
         /// </summary>
         /// <param name="edmModel">The Edm model.</param>
         /// <param name="edmType">The Edm type.</param>
         /// <param name="assembliesResolver">The assembly resolver.</param>
         /// <returns>Null or the CLR type.</returns>
-        internal static Type GetClrType(this IEdmModel edmModel, IEdmType edmType, IAssemblyResolver assembliesResolver)
+        public static Type GetClrType(this IEdmModel edmModel, IEdmType edmType, IAssemblyResolver assembliesResolver)
         {
-            if (edmType == null)
-            {
-                throw Error.ArgumentNull(nameof(edmType));
-            }
-
-            IEdmSchemaType edmSchemaType = edmType as IEdmSchemaType;
-            Contract.Assert(edmSchemaType != null);
-
-            ClrTypeAnnotation annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmSchemaType);
-            if (annotation != null)
-            {
-                return annotation.ClrType;
-            }
-
-            string typeName = edmSchemaType.FullName();
-            IEnumerable<Type> matchingTypes = GetMatchingTypes(typeName, assembliesResolver);
-
-            if (matchingTypes.Count() > 1)
-            {
-                throw Error.Argument("edmTypeReference", SRResources.MultipleMatchingClrTypesForEdmType,
-                    typeName, string.Join(",", matchingTypes.Select(type => type.AssemblyQualifiedName)));
-            }
-
-            Type type = matchingTypes.SingleOrDefault();
-            if (type == null)
-            {
-                return null;
-            }
-
-            edmModel.SetAnnotationValue(edmSchemaType, new ClrTypeAnnotation(matchingTypes.SingleOrDefault()));
-            return matchingTypes.SingleOrDefault();
-        }
-
-        #endregion
-
-        internal static ClrTypeCache GetTypeMappingCache(this IEdmModel model)
-        {
-            Contract.Assert(model != null);
-
-            ClrTypeCache typeMappingCache = model.GetAnnotationValue<ClrTypeCache>(model);
-            if (typeMappingCache == null)
-            {
-                typeMappingCache = new ClrTypeCache();
-                model.SetAnnotationValue(model, typeMappingCache);
-            }
-
-            return typeMappingCache;
-        }
-
-        private static IEnumerable<Type> GetMatchingTypes(string edmFullName, IAssemblyResolver assembliesResolver)
-        {
-            return TypeHelper.GetLoadedTypes(assembliesResolver).Where(t => t.IsPublic && t.EdmFullName() == edmFullName);
+            return edmModel.GetTypeMapper().GetClrType(edmModel, edmType, true, assembliesResolver);
         }
 
         internal static string EdmFullName(this Type clrType)
@@ -419,64 +188,6 @@ namespace Microsoft.AspNetCore.OData.Edm
                     type.Name.Replace('`', '_'),
                     String.Join("_", type.GetGenericArguments().Select(t => MangleClrTypeName(t))));
             }
-        }
-
-        private static Type ExtractGenericInterface(Type queryType, Type interfaceType)
-        {
-            Func<Type, bool> matchesInterface = t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType;
-            return matchesInterface(queryType) ? queryType : queryType.GetInterfaces().FirstOrDefault(matchesInterface);
-        }
-
-        private static bool IsDeltaSetWrapper(Type type, out Type entityType) => IsTypeWrapper(typeof(DeltaSet<>), type, out entityType);
-
-        private static bool IsSelectExpandWrapper(Type type, out Type entityType) => IsTypeWrapper(typeof(SelectExpandWrapper<>), type, out entityType);
-
-        internal static bool IsComputeWrapper(Type type, out Type entityType) => IsTypeWrapper(typeof(ComputeWrapper<>), type, out entityType);
-
-        private static bool IsTypeWrapper(Type wrappedType, Type type, out Type entityType)
-        {
-            if (type == null)
-            {
-                entityType = null;
-                return false;
-            }
-
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == wrappedType)
-            {
-                entityType = type.GetGenericArguments()[0];
-                return true;
-            }
-
-            return IsTypeWrapper(wrappedType, type.BaseType, out entityType);
-        }
-
-        private static KeyValuePair<Type, IEdmPrimitiveTypeReference> BuildTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind)
-            => new KeyValuePair<Type, IEdmPrimitiveTypeReference>(typeof(T), EdmCoreModel.Instance.GetPrimitive(primitiveKind, IsNullable<T>()));
-
-        /// <summary>
-        /// Check the input type is nullable type or not.
-        /// </summary>
-        /// <param name="type">The input CLR type.</param>
-        /// <returns>True/False.</returns>
-        private static bool IsNullable(Type type)
-        {
-            if (type == null)
-            {
-                return false;
-            }
-
-            return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
-        }
-
-        /// <summary>
-        /// Check the input type is nullable or not.
-        /// </summary>
-        /// <typeparam name="T">The test CRL type.</typeparam>
-        /// <returns>True/False.</returns>
-        private static bool IsNullable<T>()
-        {
-            Type type = typeof(T);
-            return IsNullable(type);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
@@ -262,6 +262,48 @@ namespace Microsoft.AspNetCore.OData.Edm
         }
 
         /// <summary>
+        /// Gets the OData type mapping provider from the model.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <returns>The <see cref="IODataTypeMapper"/>.</returns>
+        public static IODataTypeMapper GetTypeMapper(this IEdmModel model)
+        {
+            // use the default one if no model or no mapper registered.
+            if (model == null)
+            {
+                return DefaultODataTypeMapper.Default;
+            }
+
+            IODataTypeMapper provider = model.GetAnnotationValue<IODataTypeMapper>(model);
+            if (provider == null)
+            {
+                return DefaultODataTypeMapper.Default;
+            }
+
+            return provider;
+        }
+
+        /// <summary>
+        /// Sets the OData type mapping provider to the model.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="mapper">The given mapper.</param>
+        public static void SetTypeMapper(this IEdmModel model, IODataTypeMapper mapper)
+        {
+            if (model == null)
+            {
+                throw Error.ArgumentNull(nameof(model));
+            }
+
+            if (mapper == null)
+            {
+                throw Error.ArgumentNull(nameof(mapper));
+            }
+
+            model.SetAnnotationValue(model, mapper);
+        }
+
+        /// <summary>
         /// Gets the declared alternate keys of the most defined entity with a declared key present.
         /// Each entity type could define a set of alternate keys.
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Edm/IODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/IODataTypeMapper.cs
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataTypeMapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    /// <summary>
+    /// Provides the mapping between CLR type and Edm type.
+    /// </summary>
+    public interface IODataTypeMapper
+    {
+        /// <summary>
+        /// Gets the corresponding Edm primitive type <see cref="IEdmPrimitiveTypeReference"/> for a given <see cref="Type"/>.
+        /// </summary>
+        /// <param name="clrType">The given CLR type.</param>
+        /// <returns>Null or the Edm primitive type.</returns>
+        IEdmPrimitiveTypeReference GetPrimitiveType(Type clrType);
+
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm primitive type <see cref="IEdmPrimitiveType"/>.
+        /// </summary>
+        /// <param name="primitiveType">The given Edm primitive type.</param>
+        /// <param name="nullable">The nullable or not.</param>
+        /// <returns>Null or the CLR type.</returns>
+        Type GetPrimitiveType(IEdmPrimitiveType primitiveType, bool nullable);
+
+        /// <summary>
+        /// Gets the corresponding Edm type <see cref="IEdmTypeReference"/> for the given CLR type <see cref="Type"/>.
+        /// </summary>
+        /// <param name="edmModel">The given Edm model.</param>
+        /// <param name="clrType">The given CLR type.</param>
+        /// <returns>Null or the corresponding Edm type reference.</returns>
+        IEdmTypeReference GetEdmTypeReference(IEdmModel edmModel, Type clrType);
+
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm type <see cref="IEdmType"/>.
+        /// </summary>
+        /// <param name="edmModel">The given Edm model.</param>
+        /// <param name="edmType">The given Edm type.</param>
+        /// <param name="nullable">The nullable or not.</param>
+        /// <param name="assembliesResolver">The assembly resolver.</param>
+        /// <returns>Null or the CLR type.</returns>
+        Type GetClrType(IEdmModel edmModel, IEdmType edmType, bool nullable, IAssemblyResolver assembliesResolver);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/IODataTypeMapperExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/IODataTypeMapperExtensions.cs
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataTypeMapperExtensions.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    /// <summary>
+    /// Extension methods for <see cref="IODataTypeMapper"/>.
+    /// </summary>
+    public static class IODataTypeMapperExtensions
+    {
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm primitive type <see cref="IEdmPrimitiveTypeReference"/>.
+        /// </summary>
+        /// <param name="mapper">The type mapper.</param>
+        /// <param name="primitiveType">The Edm primitive type reference.</param>
+        /// <returns>Null or the CLR type.</returns>
+        public static Type GetPrimitiveType(this IODataTypeMapper mapper, IEdmPrimitiveTypeReference primitiveType)
+        {
+            if (mapper == null)
+            {
+                throw Error.ArgumentNull(nameof(mapper));
+            }
+
+            if (primitiveType == null)
+            {
+                throw Error.ArgumentNull(nameof(primitiveType));
+            }
+
+            return mapper.GetPrimitiveType(primitiveType.PrimitiveDefinition(), primitiveType.IsNullable);
+        }
+
+        /// <summary>
+        /// Gets the corresponding Edm type <see cref="IEdmType"/> for the given CLR type <see cref="Type"/>.
+        /// </summary>
+        /// <param name="mapper">The type mapper.</param>
+        /// <param name="edmModel">The given Edm model.</param>
+        /// <param name="clrType">The given CLR type.</param>
+        /// <returns>Null or the corresponding Edm type.</returns>
+        public static IEdmType GetEdmType(this IODataTypeMapper mapper, IEdmModel edmModel, Type clrType)
+        {
+            if (mapper == null)
+            {
+                throw Error.ArgumentNull(nameof(mapper));
+            }
+
+            return mapper.GetEdmTypeReference(edmModel, clrType)?.Definition;
+        }
+
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm type <see cref="IEdmTypeReference"/>.
+        /// </summary>
+        /// <param name="mapper">The type mapper.</param>
+        /// <param name="edmModel">The Edm model.</param>
+        /// <param name="edmType">The Edm type reference.</param>
+        /// <returns>Null or the CLR type.</returns>
+        public static Type GetClrType(this IODataTypeMapper mapper, IEdmModel edmModel, IEdmTypeReference edmType)
+        {
+            return mapper.GetClrType(edmModel, edmType, AssemblyResolverHelper.Default);
+        }
+
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> for a given Edm type <see cref="IEdmTypeReference"/>.
+        /// </summary>
+        /// <param name="mapper">The type mapper.</param>
+        /// <param name="edmModel">The Edm model.</param>
+        /// <param name="edmType">The Edm type.</param>
+        /// <param name="assembliesResolver">The assembly resolver.</param>
+        /// <returns>Null or the CLR type.</returns>
+        public static Type GetClrType(this IODataTypeMapper mapper, IEdmModel edmModel, IEdmTypeReference edmType, IAssemblyResolver assembliesResolver)
+        {
+            if (mapper == null)
+            {
+                throw Error.ArgumentNull(nameof(mapper));
+            }
+
+            if (edmType == null)
+            {
+                throw Error.ArgumentNull(nameof(edmType));
+            }
+
+            return mapper.GetClrType(edmModel, edmType.Definition, edmType.IsNullable, assembliesResolver);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/TypeCacheItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/TypeCacheItem.cs
@@ -1,0 +1,84 @@
+//-----------------------------------------------------------------------------
+// <copyright file="TypeCacheItem.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    internal class TypeCacheItem
+    {
+        #region ClrType => EdmType
+        /// <summary>
+        /// <see cref="Type"/> to <see cref="IEdmTypeReference"/>.
+        /// </summary>
+        public ConcurrentDictionary<Type, IEdmTypeReference> ClrToEdmTypeCache = new ConcurrentDictionary<Type, IEdmTypeReference>();
+
+        public bool TryFindEdmType(Type clrType, out IEdmTypeReference edmType)
+        {
+            edmType = null;
+            if (clrType == null)
+            {
+                return false;
+            }
+
+            return ClrToEdmTypeCache.TryGetValue(clrType, out edmType);
+        }
+
+        public void AddClrToEdmMap(Type clrType, IEdmTypeReference edmType)
+        {
+            ClrToEdmTypeCache[clrType] = edmType;
+        }
+        #endregion
+
+        #region EdmType => ClrType
+        /// <summary>
+        /// <see cref="IEdmType"/> to <see cref="Type"/>.
+        /// item1: non-nullable
+        /// item2: nullable
+        /// </summary>
+        public ConcurrentDictionary<IEdmType, (Type, Type)> EdmToClrTypeCache = new ConcurrentDictionary<IEdmType, (Type, Type)>();
+
+        public bool TryFindClrType(IEdmType edmType, bool isNullable, out Type clrType)
+        {
+            if (edmType == null)
+            {
+                clrType = null;
+                return false;
+            }
+
+            clrType = null;
+            if (EdmToClrTypeCache.TryGetValue(edmType, out (Type, Type) clrTypes))
+            {
+                if (isNullable)
+                {
+                    clrType = clrTypes.Item2;
+                }
+                else
+                {
+                    clrType = clrTypes.Item1;
+                }
+            }
+
+            return clrType != null;
+        }
+
+        public void AddEdmToClrMap(IEdmType edmType, bool isNullable, Type clrType)
+        {
+            if (isNullable)
+            {
+                EdmToClrTypeCache.AddOrUpdate(edmType, (null, clrType), (k, v) => (v.Item1, clrType));
+            }
+            else
+            {
+                EdmToClrTypeCache.AddOrUpdate(edmType, (clrType, null), (k, v) => (clrType, v.Item2));
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/TypeCacheItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/TypeCacheItem.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <summary>
         /// <see cref="Type"/> to <see cref="IEdmTypeReference"/>.
         /// </summary>
-        public ConcurrentDictionary<Type, IEdmTypeReference> ClrToEdmTypeCache = new ConcurrentDictionary<Type, IEdmTypeReference>();
+        public ConcurrentDictionary<Type, IEdmTypeReference> ClrToEdmTypeCache { get; } = new ConcurrentDictionary<Type, IEdmTypeReference>();
 
         public bool TryFindEdmType(Type clrType, out IEdmTypeReference edmType)
         {
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// item1: non-nullable
         /// item2: nullable
         /// </summary>
-        public ConcurrentDictionary<IEdmType, (Type, Type)> EdmToClrTypeCache = new ConcurrentDictionary<IEdmType, (Type, Type)>();
+        public ConcurrentDictionary<IEdmType, (Type, Type)> EdmToClrTypeCache { get; } = new ConcurrentDictionary<IEdmType, (Type, Type)>();
 
         public bool TryFindClrType(IEdmType edmType, bool isNullable, out Type clrType)
         {

--- a/src/Microsoft.AspNetCore.OData/Formatter/ConventionsHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ConventionsHelpers.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 throw Error.InvalidOperation(SRResources.KeyValueCannotBeNull, key.Name, edmType.Definition);
             }
 
-            return ConvertValue(value, resourceContext.TimeZone);
+            return ConvertValue(value, resourceContext.TimeZone, resourceContext.EdmModel);
         }
 
-        public static object ConvertValue(object value, TimeZoneInfo timeZone)
+        public static object ConvertValue(object value, TimeZoneInfo timeZone, IEdmModel model)
         {
             Contract.Assert(value != null);
 
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
             else
             {
-                Contract.Assert(type.GetEdmPrimitiveType() != null);
+                Contract.Assert(model.GetEdmPrimitiveTypeReference(type) != null);
                 value = ODataPrimitiveSerializer.ConvertUnsupportedPrimitives(value, timeZone);
             }
 
@@ -113,7 +113,6 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
             else
             {
-                Contract.Assert(type.GetEdmPrimitiveType() != null);
                 value = ODataPrimitiveSerializer.ConvertUnsupportedPrimitives(value, timeZone);
             }
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -103,15 +103,15 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             }
         }
 
-        internal static void SetCollectionProperty(object resource, IEdmProperty edmProperty, object value, string propertyName, TimeZoneInfo timeZoneInfo = null)
+        internal static void SetCollectionProperty(object resource, IEdmProperty edmProperty, object value, string propertyName, ODataDeserializerContext context = null)
         {
             Contract.Assert(edmProperty != null);
 
-            SetCollectionProperty(resource, propertyName, edmProperty.Type.AsCollection(), value, clearCollection: false, timeZoneInfo: timeZoneInfo);
+            SetCollectionProperty(resource, propertyName, edmProperty.Type.AsCollection(), value, clearCollection: false, context: context);
         }
 
         internal static void SetCollectionProperty(object resource, string propertyName,
-            IEdmCollectionTypeReference edmPropertyType, object value, bool clearCollection, TimeZoneInfo timeZoneInfo = null)
+            IEdmCollectionTypeReference edmPropertyType, object value, bool clearCollection, ODataDeserializerContext context = null)
         {
             if (value != null)
             {
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     CollectionDeserializationHelpers.TryCreateInstance(propertyType, edmPropertyType, elementType, out newCollection))
                 {
                     // settable collections
-                    collection.AddToCollection(newCollection, elementType, resourceType, propertyName, propertyType, timeZoneInfo);
+                    collection.AddToCollection(newCollection, elementType, resourceType, propertyName, propertyType, context);
                     if (propertyType.IsArray)
                     {
                         newCollection = CollectionDeserializationHelpers.ToArray(newCollection, elementType);
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                         newCollection.Clear(propertyName, resourceType);
                     }
 
-                    collection.AddToCollection(newCollection, elementType, resourceType, propertyName, propertyType, timeZoneInfo);
+                    collection.AddToCollection(newCollection, elementType, resourceType, propertyName, propertyType, context);
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerProvider.cs
@@ -103,11 +103,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             }
 
             IEdmModel model = request.GetModel();
-            //IODataTypeMappingProvider typeMappingProvider = _serviceProvider.GetRequiredService<IODataTypeMappingProvider>();
-
-            ClrTypeCache typeMappingCache = model.GetTypeMappingCache();
-            IEdmTypeReference edmType = typeMappingCache.GetEdmType(type, model);
-            //IEdmTypeReference edmType = typeMappingProvider.GetEdmType(model, type);
+            IEdmTypeReference edmType = model.GetEdmTypeReference(type);
 
             if (edmType == null)
             {

--- a/src/Microsoft.AspNetCore.OData/Formatter/EdmLibHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/EdmLibHelper.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             else
             {
                 TryGetInnerTypeForDelta(ref type);
-                expectedPayloadType = model.GetTypeMappingCache().GetEdmType(type, model);
+                expectedPayloadType = model.GetEdmTypeReference(type);
             }
 
             return expectedPayloadType;

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinder.cs
@@ -86,7 +86,8 @@ namespace Microsoft.AspNetCore.OData.Formatter
 
                         HttpRequest request = bindingContext.HttpContext.Request;
                         TimeZoneInfo timeZone = request.GetTimeZoneInfo();
-                        object model = ODataModelBinderConverter.ConvertTo(valueProviderResult.FirstValue, bindingContext.ModelType, timeZone);
+                        IEdmModel edmModel = request.GetModel();
+                        object model = ODataModelBinderConverter.ConvertTo(valueProviderResult.FirstValue, bindingContext.ModelType, timeZone, edmModel);
                         if (model != null)
                         {
                             bindingContext.Result = ModelBindingResult.Success(model);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             return ConvertResourceOrResourceSet(graph, edmTypeReference, readContext);
         }
 
-        internal static object ConvertTo(string valueString, Type type, TimeZoneInfo timeZone)
+        internal static object ConvertTo(string valueString, Type type, TimeZoneInfo timeZone, IEdmModel edmModel = null)
         {
             if (valueString == null)
             {
@@ -137,8 +137,8 @@ namespace Microsoft.AspNetCore.OData.Formatter
             // can return the correct Date object.
             if (type == typeof(Date) || type == typeof(Date?))
             {
-                EdmCoreModel model = EdmCoreModel.Instance;
-                IEdmPrimitiveTypeReference dateTypeReference = type.GetEdmPrimitiveTypeReference();
+                IEdmModel model = edmModel ?? EdmCoreModel.Instance;
+                IEdmPrimitiveTypeReference dateTypeReference = model.GetEdmPrimitiveTypeReference(type);
                 return ODataUriUtils.ConvertFromUriLiteral(valueString, ODataVersion.V4, model, dateTypeReference);
             }
 
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
 
             bool isNonStandardEdmPrimitive;
-            type.IsNonstandardEdmPrimitive(out isNonStandardEdmPrimitive);
+            edmModel.IsNonstandardEdmPrimitive(type, out isNonStandardEdmPrimitive);
 
             if (isNonStandardEdmPrimitive)
             {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
@@ -303,14 +303,13 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                     throw Error.InvalidOperation(SRResources.RequestMustHaveModel);
                 }
 
-                var typeMappingCache = Model.GetTypeMappingCache();
-                edmType = typeMappingCache.GetEdmType(type, Model);
+                edmType = Model.GetEdmTypeReference(type);
 
                 if (edmType == null)
                 {
                     if (instance != null)
                     {
-                        edmType = typeMappingCache.GetEdmType(instance.GetType(), Model);
+                        edmType = Model.GetEdmTypeReference(instance.GetType());
                     }
 
                     if (edmType == null)
@@ -320,7 +319,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 }
                 else if (instance != null)
                 {
-                    IEdmTypeReference actualType = typeMappingCache.GetEdmType(instance.GetType(), Model);
+                    IEdmTypeReference actualType = Model.GetEdmTypeReference(instance.GetType());
                     if (actualType != null && actualType != edmType)
                     {
                         edmType = actualType;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerProvider.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerProvider.cs
@@ -123,8 +123,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             IEdmModel model = request.GetModel();
 
             // if it is not a special type, assume it has a corresponding EdmType.
-            ClrTypeCache typeMappingCache = model.GetTypeMappingCache();
-            IEdmTypeReference edmType = typeMappingCache.GetEdmType(type, model);
+            IEdmTypeReference edmType = model.GetEdmTypeReference(type);
 
             if (edmType != null)
             {

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1920,42 +1920,109 @@
             <param name="methodInfo">The output of method info.</param>
             <returns>True if the method info was found, false otherwise.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper">
+            <summary>
+            The default implementation for <see cref="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.Default">
+            <summary>
+            Creates a static instance for the Default type mapper.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.ClrPrimitiveTypes">
+            <summary>
+            The default mapping between Edm primitive type and Clr primitive type.
+            Primitive types are cross Edm models.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.EdmPrimitiveTypes">
+            <summary>
+            Item1 --> non-nullable
+            Item2 --> nullable
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetPrimitiveType(System.Type)">
+            <summary>
+            Gets the corresponding Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/> for a given <see cref="T:System.Type"/> type.
+            </summary>
+            <param name="clrType">The given CLR type.</param>
+            <returns>Null or the Edm primitive type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveType,System.Boolean)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> type for a given Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/>.
+            </summary>
+            <param name="primitiveType">The given Edm primitive type.</param>
+            <param name="nullable">The nullable or not.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper._cache">
+            <summary>
+            The cache used to hold the type mapping between <see cref="T:System.Type"/> and <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetEdmTypeReference(Microsoft.OData.Edm.IEdmModel,System.Type)">
+            <summary>
+            Gets the corresponding Edm type <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/> for the given CLR type <see cref="T:System.Type"/>.
+            </summary>
+            <param name="edmModel">The given Edm model.</param>
+            <param name="clrType">The given CLR type.</param>
+            <returns>Null or the corresponding Edm type reference.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetClrType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmType,System.Boolean,Microsoft.OData.ModelBuilder.IAssemblyResolver)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm type <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
+            </summary>
+            <param name="edmModel">The Edm model.</param>
+            <param name="edmType">The Edm type.</param>
+            <param name="nullable">The nullable or not.</param>
+            <param name="assembliesResolver">The assembly resolver. if it's null, will use the default resolver.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.FindClrType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmType,Microsoft.OData.ModelBuilder.IAssemblyResolver)">
+            <summary>
+            Finds the corresponding CLR type for a given Edm type reference.
+            </summary>
+            <param name="edmModel">The Edm model.</param>
+            <param name="edmType">The Edm type.</param>
+            <param name="assembliesResolver">The assembly resolver.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions">
             <summary>
             The extensions used to map between C# types and Edm types.
             </summary>
         </member>
-        <member name="F:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions._builtInPrimitiveTypes">
-            <summary>
-            The mapping between Edm primitive type and Clr primitive type.
-            </summary>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetEdmPrimitiveTypeReference(System.Type)">
             <summary>
-            Gets the corresponding Edm primitive type for the given CLR type.
+            Gets the corresponding Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/> for a given <see cref="T:System.Type"/> type.
             </summary>
             <param name="clrType">The given CLR type.</param>
             <returns>Null or the Edm primitive type.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetEdmPrimitiveType(System.Type)">
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetEdmPrimitiveTypeReference(Microsoft.OData.Edm.IEdmModel,System.Type)">
             <summary>
-            Gets the corresponding Edm primitive type for the given CLR type.
+            Gets the corresponding Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/> for a given <see cref="T:System.Type"/> type.
             </summary>
+            <param name="edmModel">The Edm model.</param>
             <param name="clrType">The given CLR type.</param>
             <returns>Null or the Edm primitive type.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetClrPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveTypeReference)">
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetClrPrimitiveType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmPrimitiveTypeReference)">
             <summary>
             Gets the corresponding CLR type for a given Edm primitive type.
             </summary>
+            <param name="edmModel">The Edm model.</param>
             <param name="edmPrimitiveType">The given Edm primitive type.</param>
             <returns>Null or the CLR type.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.IsNonstandardEdmPrimitive(System.Type,System.Boolean@)">
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.IsNonstandardEdmPrimitive(Microsoft.OData.Edm.IEdmModel,System.Type,System.Boolean@)">
             <summary>
             Figures out if the given clr type is nonstandard edm primitive like uint, ushort, char[] etc.
             and returns the corresponding clr type to which we map like uint => long.
             </summary>
+            <param name="edmModel">The Edm model.</param>
             <param name="clrType">The potential non-standard CLR type.</param>
             <param name="isNonstandardEdmPrimitive">A boolean value out to indicate whether the input CLR type is standard OData primitive type.</param>
             <returns>The standard CLR type or the input CLR type itself.</returns>
@@ -1995,7 +2062,7 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetClrType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmType)">
             <summary>
-            Gets the corresponding CLR type for a given Edm type reference.
+            Gets the corresponding CLR type for a given Edm type.
             </summary>
             <param name="edmModel">The Edm model.</param>
             <param name="edmType">The Edm type.</param>
@@ -2003,26 +2070,12 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.GetClrType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmType,Microsoft.OData.ModelBuilder.IAssemblyResolver)">
             <summary>
-            Gets the corresponding CLR type for a given Edm type reference.
+            Gets the corresponding CLR type for a given Edm type.
             </summary>
             <param name="edmModel">The Edm model.</param>
             <param name="edmType">The Edm type.</param>
             <param name="assembliesResolver">The assembly resolver.</param>
             <returns>Null or the CLR type.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.IsNullable(System.Type)">
-            <summary>
-            Check the input type is nullable type or not.
-            </summary>
-            <param name="type">The input CLR type.</param>
-            <returns>True/False.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmClrTypeMapExtensions.IsNullable``1">
-            <summary>
-            Check the input type is nullable or not.
-            </summary>
-            <typeparam name="T">The test CRL type.</typeparam>
-            <returns>True/False.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.EdmHelpers">
             <summary>
@@ -2117,6 +2170,20 @@
             </summary>
             <param name="model">The Edm model.</param>
             <param name="name">The Edm model name.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetTypeMapper(Microsoft.OData.Edm.IEdmModel)">
+            <summary>
+            Gets the OData type mapping provider from the model.
+            </summary>
+            <param name="model">The Edm model.</param>
+            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.SetTypeMapper(Microsoft.OData.Edm.IEdmModel,Microsoft.AspNetCore.OData.Edm.IODataTypeMapper)">
+            <summary>
+            Sets the OData type mapping provider to the model.
+            </summary>
+            <param name="model">The Edm model.</param>
+            <param name="mapper">The given mapper.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetAlternateKeys(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmEntityType)">
             <summary>
@@ -2344,6 +2411,85 @@
             <summary>
             Gets the whole expand path.
             </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper">
+            <summary>
+            Provides the mapping between CLR type and Edm type.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetPrimitiveType(System.Type)">
+            <summary>
+            Gets the corresponding Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/> for a given <see cref="T:System.Type"/>.
+            </summary>
+            <param name="clrType">The given CLR type.</param>
+            <returns>Null or the Edm primitive type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveType,System.Boolean)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveType"/>.
+            </summary>
+            <param name="primitiveType">The given Edm primitive type.</param>
+            <param name="nullable">The nullable or not.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetEdmTypeReference(Microsoft.OData.Edm.IEdmModel,System.Type)">
+            <summary>
+            Gets the corresponding Edm type <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/> for the given CLR type <see cref="T:System.Type"/>.
+            </summary>
+            <param name="edmModel">The given Edm model.</param>
+            <param name="clrType">The given CLR type.</param>
+            <returns>Null or the corresponding Edm type reference.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetClrType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmType,System.Boolean,Microsoft.OData.ModelBuilder.IAssemblyResolver)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm type <see cref="T:Microsoft.OData.Edm.IEdmType"/>.
+            </summary>
+            <param name="edmModel">The given Edm model.</param>
+            <param name="edmType">The given Edm type.</param>
+            <param name="nullable">The nullable or not.</param>
+            <param name="assembliesResolver">The assembly resolver.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions">
+            <summary>
+            Extension methods for <see cref="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetPrimitiveType(Microsoft.AspNetCore.OData.Edm.IODataTypeMapper,Microsoft.OData.Edm.IEdmPrimitiveTypeReference)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm primitive type <see cref="T:Microsoft.OData.Edm.IEdmPrimitiveTypeReference"/>.
+            </summary>
+            <param name="mapper">The type mapper.</param>
+            <param name="primitiveType">The Edm primitive type reference.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetEdmType(Microsoft.AspNetCore.OData.Edm.IODataTypeMapper,Microsoft.OData.Edm.IEdmModel,System.Type)">
+            <summary>
+            Gets the corresponding Edm type <see cref="T:Microsoft.OData.Edm.IEdmType"/> for the given CLR type <see cref="T:System.Type"/>.
+            </summary>
+            <param name="mapper">The type mapper.</param>
+            <param name="edmModel">The given Edm model.</param>
+            <param name="clrType">The given CLR type.</param>
+            <returns>Null or the corresponding Edm type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetClrType(Microsoft.AspNetCore.OData.Edm.IODataTypeMapper,Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmTypeReference)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm type <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.
+            </summary>
+            <param name="mapper">The type mapper.</param>
+            <param name="edmModel">The Edm model.</param>
+            <param name="edmType">The Edm type reference.</param>
+            <returns>Null or the CLR type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetClrType(Microsoft.AspNetCore.OData.Edm.IODataTypeMapper,Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.OData.ModelBuilder.IAssemblyResolver)">
+            <summary>
+            Gets the corresponding <see cref="T:System.Type"/> for a given Edm type <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.
+            </summary>
+            <param name="mapper">The type mapper.</param>
+            <param name="edmModel">The Edm model.</param>
+            <param name="edmType">The Edm type.</param>
+            <param name="assembliesResolver">The assembly resolver.</param>
+            <returns>Null or the CLR type.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.ModelNameAnnotation">
             <summary>
@@ -2582,6 +2728,18 @@
         <member name="P:Microsoft.AspNetCore.OData.Edm.SelfLinkBuilder`1.FollowsConventions">
             <summary>
             Gets a boolean indicating whether the link factory follows OData conventions or not.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.ClrToEdmTypeCache">
+            <summary>
+            <see cref="T:System.Type"/> to <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.EdmToClrTypeCache">
+            <summary>
+            <see cref="T:Microsoft.OData.Edm.IEdmType"/> to <see cref="T:System.Type"/>.
+            item1: non-nullable
+            item2: nullable
             </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2730,12 +2730,12 @@
             Gets a boolean indicating whether the link factory follows OData conventions or not.
             </summary>
         </member>
-        <member name="F:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.ClrToEdmTypeCache">
+        <member name="P:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.ClrToEdmTypeCache">
             <summary>
             <see cref="T:System.Type"/> to <see cref="T:Microsoft.OData.Edm.IEdmTypeReference"/>.
             </summary>
         </member>
-        <member name="F:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.EdmToClrTypeCache">
+        <member name="P:Microsoft.AspNetCore.OData.Edm.TypeCacheItem.EdmToClrTypeCache">
             <summary>
             <see cref="T:Microsoft.OData.Edm.IEdmType"/> to <see cref="T:System.Type"/>.
             item1: non-nullable

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1481,7 +1481,6 @@ static Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.IsODataIgnore
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.GetAttribute<T>(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> T
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.HasAttribute<T>(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> bool
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.IsODataIgnored(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> bool
-static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.GetTypeMappingProvider(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Edm.IODataTypeMapper
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataBatchFeature(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Abstracts.IODataBatchFeature
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataFeature(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Abstracts.IODataFeature
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataOptions(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.ODataOptions

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -222,6 +222,8 @@ Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation
 Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation.AddMethod(string methodToken, System.Collections.Generic.IDictionary<System.Type, System.Reflection.MethodInfo> methods) -> Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation
 Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation.CustomAggregateMethodAnnotation() -> void
 Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation.GetMethodInfo(string methodToken, System.Type returnType, out System.Reflection.MethodInfo methodInfo) -> bool
+Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper
+Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.DefaultODataTypeMapper() -> void
 Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions
 Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks
@@ -232,6 +234,12 @@ Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.IdLink.get -> System.Uri
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.IdLink.set -> void
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.ReadLink.get -> System.Uri
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.ReadLink.set -> void
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapper
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetClrType(Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver) -> System.Type
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetEdmTypeReference(Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType) -> Microsoft.OData.Edm.IEdmTypeReference
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable) -> System.Type
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetPrimitiveType(System.Type clrType) -> Microsoft.OData.Edm.IEdmPrimitiveTypeReference
+Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions
 Microsoft.AspNetCore.OData.Edm.ModelNameAnnotation
 Microsoft.AspNetCore.OData.Edm.ModelNameAnnotation.ModelName.get -> string
 Microsoft.AspNetCore.OData.Edm.ModelNameAnnotation.ModelNameAnnotation(string name) -> void
@@ -1450,7 +1458,9 @@ static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetClrPropert
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetConcurrencyProperties(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmNavigationSource navigationSource) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmStructuralProperty>
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetDynamicPropertyDictionary(this Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmStructuredType edmType) -> System.Reflection.PropertyInfo
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetModelName(this Microsoft.OData.Edm.IEdmModel model) -> string
+static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetTypeMapper(this Microsoft.OData.Edm.IEdmModel model) -> Microsoft.AspNetCore.OData.Edm.IODataTypeMapper
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.SetModelName(this Microsoft.OData.Edm.IEdmModel model, string name) -> void
+static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.SetTypeMapper(this Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper) -> void
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.GetNavigationSourceLinkBuilder(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmNavigationSource navigationSource) -> Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.GetOperationLinkBuilder(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperation operation) -> Microsoft.AspNetCore.OData.Edm.OperationLinkBuilder
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.HasEditLink(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.AspNetCore.OData.Edm.SelfLinkBuilder<System.Uri> editLinkBuilder) -> void
@@ -1459,6 +1469,10 @@ static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.HasNavigatio
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.HasReadLink(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.AspNetCore.OData.Edm.SelfLinkBuilder<System.Uri> readLinkBuilder) -> void
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.SetNavigationSourceLinkBuilder(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation navigationSourceLinkBuilder) -> void
 static Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions.SetOperationLinkBuilder(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperation operation, Microsoft.AspNetCore.OData.Edm.OperationLinkBuilder operationLinkBuilder) -> void
+static Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetClrType(this Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType) -> System.Type
+static Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetClrType(this Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver) -> System.Type
+static Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetEdmType(this Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType) -> Microsoft.OData.Edm.IEdmType
+static Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions.GetPrimitiveType(this Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType) -> System.Type
 static Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.AddSelector(this Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, string httpMethods, string prefix, Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Routing.Template.ODataPathTemplate path, Microsoft.AspNetCore.OData.Routing.ODataRouteOptions options = null) -> void
 static Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.GetAttribute<T>(this Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action) -> T
 static Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.HasODataKeyParameter(this Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel action, Microsoft.OData.Edm.IEdmEntityType entityType, string keyPrefix = "key") -> bool
@@ -1467,6 +1481,7 @@ static Microsoft.AspNetCore.OData.Extensions.ActionModelExtensions.IsODataIgnore
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.GetAttribute<T>(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> T
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.HasAttribute<T>(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> bool
 static Microsoft.AspNetCore.OData.Extensions.ControllerModelExtensions.IsODataIgnored(this Microsoft.AspNetCore.Mvc.ApplicationModels.ControllerModel controller) -> bool
+static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.GetTypeMappingProvider(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Edm.IODataTypeMapper
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataBatchFeature(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Abstracts.IODataBatchFeature
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataFeature(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.Abstracts.IODataFeature
 static Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions.ODataOptions(this Microsoft.AspNetCore.Http.HttpContext httpContext) -> Microsoft.AspNetCore.OData.ODataOptions
@@ -1555,6 +1570,10 @@ virtual Microsoft.AspNetCore.OData.Batch.UnbufferedODataBatchHandler.ExecuteChan
 virtual Microsoft.AspNetCore.OData.Batch.UnbufferedODataBatchHandler.ExecuteOperationAsync(Microsoft.OData.ODataBatchReader batchReader, System.Guid batchId, Microsoft.AspNetCore.Http.HttpRequest originalRequest, Microsoft.AspNetCore.Http.RequestDelegate handler) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem>
 virtual Microsoft.AspNetCore.OData.Deltas.Delta<T>.ExpectedClrType.get -> System.Type
 virtual Microsoft.AspNetCore.OData.Deltas.Delta<T>.StructuredType.get -> System.Type
+virtual Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetClrType(Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver) -> System.Type
+virtual Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetEdmTypeReference(Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType) -> Microsoft.OData.Edm.IEdmTypeReference
+virtual Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable) -> System.Type
+virtual Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper.GetPrimitiveType(System.Type clrType) -> Microsoft.OData.Edm.IEdmPrimitiveTypeReference
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildEditLink(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel, System.Uri idLink) -> System.Uri
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildEntitySelfLinks(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel) -> Microsoft.AspNetCore.OData.Edm.EntitySelfLinks
 virtual Microsoft.AspNetCore.OData.Edm.NavigationSourceLinkBuilderAnnotation.BuildIdLink(Microsoft.AspNetCore.OData.Formatter.ResourceContext instanceContext, Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel metadataLevel) -> System.Uri

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -88,9 +88,7 @@ namespace Microsoft.AspNetCore.OData.Query
                     return;
                 }
 
-                Type clrType = edmModel.GetTypeMappingCache().GetClrType(
-                    elementType.ToEdmTypeReference(isNullable: false),
-                    edmModel);
+                Type clrType = edmModel.GetClrType(elementType.ToEdmTypeReference(isNullable: false));
 
                 // CLRType can be missing if untyped registrations were made.
                 if (clrType != null)
@@ -726,7 +724,7 @@ namespace Microsoft.AspNetCore.OData.Query
             {
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
-            IEdmType edmType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition;
+            IEdmType edmType = model.GetEdmTypeReference(elementClrType)?.Definition;
 
             IEdmStructuredType structuredType = edmType as IEdmStructuredType;
             ODataPath path = request.ODataFeature().Path;

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/AggregationBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/AggregationBinder.cs
@@ -104,7 +104,10 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             }
 
             var customMethod = GetCustomMethod(expression);
-            var typeReference = customMethod.ReturnType.GetEdmPrimitiveTypeReference();
+
+            // var typeReference = customMethod.ReturnType.GetEdmPrimitiveTypeReference();
+            var typeReference = Model.GetEdmPrimitiveTypeReference(customMethod.ReturnType);
+
             return new AggregateExpression(expression.Expression, expression.MethodDefinition, expression.Alias, typeReference);
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
@@ -337,10 +337,10 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 return FalseConstant;
             }
 
-            bool isSourcePrimitiveOrEnum = source.Type.GetEdmPrimitiveType() != null ||
+            bool isSourcePrimitiveOrEnum = Model.GetEdmPrimitiveTypeReference(source.Type) != null ||
                                            TypeHelper.IsEnum(source.Type);
 
-            bool isTargetPrimitiveOrEnum = clrType.GetEdmPrimitiveType() != null ||
+            bool isTargetPrimitiveOrEnum = Model.GetEdmPrimitiveTypeReference(clrType) != null ||
                                            TypeHelper.IsEnum(clrType);
 
             if (isSourcePrimitiveOrEnum && isTargetPrimitiveOrEnum)
@@ -731,7 +731,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                     }
 
                     if ((!targetEdmTypeReference.IsPrimitive() && !targetEdmTypeReference.IsEnum()) ||
-                        (source.Type.GetEdmPrimitiveType() == null && !TypeHelper.IsEnum(source.Type)))
+                        (Model.GetEdmPrimitiveTypeReference(source.Type) == null && !TypeHelper.IsEnum(source.Type)))
                     {
                         // Cast fails and return null.
                         return NullConstant;
@@ -1065,7 +1065,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
         internal Expression ConvertNonStandardPrimitives(Expression source)
         {
             bool isNonstandardEdmPrimitive;
-            Type conversionType = source.Type.IsNonstandardEdmPrimitive(out isNonstandardEdmPrimitive);
+            Type conversionType = Model.IsNonstandardEdmPrimitive(source.Type, out isNonstandardEdmPrimitive);
 
             if (isNonstandardEdmPrimitive)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
@@ -154,8 +154,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                         case ExpressionType.NotEqual:
                             return Expression.MakeBinary(binaryExpressionType, left, right, liftToNull, method: Linq2ObjectsComparisonMethods.AreByteArraysNotEqualMethodInfo);
                         default:
-                            IEdmPrimitiveType binaryType = typeof(byte[]).GetEdmPrimitiveType();
-                            throw new ODataException(Error.Format(SRResources.BinaryOperatorNotSupported, binaryType.FullName(), binaryType.FullName(), binaryOperator));
+                            throw new ODataException(Error.Format(SRResources.BinaryOperatorNotSupported, "Edm.Binary", "Edm.Binary", binaryOperator));
                     }
                 }
                 else

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 throw Error.ArgumentNull(nameof(elementClrType));
             }
 
-            ElementType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition;
+            ElementType = model.GetEdmTypeReference(elementClrType)?.Definition;
 
             if (ElementType == null)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.OData.Query
             }
 
             Type clrType = value.GetType();
-            return model.GetTypeMappingCache().GetEdmType(clrType, model)?.Definition;
+            return model.GetEdmTypeReference(clrType)?.Definition;
         }
 
         private static IList<string> ParseValue(string value, char delim)

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
 
             Type elementType = GetElementType();
 
-            return model.GetTypeMappingCache().GetEdmType(elementType, model);
+            return model.GetEdmTypeReference(elementType);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.OData.Results
         private static IEdmEntityTypeReference GetEntityType(IEdmModel model, object entity)
         {
             Type entityType = entity.GetType();
-            IEdmTypeReference edmType = model.GetTypeMappingCache().GetEdmType(entityType, model);
+            IEdmTypeReference edmType = model.GetEdmTypeReference(entityType);
             if (edmType == null)
             {
                 throw Error.InvalidOperation(SRResources.ResourceTypeNotInModel, entityType.FullName);

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
@@ -1,0 +1,523 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DefaultODataTypeMapperTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Tests.Commons;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Microsoft.Spatial;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Edm
+{
+    public class DefaultODataTypeMapperTests
+    {
+        private static IEdmModel EdmModel = GetEdmModel();
+        private DefaultODataTypeMapper _mapper = new DefaultODataTypeMapper();
+
+        #region PrimitiveType
+        [Theory]
+        [InlineData(typeof(string), "Edm.String", true)]
+        [InlineData(typeof(bool), "Edm.Boolean", false)]
+        [InlineData(typeof(bool?), "Edm.Boolean", true)]
+        [InlineData(typeof(byte), "Edm.Byte", false)]
+        [InlineData(typeof(byte?), "Edm.Byte", true)]
+        [InlineData(typeof(decimal), "Edm.Decimal", false)]
+        [InlineData(typeof(decimal?), "Edm.Decimal", true)]
+        [InlineData(typeof(double), "Edm.Double", false)]
+        [InlineData(typeof(double?), "Edm.Double", true)]
+        [InlineData(typeof(Guid), "Edm.Guid", false)]
+        [InlineData(typeof(Guid?), "Edm.Guid", true)]
+        [InlineData(typeof(short), "Edm.Int16", false)]
+        [InlineData(typeof(short?), "Edm.Int16", true)]
+        [InlineData(typeof(int), "Edm.Int32", false)]
+        [InlineData(typeof(int?), "Edm.Int32", true)]
+        [InlineData(typeof(long), "Edm.Int64", false)]
+        [InlineData(typeof(long?), "Edm.Int64", true)]
+        [InlineData(typeof(sbyte), "Edm.SByte", false)]
+        [InlineData(typeof(sbyte?), "Edm.SByte", true)]
+        [InlineData(typeof(float), "Edm.Single", false)]
+        [InlineData(typeof(float?), "Edm.Single", true)]
+        [InlineData(typeof(DateTimeOffset), "Edm.DateTimeOffset", false)]
+        [InlineData(typeof(DateTimeOffset?), "Edm.DateTimeOffset", true)]
+        [InlineData(typeof(TimeSpan), "Edm.Duration", false)]
+        [InlineData(typeof(TimeSpan?), "Edm.Duration", true)]
+        [InlineData(typeof(Date), "Edm.Date", false)]
+        [InlineData(typeof(Date?), "Edm.Date", true)]
+        [InlineData(typeof(TimeOfDay), "Edm.TimeOfDay", false)]
+        [InlineData(typeof(TimeOfDay?), "Edm.TimeOfDay", true)]
+        [InlineData(typeof(byte[]), "Edm.Binary", true)]
+        [InlineData(typeof(Stream), "Edm.Stream", true)]
+        public void GetPrimitiveType_ForClrType_WorksAsExpected_ForStandardPrimitive(Type clrType, string name, bool nullable)
+        {
+            // Arrange & Act
+            IEdmPrimitiveTypeReference primitiveTypeReference = _mapper.GetPrimitiveType(clrType);
+
+            // Assert
+            Assert.NotNull(primitiveTypeReference);
+            Assert.Equal(name, primitiveTypeReference.FullName());
+            Assert.Equal(nullable, primitiveTypeReference.IsNullable);
+        }
+
+        [Theory]
+        [InlineData(typeof(XElement), "Edm.String", true)]
+        [InlineData(typeof(ushort), "Edm.Int32", false)]
+        [InlineData(typeof(ushort?), "Edm.Int32", true)]
+        [InlineData(typeof(uint), "Edm.Int64", false)]
+        [InlineData(typeof(uint?), "Edm.Int64", true)]
+        [InlineData(typeof(ulong), "Edm.Int64", false)]
+        [InlineData(typeof(ulong?), "Edm.Int64", true)]
+        [InlineData(typeof(char[]), "Edm.String", true)]
+        [InlineData(typeof(char), "Edm.String", false)]
+        [InlineData(typeof(char?), "Edm.String", true)]
+        [InlineData(typeof(DateTime), "Edm.DateTimeOffset", false)]
+        [InlineData(typeof(DateTime?), "Edm.DateTimeOffset", true)]
+        public void GetPrimitiveType_ForClrType_WorksAsExpected_ForNonStandardPrimitive(Type clrType, string name, bool nullable)
+        {
+            // Arrange & Act
+            IEdmPrimitiveTypeReference primitiveTypeReference = _mapper.GetPrimitiveType(clrType);
+
+            // Assert
+            Assert.NotNull(primitiveTypeReference);
+            Assert.Equal(name, primitiveTypeReference.FullName());
+            Assert.Equal(nullable, primitiveTypeReference.IsNullable);
+        }
+
+        [Theory]
+        [InlineData(typeof(Geography), "Edm.Geography")]
+        [InlineData(typeof(GeographyPoint), "Edm.GeographyPoint")]
+        [InlineData(typeof(GeographyLineString), "Edm.GeographyLineString")]
+        [InlineData(typeof(GeographyPolygon), "Edm.GeographyPolygon")]
+        [InlineData(typeof(GeographyCollection), "Edm.GeographyCollection")]
+        [InlineData(typeof(GeographyMultiLineString), "Edm.GeographyMultiLineString")]
+        [InlineData(typeof(GeographyMultiPoint), "Edm.GeographyMultiPoint")]
+        [InlineData(typeof(GeographyMultiPolygon), "Edm.GeographyMultiPolygon")]
+        [InlineData(typeof(Geometry), "Edm.Geometry")]
+        [InlineData(typeof(GeometryPoint), "Edm.GeometryPoint")]
+        [InlineData(typeof(GeometryLineString), "Edm.GeometryLineString")]
+        [InlineData(typeof(GeometryPolygon), "Edm.GeometryPolygon")]
+        [InlineData(typeof(GeometryCollection), "Edm.GeometryCollection")]
+        [InlineData(typeof(GeometryMultiLineString), "Edm.GeometryMultiLineString")]
+        [InlineData(typeof(GeometryMultiPoint), "Edm.GeometryMultiPoint")]
+        [InlineData(typeof(GeometryMultiPolygon), "Edm.GeometryMultiPolygon")]
+        public void GetPrimitiveType_ForClrType_WorksAsExpected_ForSpatialPrimitive(Type clrType, string name)
+        {
+            // Arrange & Act
+            IEdmPrimitiveTypeReference primitiveTypeReference = _mapper.GetPrimitiveType(clrType);
+
+            // Assert
+            Assert.NotNull(primitiveTypeReference);
+            Assert.Equal(name, primitiveTypeReference.FullName());
+            Assert.True(primitiveTypeReference.IsNullable);
+        }
+
+        //[Theory]
+        //[InlineData(null, null, false)]
+        //[InlineData(typeof(int), typeof(int), false)]
+        //[InlineData(typeof(int?), typeof(int?), false)]
+        //[InlineData(typeof(object), typeof(object), false)]
+        //[InlineData(typeof(MyAddress), typeof(MyAddress), false)]
+        //// non-standard primitive types
+        //[InlineData(typeof(XElement), typeof(string), true)]
+        //[InlineData(typeof(ushort), typeof(int), true)]
+        //[InlineData(typeof(ushort?), typeof(int?), true)]
+        //[InlineData(typeof(uint), typeof(long), true)]
+        //[InlineData(typeof(uint?), typeof(long?), true)]
+        //[InlineData(typeof(ulong), typeof(long), true)]
+        //[InlineData(typeof(ulong?), typeof(long?), true)]
+        //[InlineData(typeof(char[]), typeof(string), true)]
+        //[InlineData(typeof(char), typeof(string), true)]
+        //[InlineData(typeof(char?), typeof(string), true)]
+        //[InlineData(typeof(DateTime), typeof(DateTimeOffset), true)]
+        //[InlineData(typeof(DateTime?), typeof(DateTimeOffset?), true)]
+        //public void IsNonstandardEdmPrimitiveWorksAsExpectedForNonstandardType(Type clrType, Type expectType, bool isNonstandard)
+        //{
+        //    // Arrange & Act
+        //    Type actual = _provider.IsNonstandardEdmPrimitive(clrType, out bool isNonstandardEdmPrimtive);
+
+        //    // Assert
+        //    Assert.Equal(expectType, actual);
+        //    Assert.Equal(isNonstandard, isNonstandardEdmPrimtive);
+        //}
+
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.String, typeof(string), typeof(string))]
+        [InlineData(EdmPrimitiveTypeKind.Boolean, typeof(bool?), typeof(bool))]
+        [InlineData(EdmPrimitiveTypeKind.Byte, typeof(byte?), typeof(byte))]
+        [InlineData(EdmPrimitiveTypeKind.Decimal, typeof(decimal?), typeof(decimal))]
+        [InlineData(EdmPrimitiveTypeKind.Double, typeof(double?), typeof(double))]
+        [InlineData(EdmPrimitiveTypeKind.Guid, typeof(Guid?), typeof(Guid))]
+        [InlineData(EdmPrimitiveTypeKind.Int16, typeof(short?), typeof(short))]
+        [InlineData(EdmPrimitiveTypeKind.Int32, typeof(int?), typeof(int))]
+        [InlineData(EdmPrimitiveTypeKind.Int64, typeof(long?), typeof(long))]
+        [InlineData(EdmPrimitiveTypeKind.SByte, typeof(sbyte?), typeof(sbyte))]
+        [InlineData(EdmPrimitiveTypeKind.Single, typeof(float?), typeof(float))]
+        [InlineData(EdmPrimitiveTypeKind.DateTimeOffset, typeof(DateTimeOffset?), typeof(DateTimeOffset))]
+        [InlineData(EdmPrimitiveTypeKind.Duration, typeof(TimeSpan?), typeof(TimeSpan))]
+        [InlineData(EdmPrimitiveTypeKind.Date, typeof(Date?), typeof(Date))]
+        [InlineData(EdmPrimitiveTypeKind.TimeOfDay, typeof(TimeOfDay?), typeof(TimeOfDay))]
+        [InlineData(EdmPrimitiveTypeKind.Binary, typeof(byte[]), typeof(byte[]))]
+        [InlineData(EdmPrimitiveTypeKind.Stream, typeof(Stream), typeof(Stream))]
+        public void GetPrimitiveType_ForEdmType_WorksAsExpected_ForStandardPrimitive(EdmPrimitiveTypeKind kind, Type nullExpected, Type nonNullExpected)
+        {
+            // Arrange & Act & Assert
+            IEdmPrimitiveType primitiveType = EdmCoreModel.Instance.GetPrimitiveType(kind);
+            Type clrType = _mapper.GetPrimitiveType(primitiveType, true);
+            Assert.Equal(nullExpected, clrType);
+
+            // Arrange & Act & Assert
+            clrType = _mapper.GetPrimitiveType(primitiveType, false);
+            Assert.Equal(nonNullExpected, clrType);
+        }
+
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.Geography, typeof(Geography))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyPoint, typeof(GeographyPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyLineString, typeof(GeographyLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyPolygon, typeof(GeographyPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyCollection, typeof(GeographyCollection))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiLineString, typeof(GeographyMultiLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPoint, typeof(GeographyMultiPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPolygon, typeof(GeographyMultiPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.Geometry, typeof(Geometry))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryPoint, typeof(GeometryPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryLineString, typeof(GeometryLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryPolygon, typeof(GeometryPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryCollection, typeof(GeometryCollection))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiLineString, typeof(GeometryMultiLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPoint, typeof(GeometryMultiPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPolygon, typeof(GeometryMultiPolygon))]
+        public void GetPrimitiveType_ForEdmType_WorksAsExpected_ForSpatialPrimitive(EdmPrimitiveTypeKind kind, Type expected)
+        {
+            // Arrange & Act & Assert
+            IEdmPrimitiveType primitiveType = EdmCoreModel.Instance.GetPrimitiveType(kind);
+            Type clrType = _mapper.GetPrimitiveType(primitiveType, true);
+            Assert.Equal(expected, clrType);
+
+            // Arrange & Act & Assert
+            clrType = _mapper.GetPrimitiveType(primitiveType, false);
+            Assert.Equal(expected, clrType);
+        }
+
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.None)]
+        [InlineData(EdmPrimitiveTypeKind.PrimitiveType)]
+        public void GetPrimitiveType_ForEdmType_WorksAsExpected_ForNotUsedKind(EdmPrimitiveTypeKind kind)
+        {
+            // Arrange & Act & Assert
+            IEdmPrimitiveType primitiveType = EdmCoreModel.Instance.GetPrimitiveType(kind);
+            Type clrType = _mapper.GetPrimitiveType(primitiveType, true);
+            Assert.Null(clrType);
+
+            // Arrange & Act & Assert
+            clrType = _mapper.GetPrimitiveType(primitiveType, false);
+            Assert.Null(clrType);
+        }
+        #endregion
+
+        #region GetClrType
+        [Fact]
+        public void GetClrType_ThrowsArgumentNull_ForInputParameters()
+        {
+            // Arrange & Act & Assert
+            Mock<IEdmType> edmType = new Mock<IEdmType>();
+            edmType.Setup(x => x.TypeKind).Returns(EdmTypeKind.Entity);
+            ExceptionAssert.ThrowsArgumentNull(() => _mapper.GetClrType(null, edmType.Object, true, null), "edmModel");
+
+            IEdmModel model = new Mock<IEdmModel>().Object;
+            IAssemblyResolver resolver = new Mock<IAssemblyResolver>().Object;
+            ExceptionAssert.ThrowsArgumentNull(() => _mapper.GetClrType(model, null, true, resolver), "edmType");
+        }
+
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.String, typeof(string))]
+        [InlineData(EdmPrimitiveTypeKind.Boolean, typeof(bool))]
+        [InlineData(EdmPrimitiveTypeKind.Byte, typeof(byte))]
+        [InlineData(EdmPrimitiveTypeKind.Decimal, typeof(decimal))]
+        [InlineData(EdmPrimitiveTypeKind.Double, typeof(double))]
+        [InlineData(EdmPrimitiveTypeKind.Guid, typeof(Guid))]
+        [InlineData(EdmPrimitiveTypeKind.Int16, typeof(short))]
+        [InlineData(EdmPrimitiveTypeKind.Int32, typeof(int))]
+        [InlineData(EdmPrimitiveTypeKind.Int64, typeof(long))]
+        [InlineData(EdmPrimitiveTypeKind.SByte, typeof(sbyte))]
+        [InlineData(EdmPrimitiveTypeKind.Single, typeof(float))]
+        [InlineData(EdmPrimitiveTypeKind.Binary, typeof(byte[]))]
+        [InlineData(EdmPrimitiveTypeKind.Stream, typeof(Stream))]
+        [InlineData(EdmPrimitiveTypeKind.DateTimeOffset, typeof(DateTimeOffset))]
+        [InlineData(EdmPrimitiveTypeKind.Duration, typeof(TimeSpan))]
+        [InlineData(EdmPrimitiveTypeKind.Date, typeof(Date))]
+        [InlineData(EdmPrimitiveTypeKind.TimeOfDay, typeof(TimeOfDay))]
+        public void GetClrType_WorksAsExpected_ForStandardPrimitive(EdmPrimitiveTypeKind kind, Type expected)
+        {
+            // #1 Arrange & Act & Assert for nullable equals to false
+            IEdmPrimitiveType primitiveType = EdmCoreModel.Instance.GetPrimitiveType(kind);
+            Type clrType = _mapper.GetClrType(EdmModel, primitiveType, false, assembliesResolver: null);
+            Assert.Equal(expected, clrType);
+
+            // #2 Arrange & Act & Assert for nullable equals to true
+            clrType = _mapper.GetClrType(EdmModel, primitiveType, true, assembliesResolver: null);
+            if (expected.IsValueType)
+            {
+                Type generic = typeof(Nullable<>);
+                expected = generic.MakeGenericType(expected);
+                Assert.Same(expected, clrType);
+            }
+            else
+            {
+                Assert.Same(expected, clrType);
+            }
+        }
+
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.Geography, typeof(Geography))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyPoint, typeof(GeographyPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyLineString, typeof(GeographyLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyPolygon, typeof(GeographyPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyCollection, typeof(GeographyCollection))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiLineString, typeof(GeographyMultiLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPoint, typeof(GeographyMultiPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPolygon, typeof(GeographyMultiPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.Geometry, typeof(Geometry))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryPoint, typeof(GeometryPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryLineString, typeof(GeometryLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryPolygon, typeof(GeometryPolygon))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryCollection, typeof(GeometryCollection))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiLineString, typeof(GeometryMultiLineString))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPoint, typeof(GeometryMultiPoint))]
+        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPolygon, typeof(GeometryMultiPolygon))]
+        public void GetClrType_WorksAsExpected_ForSpatialPrimitive(EdmPrimitiveTypeKind kind, Type type)
+        {
+            // Arrange
+            IEdmPrimitiveType primitiveType = EdmCoreModel.Instance.GetPrimitiveType(kind);
+
+            // Act
+            Type clrType1 = _mapper.GetClrType(EdmModel, primitiveType, false, assembliesResolver: null);
+            Type clrType2 = _mapper.GetClrType(EdmModel, primitiveType, true, assembliesResolver: null);
+
+            // Assert
+            Assert.Same(clrType1, clrType2);
+            Assert.Same(type, clrType1);
+        }
+
+        [Theory]
+        [InlineData("NS.Address", typeof(MyAddress))] // use ClrTypeAnnotation
+        [InlineData("NS.CnAddress", typeof(CnMyAddress))]
+        [InlineData("Microsoft.AspNetCore.OData.Tests.Edm.MyCustomer", typeof(MyCustomer))] // use the full name match
+        public void GetClrType_WorksAsExpected_ForSchemaStrucutralType(string typeName, Type expected)
+        {
+            // Arrange
+            IEdmType edmType = EdmModel.FindType(typeName);
+            Assert.NotNull(edmType); // Guard
+
+            // #1. Act & Assert
+            Type clrType = _mapper.GetClrType(EdmModel, edmType, true, new AssemblyResolver());
+            Assert.Same(expected, clrType);
+
+            // #2. Act & Assert
+            clrType = _mapper.GetClrType(EdmModel, edmType, false, new AssemblyResolver());
+            Assert.Same(expected, clrType);
+        }
+
+        [Fact]
+        public void GetClrType_WorksAsExpected_ForSchemaEnumType()
+        {
+            // Arrange
+            IEdmType edmType = EdmModel.FindType("NS.Color");
+            Assert.NotNull(edmType); // Guard
+
+            // #1. Act & Assert
+            Type clrType = _mapper.GetClrType(EdmModel, edmType, true, null);
+            Assert.Same(typeof(MyColor?), clrType);
+
+            // #2. Act & Assert
+            clrType = _mapper.GetClrType(EdmModel, edmType, false, null);
+            Assert.Same(typeof(MyColor), clrType);
+        }
+
+        #endregion
+
+        #region GetEdmType
+        [Fact]
+        public void GetEdmType_ThrowsArgumentNull_ModelAndClrType()
+        {
+            // Arrange & Act
+            IEdmModel model = null;
+            ExceptionAssert.ThrowsArgumentNull(() => _mapper.GetEdmTypeReference(model, typeof(TypeNotInModel)), "edmModel");
+
+            model = new Mock<IEdmModel>().Object;
+            ExceptionAssert.ThrowsArgumentNull(() => _mapper.GetEdmTypeReference(model, null), "clrType");
+        }
+
+        [Fact]
+        public void GetEdmTypeReference_ReturnsNull_ForUnknownType()
+        {
+            // Arrange & Act & Assert
+            Assert.Null(_mapper.GetEdmTypeReference(EdmModel, typeof(TypeNotInModel)));
+        }
+
+        [Theory]
+        [InlineData(typeof(IEnumerable<BaseType>), "NS.BaseType")]
+        [InlineData(typeof(IEnumerable<Derived1Type>), "NS.Derived1Type")]
+        [InlineData(typeof(Derived2Type[]), "NS.Derived2Type")]
+        public void GetEdmTypeReference_ReturnsCollection_ForIEnumerableOfT(Type clrType, string typeName)
+        {
+            // Arrange & Act
+            IEdmType edmType = _mapper.GetEdmType(EdmModel, clrType);
+
+            // Assert
+            Assert.Equal(EdmTypeKind.Collection, edmType.TypeKind);
+            Assert.Equal(typeName, (edmType as IEdmCollectionType).ElementType.FullName());
+        }
+
+        [Theory]
+        [InlineData(typeof(string), "Edm.String")]
+        [InlineData(typeof(int?), "Edm.Int32")]
+        [InlineData(typeof(MyAddress), "NS.Address")]
+        [InlineData(typeof(CnMyAddress), "NS.CnAddress")]
+        [InlineData(typeof(MyCustomer), "Microsoft.AspNetCore.OData.Tests.Edm.MyCustomer")]
+        [InlineData(typeof(BaseType), "NS.BaseType")]
+        [InlineData(typeof(Derived1Type), "NS.Derived1Type")]
+        [InlineData(typeof(Derived2Type), "NS.Derived2Type")]
+        [InlineData(typeof(SubDerivedType), "NS.SubDerivedType")]
+        public void GetEdmTypeReference_WorksAsExpected_ForEdmType(Type clrType, string typeName)
+        {
+            // Arrange
+            IEdmType expectedEdmType = EdmModel.FindType(typeName);
+            Assert.NotNull(expectedEdmType); // Guard
+
+            // Arrange & Act
+            IEdmTypeReference edmTypeRef = _mapper.GetEdmTypeReference(EdmModel, clrType);
+            IEdmType edmType = _mapper.GetEdmType(EdmModel, clrType);
+
+            // Assert
+            Assert.NotNull(edmTypeRef);
+            Assert.Same(expectedEdmType, edmTypeRef.Definition);
+            Assert.Same(expectedEdmType, edmType);
+            Assert.True(edmTypeRef.IsNullable);
+        }
+
+        [Fact]
+        public void GetEdmTypeReference_WorksAsExpected_ForSchemaEnumType()
+        {
+            // Arrange
+            IEdmType expectedType = EdmModel.FindType("NS.Color");
+            Assert.NotNull(expectedType); // Guard
+
+            // #1. Act & Assert
+            IEdmTypeReference colorType = _mapper.GetEdmTypeReference(EdmModel, typeof(MyColor));
+            Assert.Same(expectedType, colorType.Definition);
+            Assert.False(colorType.IsNullable);
+
+            // #2. Act & Assert
+            colorType = _mapper.GetEdmTypeReference(EdmModel, typeof(MyColor?));
+            Assert.Same(expectedType, colorType.Definition);
+            Assert.True(colorType.IsNullable);
+        }
+        #endregion
+
+        [Theory]
+        [InlineData(typeof(MyCustomer), "MyCustomer")]
+        [InlineData(typeof(int), "Int32")]
+        [InlineData(typeof(IEnumerable<int>), "IEnumerable_1OfInt32")]
+        [InlineData(typeof(IEnumerable<Func<int, string>>), "IEnumerable_1OfFunc_2OfInt32_String")]
+        [InlineData(typeof(List<Func<int, string>>), "List_1OfFunc_2OfInt32_String")]
+        public void EdmFullName(Type clrType, string expectedName)
+        {
+            // Arrange & Act & Assert
+            Assert.Equal(expectedName, clrType.EdmName());
+        }
+
+        private static IEdmModel GetEdmModel()
+        {
+            EdmModel model = new EdmModel();
+
+            // ComplexType: Address
+            EdmComplexType address = new EdmComplexType("NS", "Address");
+            address.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+            model.AddElement(address);
+            model.SetAnnotationValue(address, new ClrTypeAnnotation(typeof(MyAddress)));
+
+            // ComplexType: CnAddress
+            var cnAddress = new EdmComplexType("NS", "CnAddress", address);
+            cnAddress.AddStructuralProperty("Zipcode", EdmPrimitiveTypeKind.String);
+            model.AddElement(cnAddress);
+            model.SetAnnotationValue(cnAddress, new ClrTypeAnnotation(typeof(CnMyAddress)));
+
+            // EnumType: Color
+            var color = new EdmEnumType("NS", "Color");
+            model.AddElement(color);
+            model.SetAnnotationValue(color, new ClrTypeAnnotation(typeof(MyColor)));
+
+            // EntityType: MyCustomer
+            var customer = new EdmEntityType("Microsoft.AspNetCore.OData.Tests.Edm", "MyCustomer");
+            model.AddElement(customer);
+
+            // Inheritance EntityType
+            var baseEntity = new EdmEntityType("NS", "BaseType");
+            var derived1Entity = new EdmEntityType("NS", "Derived1Type", baseEntity);
+            var derived2Entity = new EdmEntityType("NS", "Derived2Type", baseEntity);
+            var subDerivedEntity = new EdmEntityType("NS", "SubDerivedType", derived1Entity);
+            model.AddElements(new[] { baseEntity, derived1Entity, derived2Entity, subDerivedEntity });
+            model.SetAnnotationValue(baseEntity, new ClrTypeAnnotation(typeof(BaseType)));
+            model.SetAnnotationValue(derived1Entity, new ClrTypeAnnotation(typeof(Derived1Type)));
+            model.SetAnnotationValue(derived2Entity, new ClrTypeAnnotation(typeof(Derived2Type)));
+            model.SetAnnotationValue(subDerivedEntity, new ClrTypeAnnotation(typeof(SubDerivedType)));
+
+            return model;
+        }
+
+        public class MyAddress
+        {
+            public string City { get; set; }
+        }
+
+        public class CnMyAddress : MyAddress
+        {
+            public string Zipcode { get; set; }
+        }
+
+        public enum MyColor
+        {
+            Red
+        }
+
+        public class BaseType
+        { }
+
+        public class Derived1Type : BaseType
+        { }
+
+        public class Derived2Type : BaseType
+        { }
+
+        public class SubDerivedType : Derived1Type
+        { }
+
+        public class TypeNotInModel
+        { }
+
+        public class AssemblyResolver : IAssemblyResolver
+        {
+            public IEnumerable<Assembly> Assemblies
+            {
+                get
+                {
+                    yield return typeof(AssemblyResolver).Assembly;
+                }
+            }
+        }
+    }
+
+    public class MyCustomer
+    { }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
@@ -121,35 +121,6 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
             Assert.True(primitiveTypeReference.IsNullable);
         }
 
-        //[Theory]
-        //[InlineData(null, null, false)]
-        //[InlineData(typeof(int), typeof(int), false)]
-        //[InlineData(typeof(int?), typeof(int?), false)]
-        //[InlineData(typeof(object), typeof(object), false)]
-        //[InlineData(typeof(MyAddress), typeof(MyAddress), false)]
-        //// non-standard primitive types
-        //[InlineData(typeof(XElement), typeof(string), true)]
-        //[InlineData(typeof(ushort), typeof(int), true)]
-        //[InlineData(typeof(ushort?), typeof(int?), true)]
-        //[InlineData(typeof(uint), typeof(long), true)]
-        //[InlineData(typeof(uint?), typeof(long?), true)]
-        //[InlineData(typeof(ulong), typeof(long), true)]
-        //[InlineData(typeof(ulong?), typeof(long?), true)]
-        //[InlineData(typeof(char[]), typeof(string), true)]
-        //[InlineData(typeof(char), typeof(string), true)]
-        //[InlineData(typeof(char?), typeof(string), true)]
-        //[InlineData(typeof(DateTime), typeof(DateTimeOffset), true)]
-        //[InlineData(typeof(DateTime?), typeof(DateTimeOffset?), true)]
-        //public void IsNonstandardEdmPrimitiveWorksAsExpectedForNonstandardType(Type clrType, Type expectType, bool isNonstandard)
-        //{
-        //    // Arrange & Act
-        //    Type actual = _provider.IsNonstandardEdmPrimitive(clrType, out bool isNonstandardEdmPrimtive);
-
-        //    // Assert
-        //    Assert.Equal(expectType, actual);
-        //    Assert.Equal(isNonstandard, isNonstandardEdmPrimtive);
-        //}
-
         [Theory]
         [InlineData(EdmPrimitiveTypeKind.String, typeof(string), typeof(string))]
         [InlineData(EdmPrimitiveTypeKind.Boolean, typeof(bool?), typeof(bool))]

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmClrTypeMapExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmClrTypeMapExtensionsTests.cs
@@ -7,14 +7,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
 using System.Xml.Linq;
+using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Edm;
-using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
-using Microsoft.Spatial;
 using Moq;
 using Xunit;
 
@@ -22,108 +19,44 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
 {
     public class EdmClrTypeMapExtensionsTests
     {
-        private static IEdmModel EdmModel = GetEdmModel();
-
-        #region PrimitiveType
-        [Theory]
-        [InlineData(typeof(string), "Edm.String", true)]
-        [InlineData(typeof(bool), "Edm.Boolean", false)]
-        [InlineData(typeof(bool?), "Edm.Boolean", true)]
-        [InlineData(typeof(byte), "Edm.Byte", false)]
-        [InlineData(typeof(byte?), "Edm.Byte", true)]
-        [InlineData(typeof(decimal), "Edm.Decimal", false)]
-        [InlineData(typeof(decimal?), "Edm.Decimal", true)]
-        [InlineData(typeof(double), "Edm.Double", false)]
-        [InlineData(typeof(double?), "Edm.Double", true)]
-        [InlineData(typeof(Guid), "Edm.Guid", false)]
-        [InlineData(typeof(Guid?), "Edm.Guid", true)]
-        [InlineData(typeof(short), "Edm.Int16", false)]
-        [InlineData(typeof(short?), "Edm.Int16", true)]
-        [InlineData(typeof(int), "Edm.Int32", false)]
-        [InlineData(typeof(int?), "Edm.Int32", true)]
-        [InlineData(typeof(long), "Edm.Int64", false)]
-        [InlineData(typeof(long?), "Edm.Int64", true)]
-        [InlineData(typeof(sbyte), "Edm.SByte", false)]
-        [InlineData(typeof(sbyte?), "Edm.SByte", true)]
-        [InlineData(typeof(float), "Edm.Single", false)]
-        [InlineData(typeof(float?), "Edm.Single", true)]
-        [InlineData(typeof(DateTimeOffset), "Edm.DateTimeOffset", false)]
-        [InlineData(typeof(DateTimeOffset?), "Edm.DateTimeOffset", true)]
-        [InlineData(typeof(TimeSpan), "Edm.Duration", false)]
-        [InlineData(typeof(TimeSpan?), "Edm.Duration", true)]
-        [InlineData(typeof(Date), "Edm.Date", false)]
-        [InlineData(typeof(Date?), "Edm.Date", true)]
-        [InlineData(typeof(TimeOfDay), "Edm.TimeOfDay", false)]
-        [InlineData(typeof(TimeOfDay?), "Edm.TimeOfDay", true)]
-        [InlineData(typeof(byte[]), "Edm.Binary", true)]
-        [InlineData(typeof(Stream), "Edm.Stream", true)]
-        public void GetEdmPrimitiveTypeReferenceWorksAsExpectedForStandardPrimitive(Type clrType, string name, bool nullable)
+        [Fact]
+        public void GetEdmPrimitiveTypeReference_Calls_GetPrimitiveTypeOnMapper()
         {
-            // Arrange & Act
-            IEdmPrimitiveTypeReference primitiveTypeReference = clrType.GetEdmPrimitiveTypeReference();
-            IEdmPrimitiveType primitiveType = clrType.GetEdmPrimitiveType();
+            // Arrange
+            Type type = typeof(int);
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetPrimitiveType(type)).Verifiable();
+
+            EdmModel model = new EdmModel();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetEdmPrimitiveTypeReference(type);
 
             // Assert
-            Assert.NotNull(primitiveTypeReference);
-            Assert.Same(primitiveTypeReference.Definition, primitiveType);
-            Assert.Equal(name, primitiveTypeReference.FullName());
-            Assert.Equal(nullable, primitiveTypeReference.IsNullable);
+            mapper.Verify();
         }
 
-        [Theory]
-        [InlineData(typeof(XElement), "Edm.String", true)]
-        [InlineData(typeof(ushort), "Edm.Int32", false)]
-        [InlineData(typeof(ushort?), "Edm.Int32", true)]
-        [InlineData(typeof(uint), "Edm.Int64", false)]
-        [InlineData(typeof(uint?), "Edm.Int64", true)]
-        [InlineData(typeof(ulong), "Edm.Int64", false)]
-        [InlineData(typeof(ulong?), "Edm.Int64", true)]
-        [InlineData(typeof(char[]), "Edm.String", true)]
-        [InlineData(typeof(char), "Edm.String", false)]
-        [InlineData(typeof(char?), "Edm.String", true)]
-        [InlineData(typeof(DateTime), "Edm.DateTimeOffset", false)]
-        [InlineData(typeof(DateTime?), "Edm.DateTimeOffset", true)]
-        public void GetEdmPrimitiveTypeReferenceWorksAsExpectedForNonStandardPrimitive(Type clrType, string name, bool nullable)
+        [Fact]
+        public void GetClrPrimitiveType_Calls_GetPrimitiveTypeOnMapper()
         {
-            // Arrange & Act
-            IEdmPrimitiveTypeReference primitiveTypeReference = clrType.GetEdmPrimitiveTypeReference();
-            IEdmPrimitiveType primitiveType = clrType.GetEdmPrimitiveType();
+            // Arrange
+            Mock<IEdmPrimitiveType> primitiveType = new Mock<IEdmPrimitiveType>();
+            Mock<IEdmPrimitiveTypeReference> edmType = new Mock<IEdmPrimitiveTypeReference>();
+            edmType.Setup(x => x.Definition).Returns(primitiveType.Object);
+            edmType.Setup(x => x.IsNullable).Returns(true);
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetPrimitiveType(edmType.Object.PrimitiveDefinition(), edmType.Object.IsNullable)).Verifiable();
+
+            EdmModel model = new EdmModel();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetClrPrimitiveType(edmType.Object);
 
             // Assert
-            Assert.NotNull(primitiveTypeReference);
-            Assert.Same(primitiveTypeReference.Definition, primitiveType);
-            Assert.Equal(name, primitiveTypeReference.FullName());
-            Assert.Equal(nullable, primitiveTypeReference.IsNullable);
-        }
-
-        [Theory]
-        [InlineData(typeof(Geography), "Edm.Geography")]
-        [InlineData(typeof(GeographyPoint), "Edm.GeographyPoint")]
-        [InlineData(typeof(GeographyLineString), "Edm.GeographyLineString")]
-        [InlineData(typeof(GeographyPolygon), "Edm.GeographyPolygon")]
-        [InlineData(typeof(GeographyCollection), "Edm.GeographyCollection")]
-        [InlineData(typeof(GeographyMultiLineString), "Edm.GeographyMultiLineString")]
-        [InlineData(typeof(GeographyMultiPoint), "Edm.GeographyMultiPoint")]
-        [InlineData(typeof(GeographyMultiPolygon), "Edm.GeographyMultiPolygon")]
-        [InlineData(typeof(Geometry), "Edm.Geometry")]
-        [InlineData(typeof(GeometryPoint), "Edm.GeometryPoint")]
-        [InlineData(typeof(GeometryLineString), "Edm.GeometryLineString")]
-        [InlineData(typeof(GeometryPolygon), "Edm.GeometryPolygon")]
-        [InlineData(typeof(GeometryCollection), "Edm.GeometryCollection")]
-        [InlineData(typeof(GeometryMultiLineString), "Edm.GeometryMultiLineString")]
-        [InlineData(typeof(GeometryMultiPoint), "Edm.GeometryMultiPoint")]
-        [InlineData(typeof(GeometryMultiPolygon), "Edm.GeometryMultiPolygon")]
-        public void GetEdmTypeWorksAsExpectedForSpatialPrimitive(Type clrType, string name)
-        {
-            // Arrange & Act
-            IEdmPrimitiveTypeReference primitiveTypeReference = clrType.GetEdmPrimitiveTypeReference();
-            IEdmPrimitiveType primitiveType = clrType.GetEdmPrimitiveType();
-
-            // Assert
-            Assert.NotNull(primitiveTypeReference);
-            Assert.Same(primitiveTypeReference.Definition, primitiveType);
-            Assert.Equal(name, primitiveTypeReference.FullName());
-            Assert.True(primitiveTypeReference.IsNullable);
+            mapper.Verify();
         }
 
         [Theory]
@@ -131,7 +64,6 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
         [InlineData(typeof(int), typeof(int), false)]
         [InlineData(typeof(int?), typeof(int?), false)]
         [InlineData(typeof(object), typeof(object), false)]
-        [InlineData(typeof(MyAddress), typeof(MyAddress), false)]
         // non-standard primitive types
         [InlineData(typeof(XElement), typeof(string), true)]
         [InlineData(typeof(ushort), typeof(int), true)]
@@ -145,223 +77,138 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
         [InlineData(typeof(char?), typeof(string), true)]
         [InlineData(typeof(DateTime), typeof(DateTimeOffset), true)]
         [InlineData(typeof(DateTime?), typeof(DateTimeOffset?), true)]
-        public void IsNonstandardEdmPrimitiveWorksAsExpectedForNonstandardType(Type clrType, Type expectType, bool isNonstandard)
+        public void IsNonstandardEdmPrimitive_WorksAsExpected_ForNonstandardType(Type clrType, Type expectType, bool isNonstandard)
         {
-            // Arrange & Act
-            Type actual = clrType.IsNonstandardEdmPrimitive(out bool isNonstandardEdmPrimtive);
+            // Arrange
+            EdmModel model = new EdmModel();
+            model.SetTypeMapper(DefaultODataTypeMapper.Default);
+
+            // Act
+            Type actual = model.IsNonstandardEdmPrimitive(clrType, out bool isNonstandardEdmPrimtive);
 
             // Assert
             Assert.Equal(expectType, actual);
             Assert.Equal(isNonstandard, isNonstandardEdmPrimtive);
         }
 
-        #endregion
-
-        #region GetClrType
         [Fact]
-        public void GetClrType_ThrowsArgumentNull_EdmType()
-        {
-            // Arrange & Act
-            IAssemblyResolver resolver = new Mock<IAssemblyResolver>().Object;
-            IEdmModel model = new Mock<IEdmModel>().Object;
-            ExceptionAssert.ThrowsArgumentNull(() => model.GetClrType((IEdmTypeReference)null, resolver), "edmTypeReference");
-
-            ExceptionAssert.ThrowsArgumentNull(() => model.GetClrType((IEdmType)null, resolver), "edmType");
-        }
-
-        [Theory]
-        [InlineData(EdmPrimitiveTypeKind.String, typeof(string))]
-        [InlineData(EdmPrimitiveTypeKind.Boolean, typeof(bool))]
-        [InlineData(EdmPrimitiveTypeKind.Byte, typeof(byte))]
-        [InlineData(EdmPrimitiveTypeKind.Decimal, typeof(decimal))]
-        [InlineData(EdmPrimitiveTypeKind.Double, typeof(double))]
-        [InlineData(EdmPrimitiveTypeKind.Guid, typeof(Guid))]
-        [InlineData(EdmPrimitiveTypeKind.Int16, typeof(short))]
-        [InlineData(EdmPrimitiveTypeKind.Int32, typeof(int))]
-        [InlineData(EdmPrimitiveTypeKind.Int64, typeof(long))]
-        [InlineData(EdmPrimitiveTypeKind.SByte, typeof(sbyte))]
-        [InlineData(EdmPrimitiveTypeKind.Single, typeof(float))]
-        [InlineData(EdmPrimitiveTypeKind.Binary, typeof(byte[]))]
-        [InlineData(EdmPrimitiveTypeKind.Stream, typeof(Stream))]
-        [InlineData(EdmPrimitiveTypeKind.DateTimeOffset, typeof(DateTimeOffset))]
-        [InlineData(EdmPrimitiveTypeKind.Duration, typeof(TimeSpan))]
-        [InlineData(EdmPrimitiveTypeKind.Date, typeof(Date))]
-        [InlineData(EdmPrimitiveTypeKind.TimeOfDay, typeof(TimeOfDay))]
-        public void GetClrTypeWorksAsExpectedForStandardPrimitive(EdmPrimitiveTypeKind kind, Type expected)
-        {
-            // #1 Arrange & Act & Assert for nullable equals to false
-            IEdmPrimitiveTypeReference primitiveType = EdmCoreModel.Instance.GetPrimitive(kind, false);
-            Type clrType = EdmModel.GetClrType(primitiveType);
-            Assert.Equal(expected, clrType);
-
-            // #2 Arrange & Act & Assert for nullable equals to true
-            primitiveType = EdmCoreModel.Instance.GetPrimitive(kind, true);
-            clrType = EdmModel.GetClrType(primitiveType);
-            if (expected.IsValueType)
-            {
-                Type generic = typeof(Nullable<>);
-                expected = generic.MakeGenericType(expected);
-                Assert.Same(expected, clrType);
-            }
-            else
-            {
-                Assert.Same(expected, clrType);
-            }
-        }
-
-        [Theory]
-        [InlineData(EdmPrimitiveTypeKind.Geography, typeof(Geography))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyPoint, typeof(GeographyPoint))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyLineString, typeof(GeographyLineString))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyPolygon, typeof(GeographyPolygon))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyCollection, typeof(GeographyCollection))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyMultiLineString, typeof(GeographyMultiLineString))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPoint, typeof(GeographyMultiPoint))]
-        [InlineData(EdmPrimitiveTypeKind.GeographyMultiPolygon, typeof(GeographyMultiPolygon))]
-        [InlineData(EdmPrimitiveTypeKind.Geometry, typeof(Geometry))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryPoint, typeof(GeometryPoint))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryLineString, typeof(GeometryLineString))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryPolygon, typeof(GeometryPolygon))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryCollection, typeof(GeometryCollection))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryMultiLineString, typeof(GeometryMultiLineString))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPoint, typeof(GeometryMultiPoint))]
-        [InlineData(EdmPrimitiveTypeKind.GeometryMultiPolygon, typeof(GeometryMultiPolygon))]
-        public void GetClrTypeWorksAsExpectedForSpatialPrimitive(EdmPrimitiveTypeKind kind, Type type)
+        public void GetEdmTypeReference_Calls_GetEdmTypeReferenceOnMapper()
         {
             // Arrange
-            IEdmPrimitiveTypeReference primitiveType1 = EdmCoreModel.Instance.GetPrimitive(kind, true);
-            IEdmPrimitiveTypeReference primitiveType2 = EdmCoreModel.Instance.GetPrimitive(kind, false);
+            Type type = typeof(int);
+            EdmModel model = new EdmModel();
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetEdmTypeReference(model, type)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
 
             // Act
-            Type clrType1 = EdmModel.GetClrType(primitiveType1);
-            Type clrType2 = EdmModel.GetClrType(primitiveType2);
+            model.GetEdmTypeReference(type);
 
             // Assert
-            Assert.Same(clrType1, clrType2);
-            Assert.Same(type, clrType1);
+            mapper.Verify();
         }
 
-        [Theory]
-        [InlineData("NS.Address", typeof(MyAddress))] // use ClrTypeAnnotation
-        [InlineData("NS.CnAddress", typeof(CnMyAddress))]
-        [InlineData("Microsoft.AspNetCore.OData.Tests.Edm.MyCustomer", typeof(MyCustomer))] // use the full name match
-        public void GetClrTypeWorksAsExpectedForSchemaStrucutralType(string typeName, Type expected)
+        [Fact]
+        public void GetEdmType_Calls_GetEdmTypeReferenceOnMapper()
         {
             // Arrange
-            IEdmType edmType = EdmModel.FindType(typeName);
-            Assert.NotNull(edmType); // Guard
+            Type type = typeof(int);
+            EdmModel model = new EdmModel();
 
-            // #1. Act & Assert
-            IEdmTypeReference edmTypeReference = edmType.ToEdmTypeReference(true);
-            Type clrType = EdmModel.GetClrType(edmTypeReference, new AssemblyResolver());
-            Assert.Same(expected, clrType);
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetEdmTypeReference(model, type)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
 
-            // #2. Act & Assert
-            edmTypeReference = edmType.ToEdmTypeReference(false);
-            clrType = EdmModel.GetClrType(edmTypeReference);
-            Assert.Same(expected, clrType);
-        }
-
-        [Fact]
-        public void GetClrTypeWorksAsExpectedForSchemaEnumType()
-        {
-            // Arrange
-            IEdmType edmType = EdmModel.FindType("NS.Color");
-            Assert.NotNull(edmType); // Guard
-
-            // #1. Act & Assert
-            IEdmTypeReference edmTypeReference = edmType.ToEdmTypeReference(true);
-            Type clrType = EdmModel.GetClrType(edmTypeReference);
-            Assert.Same(typeof(MyColor?), clrType);
-
-            // #2. Act & Assert
-            edmTypeReference = edmType.ToEdmTypeReference(false);
-            clrType = EdmModel.GetClrType(edmTypeReference);
-            Assert.Same(typeof(MyColor), clrType);
-        }
-
-        #endregion
-
-        #region GetEdmType
-
-        [Fact]
-        public void GetEdmType_ThrowsArgumentNull_ModelAndClrType()
-        {
-            // Arrange & Act
-            IEdmModel model = null;
-            ExceptionAssert.ThrowsArgumentNull(() => model.GetEdmType(typeof(int)), "edmModel");
-
-            model = new Mock<IEdmModel>().Object;
-            ExceptionAssert.ThrowsArgumentNull(() => model.GetEdmType(null), "clrType");
-        }
-
-        [Fact]
-        public void GetEdmTypeReferenceReturnsNullForUnknownType()
-        {
-            // Arrange & Act & Assert
-            Assert.Null(EdmModel.GetEdmTypeReference(typeof(TypeNotInModel)));
-            Assert.Null(EdmModel.GetEdmType(typeof(TypeNotInModel)));
-        }
-
-        [Theory]
-        [InlineData(typeof(IEnumerable<BaseType>), "NS.BaseType")]
-        [InlineData(typeof(IEnumerable<Derived1Type>), "NS.Derived1Type")]
-        [InlineData(typeof(Derived2Type[]), "NS.Derived2Type")]
-        public void GetEdmTypeReferenceReturnsCollectionForIEnumerableOfT(Type clrType, string typeName)
-        {
-            // Arrange & Act
-            IEdmType edmType = EdmModel.GetEdmType(clrType);
+            // Act
+            model.GetEdmType(type);
 
             // Assert
-            Assert.Equal(EdmTypeKind.Collection, edmType.TypeKind);
-            Assert.Equal(typeName, (edmType as IEdmCollectionType).ElementType.FullName());
-        }
-
-        [Theory]
-        [InlineData(typeof(string), "Edm.String")]
-        [InlineData(typeof(int?), "Edm.Int32")]
-        [InlineData(typeof(MyAddress), "NS.Address")]
-        [InlineData(typeof(CnMyAddress), "NS.CnAddress")]
-        [InlineData(typeof(MyCustomer), "Microsoft.AspNetCore.OData.Tests.Edm.MyCustomer")]
-        [InlineData(typeof(BaseType), "NS.BaseType")]
-        [InlineData(typeof(Derived1Type), "NS.Derived1Type")]
-        [InlineData(typeof(Derived2Type), "NS.Derived2Type")]
-        [InlineData(typeof(SubDerivedType), "NS.SubDerivedType")]
-        public void GetEdmTypeReferenceWorksAsExpectedForEdmType(Type clrType, string typeName)
-        {
-            // Arrange
-            IEdmType expectedEdmType = EdmModel.FindType(typeName);
-            Assert.NotNull(expectedEdmType); // Guard
-
-            // Arrange & Act
-            IEdmTypeReference edmTypeRef = EdmModel.GetEdmTypeReference(clrType);
-            IEdmType edmType = EdmModel.GetEdmType(clrType);
-
-            // Assert
-            Assert.NotNull(edmTypeRef);
-            Assert.Same(expectedEdmType, edmTypeRef.Definition);
-            Assert.Same(expectedEdmType, edmType);
-            Assert.True(edmTypeRef.IsNullable);
+            mapper.Verify();
         }
 
         [Fact]
-        public void GetEdmTypeWorksAsExpectedForSchemaEnumType()
+        public void GetClrType_Calls_GetClrTypeOnMapper()
         {
             // Arrange
-            IEdmType expectedType = EdmModel.FindType("NS.Color");
-            Assert.NotNull(expectedType); // Guard
+            Mock<IEdmType> edmType = new Mock<IEdmType>();
+            Mock<IEdmTypeReference> edmTypeRef = new Mock<IEdmTypeReference>();
+            edmTypeRef.Setup(x => x.Definition).Returns(edmType.Object);
+            edmTypeRef.Setup(x => x.IsNullable).Returns(true);
 
-            // #1. Act & Assert
-            IEdmTypeReference colorType = EdmModel.GetEdmTypeReference(typeof(MyColor));
-            Assert.Same(expectedType, colorType.Definition);
-            Assert.False(colorType.IsNullable);
+            EdmModel model = new EdmModel();
 
-            // #2. Act & Assert
-            colorType = EdmModel.GetEdmTypeReference(typeof(MyColor?));
-            Assert.Same(expectedType, colorType.Definition);
-            Assert.True(colorType.IsNullable);
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetClrType(model, edmType.Object, true, AssemblyResolverHelper.Default)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetClrType(edmTypeRef.Object);
+
+            // Assert
+            mapper.Verify();
         }
-        #endregion
+
+        [Fact]
+        public void GetClrTypeWithResolver_Calls_GetClrTypeOnMapper()
+        {
+            // Arrange
+            Mock<IAssemblyResolver> resolver = new Mock<IAssemblyResolver>();
+            Mock<IEdmType> edmType = new Mock<IEdmType>();
+            Mock<IEdmTypeReference> edmTypeRef = new Mock<IEdmTypeReference>();
+            edmTypeRef.Setup(x => x.Definition).Returns(edmType.Object);
+            edmTypeRef.Setup(x => x.IsNullable).Returns(true);
+
+            EdmModel model = new EdmModel();
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetClrType(model, edmType.Object, true, resolver.Object)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetClrType(edmTypeRef.Object, resolver.Object);
+
+            // Assert
+            mapper.Verify();
+        }
+
+        [Fact]
+        public void GetClrTypeUsingEdmType_Calls_GetClrTypeOnMapper()
+        {
+            // Arrange
+            Mock<IEdmType> edmType = new Mock<IEdmType>();
+
+            EdmModel model = new EdmModel();
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetClrType(model, edmType.Object, true, AssemblyResolverHelper.Default)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetClrType(edmType.Object);
+
+            // Assert
+            mapper.Verify();
+        }
+
+        [Fact]
+        public void GetClrTypeUsingEdmTypeWithResolver_Calls_GetClrTypeOnMapper()
+        {
+            // Arrange
+            Mock<IAssemblyResolver> resolver = new Mock<IAssemblyResolver>();
+            Mock<IEdmType> edmType = new Mock<IEdmType>();
+
+            EdmModel model = new EdmModel();
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(x => x.GetClrType(model, edmType.Object, true, resolver.Object)).Verifiable();
+            model.SetTypeMapper(mapper.Object);
+
+            // Act
+            model.GetClrType(edmType.Object, resolver.Object);
+
+            // Assert
+            mapper.Verify();
+        }
 
         [Theory]
         [InlineData(typeof(MyCustomer), "MyCustomer")]
@@ -374,82 +221,5 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
             // Arrange & Act & Assert
             Assert.Equal(expectedName, clrType.EdmName());
         }
-
-        private static IEdmModel GetEdmModel()
-        {
-            EdmModel model = new EdmModel();
-            EdmComplexType address = new EdmComplexType("NS", "Address");
-            address.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
-            model.AddElement(address);
-            model.SetAnnotationValue(address, new ClrTypeAnnotation(typeof(MyAddress)));
-            var cnAddress = new EdmComplexType("NS", "CnAddress", address);
-            cnAddress.AddStructuralProperty("Zipcode", EdmPrimitiveTypeKind.String);
-            model.AddElement(cnAddress);
-            model.SetAnnotationValue(cnAddress, new ClrTypeAnnotation(typeof(CnMyAddress)));
-
-            var color = new EdmEnumType("NS", "Color");
-            model.AddElement(color);
-            model.SetAnnotationValue(color, new ClrTypeAnnotation(typeof(MyColor)));
-
-            var customer = new EdmEntityType("Microsoft.AspNetCore.OData.Tests.Edm", "MyCustomer");
-            model.AddElement(customer);
-
-            // Inheritance
-            var baseEntity = new EdmEntityType("NS", "BaseType");
-            var derived1Entity = new EdmEntityType("NS", "Derived1Type", baseEntity);
-            var derived2Entity = new EdmEntityType("NS", "Derived2Type", baseEntity);
-            var subDerivedEntity = new EdmEntityType("NS", "SubDerivedType", derived1Entity);
-            model.AddElements(new[] { baseEntity, derived1Entity, derived2Entity, subDerivedEntity });
-            model.SetAnnotationValue(baseEntity, new ClrTypeAnnotation(typeof(BaseType)));
-            model.SetAnnotationValue(derived1Entity, new ClrTypeAnnotation(typeof(Derived1Type)));
-            model.SetAnnotationValue(derived2Entity, new ClrTypeAnnotation(typeof(Derived2Type)));
-            model.SetAnnotationValue(subDerivedEntity, new ClrTypeAnnotation(typeof(SubDerivedType)));
-
-            return model;
-        }
-
-        public class MyAddress
-        {
-            public string City { get; set; }
-        }
-
-        public class CnMyAddress : MyAddress
-        {
-            public string Zipcode { get; set; }
-        }
-
-        public enum MyColor
-        {
-            Red
-        }
-
-        public class BaseType
-        { }
-
-        public class Derived1Type : BaseType
-        { }
-
-        public class Derived2Type : BaseType
-        { }
-
-        public class SubDerivedType : Derived1Type
-        { }
-
-        public class TypeNotInModel
-        { }
-
-        public class AssemblyResolver : IAssemblyResolver
-        {
-            public IEnumerable<Assembly> Assemblies
-            {
-                get
-                {
-                    yield return typeof(AssemblyResolver).Assembly;
-                }
-            }
-        }
     }
-
-    public class MyCustomer
-    { }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmModelAnnotationExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmModelAnnotationExtensionsTests.cs
@@ -205,6 +205,48 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
         }
 
         [Fact]
+        public void GetTypeMapper_ReturnsDefaultTypeMapper_IfNullModelOrWithoutTypeMapper()
+        {
+            // Arrange & Act & Assert
+            IEdmModel model = null;
+            Assert.IsType<DefaultODataTypeMapper>(model.GetTypeMapper());
+
+            // Arrange & Act & Assert
+            model = EdmCoreModel.Instance;
+            Assert.IsType<DefaultODataTypeMapper>(model.GetTypeMapper());
+
+            // Arrange & Act & Assert
+            model = new EdmModel();
+            Assert.IsType<DefaultODataTypeMapper>(model.GetTypeMapper());
+        }
+
+        [Fact]
+        public void SetTypeMapper_ThrowsArugmentNull_Model()
+        {
+            // Arrange & Act & Assert
+            IEdmModel model = null;
+            ExceptionAssert.ThrowsArgumentNull(() => model.SetTypeMapper(null), "model");
+
+            model = new Mock<IEdmModel>().Object;
+            ExceptionAssert.ThrowsArgumentNull(() => model.SetTypeMapper(null), "mapper");
+        }
+
+        [Fact]
+        public void GetAndSetTypeMapper_RoundTrip()
+        {
+            // Arrange
+            IODataTypeMapper mapper = new Mock<IODataTypeMapper>().Object;
+            IEdmModel model = new EdmModel();
+
+            // Act
+            model.SetTypeMapper(mapper);
+            IODataTypeMapper actual = model.GetTypeMapper();
+
+            // Assert
+            Assert.Same(mapper, actual);
+        }
+
+        [Fact]
         public void GetAlternateKeys_ThrowsArugmentNull_ForInputParameters()
         {
             // Arrange & Act & Assert

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/IODataTypeMapperExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/IODataTypeMapperExtensionsTests.cs
@@ -1,0 +1,130 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataTypeMapperExtensionsTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Tests.Commons;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Edm
+{
+    public class IODataTypeMapperExtensionsTests
+    {
+        [Fact]
+        public void GetPrimitiveType_ThrowsArgumentNull_ForInputParameters()
+        {
+            // Arrange & Act & Assert
+            IODataTypeMapper mapper = null;
+            ExceptionAssert.ThrowsArgumentNull(() => mapper.GetPrimitiveType(primitiveType: null), "mapper");
+
+            // Arrange & Act & Assert
+            mapper = new Mock<IODataTypeMapper>().Object;
+            ExceptionAssert.ThrowsArgumentNull(() => mapper.GetPrimitiveType(primitiveType: null), "primitiveType");
+        }
+
+        [Fact]
+        public void GetPrimitiveType_Calls_GetPrimitiveTypeOnInterface()
+        {
+            // Arrange
+            Mock<IEdmPrimitiveType> primitive = new Mock<IEdmPrimitiveType>();
+            Mock<IEdmPrimitiveTypeReference> primitiveRef = new Mock<IEdmPrimitiveTypeReference>();
+            primitiveRef.Setup(x => x.Definition).Returns(primitive.Object);
+            primitiveRef.SetupGet(x => x.IsNullable).Returns(false);
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(s => s.GetPrimitiveType(primitive.Object, false)).Verifiable();
+
+            // Act
+            mapper.Object.GetPrimitiveType(primitiveRef.Object);
+
+            // Assert
+            mapper.Verify();
+        }
+
+        [Fact]
+        public void GetEdmType_ThrowsArgumentNull_ForInputParameters()
+        {
+            // Arrange & Act & Assert
+            IODataTypeMapper mapper = null;
+            ExceptionAssert.ThrowsArgumentNull(() => mapper.GetEdmType(null, null), "mapper");
+        }
+
+        [Fact]
+        public void GetEdmType_Calls_GetEdmTypeReferenceOnInterface()
+        {
+            // Arrange
+            Mock<IEdmModel> model = new Mock<IEdmModel>();
+            Type type = typeof(int);
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(s => s.GetEdmTypeReference(model.Object, type)).Verifiable();
+
+            // Act
+            mapper.Object.GetEdmType(model.Object, type);
+
+            // Assert
+            mapper.Verify();
+        }
+
+        [Fact]
+        public void GetClrType_ThrowsArgumentNull_ForInputParameters()
+        {
+            // Arrange & Act & Assert
+            IODataTypeMapper mapper = null;
+            ExceptionAssert.ThrowsArgumentNull(() => mapper.GetClrType(null, null), "mapper");
+
+            // Arrange & Act & Assert
+            mapper = new Mock<IODataTypeMapper>().Object;
+            ExceptionAssert.ThrowsArgumentNull(() => mapper.GetClrType(null, null), "edmType");
+        }
+
+        [Fact]
+        public void GetClrType_Calls_GetClrTypeOnInterface()
+        {
+            // Arrange
+            Mock<IEdmModel> model = new Mock<IEdmModel>();
+            Mock<IEdmPrimitiveType> primitive = new Mock<IEdmPrimitiveType>();
+            Mock<IEdmPrimitiveTypeReference> primitiveRef = new Mock<IEdmPrimitiveTypeReference>();
+            primitiveRef.Setup(x => x.Definition).Returns(primitive.Object);
+            primitiveRef.SetupGet(x => x.IsNullable).Returns(false);
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(s => s.GetClrType(model.Object, primitive.Object, false, AssemblyResolverHelper.Default)).Verifiable();
+
+            // Act
+            mapper.Object.GetClrType(model.Object, primitiveRef.Object);
+
+            // Assert
+            mapper.Verify();
+        }
+
+        [Fact]
+        public void GetClrTypeWithAssemblyResolver_Calls_GetClrTypeOnInterface()
+        {
+            // Arrange
+            Mock<IAssemblyResolver> resolver = new Mock<IAssemblyResolver>();
+            Mock<IEdmModel> model = new Mock<IEdmModel>();
+            Mock<IEdmPrimitiveType> primitive = new Mock<IEdmPrimitiveType>();
+            Mock<IEdmPrimitiveTypeReference> primitiveRef = new Mock<IEdmPrimitiveTypeReference>();
+            primitiveRef.Setup(x => x.Definition).Returns(primitive.Object);
+            primitiveRef.SetupGet(x => x.IsNullable).Returns(false);
+
+            Mock<IODataTypeMapper> mapper = new Mock<IODataTypeMapper>();
+            mapper.Setup(s => s.GetClrType(model.Object, primitive.Object, false, resolver.Object)).Verifiable();
+
+            // Act
+            mapper.Object.GetClrType(model.Object, primitiveRef.Object, resolver.Object);
+
+            // Assert
+            mapper.Verify();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/TypeCacheItemTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/TypeCacheItemTests.cs
@@ -1,0 +1,126 @@
+//-----------------------------------------------------------------------------
+// <copyright file="TypeCacheItemTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Edm
+{
+    public class TypeCacheItemTests
+    {
+        #region TryFindEdmType
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(TypeCacheItemTests))]
+        public void AddAndFindEdmType_Returns_CachedInstance(Type testType)
+        {
+            // Arrange
+            IEdmTypeReference edmType = new Mock<IEdmTypeReference>().Object;
+            TypeCacheItem cache = new TypeCacheItem();
+
+            // Act
+            bool found = cache.TryFindEdmType(testType, out _);
+            Assert.False(found); // not found
+
+            cache.AddClrToEdmMap(testType, edmType);
+            found = cache.TryFindEdmType(testType, out IEdmTypeReference acutal);
+
+            // Assert
+            Assert.True(found);
+            Assert.Same(edmType, acutal);
+        }
+
+        [Fact]
+        public void AddClrToEdmMap_Cached_OnlyOneInstance()
+        {
+            // Arrange
+            TypeCacheItem cache = new TypeCacheItem();
+            Action cacheCallAndVerify = () =>
+            {
+                IEdmTypeReference edmType = new Mock<IEdmTypeReference>().Object;
+                cache.AddClrToEdmMap(typeof(TypeCacheItemTests), edmType);
+                Assert.Single(cache.ClrToEdmTypeCache);
+            };
+
+            // Act & Assert
+            cacheCallAndVerify();
+
+            // 5 is a magic number, it doesn't matter, just want to call it multiple times.
+            for (int i = 0; i < 5; i++)
+            {
+                cacheCallAndVerify();
+            }
+
+            cacheCallAndVerify();
+        }
+
+        #endregion
+
+        #region TryFindClrType
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(TypeCacheItemTests))]
+        public void AddAndGetClrType_Returns_CorrectType(Type testType)
+        {
+            // Arrange
+            IEdmType edmType = new Mock<IEdmType>().Object;
+            TypeCacheItem cache = new TypeCacheItem();
+
+            // Act
+            bool found = cache.TryFindClrType(edmType, true, out _);
+            Assert.False(found);
+
+            cache.AddEdmToClrMap(edmType, true, testType);
+
+            found = cache.TryFindClrType(edmType, true, out Type actualType);
+
+            // Act & Assert
+            Assert.True(found);
+            Assert.Same(testType, actualType);
+        }
+
+        [Fact]
+        public void AddEdmToClrMap_Cached_OnlyOneInstance()
+        {
+            // Arrange
+            TypeCacheItem cache = new TypeCacheItem();
+            IEdmType edmType = new Mock<IEdmType>().Object;
+
+            Action cacheCallAndVerify = () =>
+            {
+                cache.AddEdmToClrMap(edmType, true, typeof(int?));
+                cache.AddEdmToClrMap(edmType, false, typeof(int));
+
+                KeyValuePair<IEdmType, (Type, Type)> item = Assert.Single(cache.EdmToClrTypeCache);
+                Assert.Same(edmType, item.Key);
+                Assert.Equal(typeof(int), item.Value.Item1);
+                Assert.Equal(typeof(int?), item.Value.Item2);
+            };
+
+            // Act & Assert
+            cacheCallAndVerify();
+
+            // 5 is a magic number, it doesn't matter, just want to call it multiple times.
+            for (int i = 0; i < 5; i++)
+            {
+                cacheCallAndVerify();
+            }
+
+            cacheCallAndVerify();
+        }
+        #endregion
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/CollectionDeserializationHelpersTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/CollectionDeserializationHelpersTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
 
             // Act
             source.AddToCollection(newCollection, typeof(DateTime), typeof(CollectionDeserializationHelpersTest),
-                "PropertyName", newCollection.GetType(), timeZoneInfo: null);
+                "PropertyName", newCollection.GetType(), context: null);
 
             // Assert
             Assert.Equal(expect, newCollection as IEnumerable<DateTime>);
@@ -105,10 +105,14 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IList source = new List<DateTimeOffset> { new DateTimeOffset(dt1), new DateTimeOffset(dt2) };
             IEnumerable newCollection = new CustomCollectionWithAdd<DateTime>();
             TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8:00 / -7:00
+            ODataDeserializerContext context = new ODataDeserializerContext
+            {
+                TimeZone = timeZoneInfo
+            };
 
             // Act
             source.AddToCollection(newCollection, typeof(DateTime), typeof(CollectionDeserializationHelpersTest),
-                "PropertyName", newCollection.GetType(), timeZoneInfo);
+                "PropertyName", newCollection.GetType(), context);
 
             // Assert
             Assert.Equal(new[] { dt1.AddHours(-8), dt2.AddHours(-7) }, newCollection as IEnumerable<DateTime>);
@@ -130,7 +134,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
 
             // Act
             source.AddToCollection(newCollection, typeof(DateTime), typeof(CollectionDeserializationHelpersTest),
-                "PropertyName", newCollection.GetType(), timeZoneInfo: null);
+                "PropertyName", newCollection.GetType(), context: null);
 
             // Assert
             Assert.Equal(expect, newCollection as IEnumerable<DateTime>);
@@ -145,10 +149,14 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IList source = new List<DateTimeOffset> { dto1, dto2 };
             IEnumerable newCollection = new CustomCollectionWithAdd<DateTime>();
             TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8:00 / -7:00
+            ODataDeserializerContext context = new ODataDeserializerContext
+            {
+                TimeZone = timeZone
+            };
 
             // Act
             source.AddToCollection(newCollection, typeof(DateTime), typeof(CollectionDeserializationHelpersTest),
-                "PropertyName", newCollection.GetType(), timeZone);
+                "PropertyName", newCollection.GetType(), context);
 
             // Assert
             Assert.Equal(new[] { new DateTime(2014, 12, 15, 9, 2, 3), new DateTime(2014, 12, 15, 19, 2, 3) },

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationHelpersTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/DeserializationHelpersTest.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
             IEnumerable<DateTime> expects = dtos.Select(e => e.LocalDateTime);
 
             // Act
-            DeserializationHelpers.SetCollectionProperty(source, edmProperty, dtos, edmProperty.Name, timeZoneInfo: null);
+            DeserializationHelpers.SetCollectionProperty(source, edmProperty, dtos, edmProperty.Name, context: null);
 
             // Assert
             Assert.Equal(expects, source.DateTimeList);
@@ -191,9 +191,13 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
                 new DateTimeOffset(dt, new TimeSpan(+7, 0, 0)),
                 new DateTimeOffset(dt, new TimeSpan(-8, 0, 0))
             };
+            ODataDeserializerContext context = new ODataDeserializerContext
+            {
+                TimeZone = tzi
+            };
 
             // Act
-            DeserializationHelpers.SetCollectionProperty(source, edmProperty, dtos, edmProperty.Name, timeZoneInfo: tzi);
+            DeserializationHelpers.SetCollectionProperty(source, edmProperty, dtos, edmProperty.Name, context: context);
 
             // Assert
             Assert.Equal(new List<DateTime> { dt.AddHours(-8), dt.AddHours(-15), dt }, source.DateTimeList);
@@ -375,7 +379,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
 
             var property = new ODataProperty { Name = "Unknown", Value = "Value" };
             var entityType = new EdmComplexType("namespace", "name");
-            entityType.AddStructuralProperty("Known", typeof(string).GetEdmPrimitiveTypeReference());
+            entityType.AddStructuralProperty("Known", EdmCoreModel.Instance.GetString(true));
 
             var entityTypeReference = new EdmComplexTypeReference(entityType, isNullable: false);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -524,6 +524,13 @@ public class Microsoft.AspNetCore.OData.Deltas.DeltaSet`1 : System.Collections.O
 	System.Type StructuredType  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Edm.IODataTypeMapper {
+	System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+	Microsoft.OData.Edm.IEdmTypeReference GetEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	Microsoft.OData.Edm.IEdmPrimitiveTypeReference GetPrimitiveType (System.Type clrType)
+	System.Type GetPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
+}
+
 [
 ExtensionAttribute(),
 ]
@@ -561,7 +568,17 @@ public sealed class Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions 
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.AspNetCore.OData.Edm.IODataTypeMapper GetTypeMapper (Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static void SetModelName (Microsoft.OData.Edm.IEdmModel model, string name)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static void SetTypeMapper (Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper)
 }
 
 [
@@ -609,11 +626,45 @@ public sealed class Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions
 	public static void SetOperationLinkBuilder (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperation operation, Microsoft.AspNetCore.OData.Edm.OperationLinkBuilder operationLinkBuilder)
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetClrType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetClrType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.OData.Edm.IEdmType GetEdmType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetPrimitiveType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType)
+}
+
 public class Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation {
 	public CustomAggregateMethodAnnotation ()
 
 	public Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation AddMethod (string methodToken, System.Collections.Generic.IDictionary`2[[System.Type],[System.Reflection.MethodInfo]] methods)
 	public bool GetMethodInfo (string methodToken, System.Type returnType, out System.Reflection.MethodInfo& methodInfo)
+}
+
+public class Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper : IODataTypeMapper {
+	public DefaultODataTypeMapper ()
+
+	public virtual System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+	public virtual Microsoft.OData.Edm.IEdmTypeReference GetEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	public virtual Microsoft.OData.Edm.IEdmPrimitiveTypeReference GetPrimitiveType (System.Type clrType)
+	public virtual System.Type GetPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
 }
 
 public class Microsoft.AspNetCore.OData.Edm.EntitySelfLinks {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -524,6 +524,13 @@ public class Microsoft.AspNetCore.OData.Deltas.DeltaSet`1 : System.Collections.O
 	System.Type StructuredType  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Edm.IODataTypeMapper {
+	System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+	Microsoft.OData.Edm.IEdmTypeReference GetEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	Microsoft.OData.Edm.IEdmPrimitiveTypeReference GetPrimitiveType (System.Type clrType)
+	System.Type GetPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
+}
+
 [
 ExtensionAttribute(),
 ]
@@ -561,7 +568,17 @@ public sealed class Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions 
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.AspNetCore.OData.Edm.IODataTypeMapper GetTypeMapper (Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static void SetModelName (Microsoft.OData.Edm.IEdmModel model, string name)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static void SetTypeMapper (Microsoft.OData.Edm.IEdmModel model, Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper)
 }
 
 [
@@ -609,11 +626,45 @@ public sealed class Microsoft.AspNetCore.OData.Edm.EdmModelLinkBuilderExtensions
 	public static void SetOperationLinkBuilder (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperation operation, Microsoft.AspNetCore.OData.Edm.OperationLinkBuilder operationLinkBuilder)
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Edm.IODataTypeMapperExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetClrType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetClrType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.OData.Edm.IEdmType GetEdmType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Type GetPrimitiveType (Microsoft.AspNetCore.OData.Edm.IODataTypeMapper mapper, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType)
+}
+
 public class Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation {
 	public CustomAggregateMethodAnnotation ()
 
 	public Microsoft.AspNetCore.OData.Edm.CustomAggregateMethodAnnotation AddMethod (string methodToken, System.Collections.Generic.IDictionary`2[[System.Type],[System.Reflection.MethodInfo]] methods)
 	public bool GetMethodInfo (string methodToken, System.Type returnType, out System.Reflection.MethodInfo& methodInfo)
+}
+
+public class Microsoft.AspNetCore.OData.Edm.DefaultODataTypeMapper : IODataTypeMapper {
+	public DefaultODataTypeMapper ()
+
+	public virtual System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
+	public virtual Microsoft.OData.Edm.IEdmTypeReference GetEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	public virtual Microsoft.OData.Edm.IEdmPrimitiveTypeReference GetPrimitiveType (System.Type clrType)
+	public virtual System.Type GetPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
 }
 
 public class Microsoft.AspNetCore.OData.Edm.EntitySelfLinks {


### PR DESCRIPTION
In the existing implementation, customers can't customize the OData CLR type and Edm type mapping.

This PR introduces `IODataTypeMapper` and its default implementation `DefaultODataTypeMapper`.

The developer can create his own type of mapper to override it.