### PR TITLE
If $count=true, add count to context item

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -484,6 +484,19 @@ namespace Microsoft.AspNetCore.OData.Query
                     }
                 }
 
+                // if $count=true is used, add the count to the context. This allows the consuming web site
+                // to retrieve the count in middleware without having to use the odata controller.
+
+                bool countParameterIsTrue = queryOptions.Count?.Value ?? false;
+                if (countParameterIsTrue)
+                {
+                    long? count = request.ODataFeature().TotalCount;
+                    if (count.HasValue)
+                    {
+                        request.HttpContext.Items["ODataCount"] = count;
+                    }
+                }
+
                 return queryable;
             }
         }

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -484,8 +484,8 @@ namespace Microsoft.AspNetCore.OData.Query
                     }
                 }
 
-                // if $count=true is used, add the count to the context. This allows the consuming web site
-                // to retrieve the count in middleware without having to use the odata controller.
+                // if $count=true is used, add the count to the context. This way, the count can be retrieved in middleware
+                // and for example used to create a response header with this count.
 
                 bool countParameterIsTrue = queryOptions.Count?.Value ?? false;
                 if (countParameterIsTrue)


### PR DESCRIPTION
I added OData to an existing large API, It works great. However, when a client adds $count=true to the url, they do not get the count. To make this happen, I would have to provide an EDM and go via the odata controller. However:

- I would also have to change many of my end points, meaning breaking changes for my clients.
- The responses from the end points would also change (they would now include the odata meta data, and the data would sit in a separate array).

Created this pull request to allow me (and your other users) to retrieve the count without making these changes. If the url contains $count=true, and if the count is available, the count will be added to the HttpContext, as item "ODataCount".

This way, the count can be retrieved in middleware (from the context item). I used this in my API to create a response header with the count. Other users of this library could process the count in another way, or not at all. Specifically, this change does not in itself modify the HTTP response from APIs using this library, so no surprises for your users.  

Thanks in advance for considering this pull request. 


