### PR TITLE
Added possibility to bind params of custom type

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -139,6 +139,11 @@ namespace Microsoft.AspNetCore.OData.Edm
                 }
                 else
                 {
+                    if (TypeHelper.TryGetInstance(type, value, out var result))
+                    {
+                        return result;
+                    }
+
                     try
                     {
                         // Note that we are not casting the return value to nullable<T> as even if we do it

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
 
             // primitive value
-            if (edmTypeReference.IsPrimitive())
+            if (edmTypeReference.IsPrimitive() || edmTypeReference.Definition.TypeKind == EdmTypeKind.TypeDefinition)
             {
                 ConstantNode node = graph as ConstantNode;
                 return EdmPrimitiveHelper.ConvertPrimitiveValue(node != null ? node.Value : graph, clrType, readContext?.TimeZone);

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinderConverter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
 
             // primitive value
-            if (edmTypeReference.IsPrimitive() || edmTypeReference.Definition.TypeKind == EdmTypeKind.TypeDefinition)
+            if (edmTypeReference.IsPrimitive() || edmTypeReference.IsTypeDefinition())
             {
                 ConstantNode node = graph as ConstantNode;
                 return EdmPrimitiveHelper.ConvertPrimitiveValue(node != null ? node.Value : graph, clrType, readContext?.TimeZone);


### PR DESCRIPTION
If the function parameter, marked with [FromODataUri] has custom type in the model (TypeDefinition) it could still be processed as a primitive (cause it has primitive underlying type)