### PR TITLE
Fix convert type issue when property name case-insensitive

### DIFF
--- a/sample/ODataRoutingSample/Controllers/ProductsController.cs
+++ b/sample/ODataRoutingSample/Controllers/ProductsController.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -32,18 +33,24 @@ namespace ODataRoutingSample.Controllers
                     {
                         Category = "Goods",
                         Color = Color.Red,
+                        CreatedDate = new DateTimeOffset(2001, 4, 15, 16, 24, 8, TimeSpan.FromHours(-8)),
+                        UpdatedDate = new DateTimeOffset(2011, 2, 15, 16, 24, 8, TimeSpan.FromHours(-8)),
                         Detail = new ProductDetail { Id = "3", Info = "Zhang" },
                     },
                     new Product
                     {
                         Category = "Magazine",
                         Color = Color.Blue,
+                        CreatedDate = new DateTimeOffset(2021, 12, 27, 9, 12, 8, TimeSpan.FromHours(-8)),
+                        UpdatedDate = null,
                         Detail = new ProductDetail { Id = "4", Info = "Jinchan" },
                     },
                     new Product
                     {
                         Category = "Fiction",
                         Color = Color.Green,
+                        CreatedDate = new DateTimeOffset(1978, 11, 15, 9, 24, 8, TimeSpan.FromHours(-8)),
+                        UpdatedDate = new DateTimeOffset(1987, 2, 25, 5, 1, 8, TimeSpan.FromHours(-8)),
                         Detail = new ProductDetail { Id = "5", Info = "Hollewye" },
                     },
                 };

--- a/sample/ODataRoutingSample/Models/Product.cs
+++ b/sample/ODataRoutingSample/Models/Product.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
+
 namespace ODataRoutingSample.Models
 {
     public class Product
@@ -14,6 +16,10 @@ namespace ODataRoutingSample.Models
         public string Category { get; set; }
 
         public Color Color { get; set; }
+
+        public DateTimeOffset CreatedDate { get; set; }
+
+        public DateTimeOffset? UpdatedDate { get; set; }
 
         public virtual ProductDetail Detail { get; set; }
     }

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.OData.Edm
                     }
                     catch (InvalidCastException)
                     {
-                        throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, type));
+                        throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, value.ToString(), type));
                     }
                     catch (FormatException)
                     {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     return date;
                 }
 
-                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, clrType.FullName));
+                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, stringValue, clrType.FullName));
             }
 
             // TimeOfDay
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     return date;
                 }
 
-                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, clrType.FullName));
+                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, stringValue, clrType.FullName));
             }
 
             // DateTimeOffset
@@ -360,7 +360,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     return dto;
                 }
 
-                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, clrType.FullName));
+                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, stringValue, clrType.FullName));
             }
 
             if (clrType == typeof(Double) || clrType == typeof(Single))
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 {
                     return d;
                 }
-                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, clrType.FullName));
+                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, stringValue, clrType.FullName));
 
             }
 
@@ -380,7 +380,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     return s;
                 }
 
-                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, clrType.FullName));
+                throw new ValidationException(Error.Format(SRResources.PropertyCannotBeConverted, stringValue, clrType.FullName));
             }
 
             // for others, for example the spatial primitive types. Let's wait ODL to fix it.

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6834,7 +6834,7 @@
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyCannotBeConverted">
             <summary>
-              Looks up a localized string similar to The value cannot be converted to type {0}..
+              Looks up a localized string similar to The value &apos;{0}&apos; cannot be converted to type {1}..
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.PropertyIsNotCollection">

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value cannot be converted to type {0}..
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; cannot be converted to type {1}..
         /// </summary>
         internal static string PropertyCannotBeConverted {
             get {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -706,7 +706,7 @@
     <value>Unable to parse query request payload.</value>
   </data>
   <data name="PropertyCannotBeConverted" xml:space="preserve">
-    <value>The value cannot be converted to type {0}.</value>
+    <value>The value '{0}' cannot be converted to type {1}.</value>
   </data>
   <data name="PropertyTypeOverflow" xml:space="preserve">
     <value>The value has a value that is out of range of type {0}.</value>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetController.cs
@@ -20,8 +20,6 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DateTimeOffsetSupport
     {
         private readonly FilesContext _db;
 
-        
-
          public FilesController(FilesContext context)
         {
             context.Database.EnsureCreated();

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Deltas;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.DateTimeOffsetSupport
 {
@@ -57,6 +58,17 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DateTimeOffsetSupport
         [HttpPost]
         public IActionResult Post([FromBody]File file)
         {
+            if (file.FileId == 99)
+            {
+                // Special test case for property name case-insensitive
+                Assert.Equal("abc", file.Name);
+                Assert.Equal(DateTimeOffset.Parse("10/28/2021 9:33:26 PM +08:00"), file.CreatedDate);
+                Assert.Equal(DateTimeOffset.Parse("11/1/2021 10:48:12 AM +08:00"), file.DeleteDate);
+
+                // special string used to verify at test case.
+                return Ok("PropertyCaseInsensitive");
+            }
+
             _db.Files.Add(file);
             _db.SaveChanges();
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateTimeOffsetSupport/DateTimeOffsetTest.cs
@@ -181,6 +181,34 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DateTimeOffsetSupport
             getResponse = await client.GetAsync(fileUri);
             Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
         }
+
+        [Fact]
+        public async Task CreateFileEntity_Works_UsingDifferentPropertyNameCase()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            string filesUri = $"convention/Files";
+            string content =
+                "{" +
+                    "\"fileid\":99," + // use a special ID to test
+                    "\"naMe\":\"abc\"," +
+                    "\"creaTeddate\":\"2021-10-28T21:33:26+08:00\"," +
+                    "\"deLEteDate\":\"2021-11-01T10:48:12+08:00\"" +
+                "}";
+
+            // Act: POST ~/Files
+            HttpRequestMessage postRequest = new HttpRequestMessage(HttpMethod.Post, filesUri);
+            postRequest.Content = new StringContent(content);
+            postRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+            var postResponse = await client.SendAsync(postRequest);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, postResponse.StatusCode);
+
+            string payload = await postResponse.Content.ReadAsStringAsync();
+            Assert.Contains("PropertyCaseInsensitive", payload);
+        }
         #endregion
 
         #region Query option on DateTime

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -80,8 +80,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
                     { 0, typeof(bool), "The value must be a boolean." },
                     { 1024, typeof(byte), "The value has a value that is out of range of type System.Byte." },
                     { "data", typeof(long),  "The value has a format that is not recognized by type System.Int64." },
-                    { "data", typeof(TestStruct),  "The value cannot be converted to type Microsoft.AspNetCore.OData.Tests.Edm.EdmPrimitiveHelperTests+TestStruct." },
-                    { new TestStruct(), typeof(int),  "The value cannot be converted to type System.Int32." }
+                    { "data", typeof(TestStruct),  "The value 'data' cannot be converted to type Microsoft.AspNetCore.OData.Tests.Edm.EdmPrimitiveHelperTests+TestStruct." },
+                    { new TestStruct(), typeof(int),  "The value 'Microsoft.AspNetCore.OData.Tests.Edm.EdmPrimitiveHelperTests+TestStruct' cannot be converted to type System.Int32." }
                 };
 
         public static TheoryDataSet<DateTimeOffset> ConvertDateTime_NonStandardPrimitives_Data


### PR DESCRIPTION
#345 


 Since we support property name case-insensitive and enable "ReadUntypedAsString=true" by default.
 ODL reads "unknown" property value as "value", not as "ODataUntypedValue".
 For most of the primitive types, for example, DateTimeOffset, the "value" from ODL is a "string".
 We should convert the "string" value to its correct format.
Ideally, ODL should read "case-insensitive" property value as its correct format. So far, ODL hasn't been enabled.

This PR is to add a workaround for fixing most primitive-type property case-insensitive.

The ideal fix is to fix it on the ODL side and allow to read property name case-insensitive.