### PR TITLE
Trim forward slashes from route prefix

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6190,6 +6190,13 @@
             <param name="setupAction">The setup config.</param>
             <returns>The built service provider.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataOptions.SanitizeRoutePrefix(System.String)">
+            <summary>
+            Sanitizes the route prefix by stripping leading and trailing forward slashes.
+            </summary>
+            <param name="routePrefix">Route prefix to sanitize.</param>
+            <returns>Sanitized route prefix.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataOptionsSetup">
             <summary>
             Sets up default options for <see cref="T:Microsoft.AspNetCore.OData.ODataOptions"/>.

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Batch;
@@ -323,7 +324,9 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>Sanitized route prefix.</returns>
         private string SanitizeRoutePrefix(string routePrefix)
         {
-            if (!routePrefix.StartsWith('/') && !routePrefix.EndsWith('/'))
+            Debug.Assert(routePrefix != null);
+
+            if (routePrefix.Length > 0 && routePrefix[0] != '/' && routePrefix[^1] != '/')
             {
                 return routePrefix;
             }

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.OData
                 throw Error.ArgumentNull(nameof(routePrefix));
             }
 
-            string sanitizedRoutePrefix = routePrefix.Trim('/');
+            string sanitizedRoutePrefix = SanitizeRoutePrefix(routePrefix);
 
             if (RouteComponents.ContainsKey(sanitizedRoutePrefix))
             {
@@ -155,9 +155,16 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The root service provider for the route (prefix) name.</returns>
         public IServiceProvider GetRouteServices(string routePrefix)
         {
-            if (routePrefix != null && RouteComponents.ContainsKey(routePrefix))
+            if (routePrefix == null)
             {
-                return RouteComponents[routePrefix].ServiceProvider;
+                return null;
+            }
+
+            string sanitizedRoutePrefix = SanitizeRoutePrefix(routePrefix);
+
+            if (RouteComponents.TryGetValue(sanitizedRoutePrefix, out var components))
+            {
+                return components.ServiceProvider;
             }
 
             return null;
@@ -307,6 +314,21 @@ namespace Microsoft.AspNetCore.OData
             setupAction?.Invoke(builder.Services);
 
             return builder.BuildContainer();
+        }
+
+        /// <summary>
+        /// Sanitizes the route prefix by stripping leading and trailing forward slashes.
+        /// </summary>
+        /// <param name="routePrefix">Route prefix to sanitize.</param>
+        /// <returns>Sanitized route prefix.</returns>
+        private string SanitizeRoutePrefix(string routePrefix)
+        {
+            if (!routePrefix.StartsWith('/') && !routePrefix.EndsWith('/'))
+            {
+                return routePrefix;
+            }
+
+            return routePrefix.Trim('/');
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -129,14 +129,22 @@ namespace Microsoft.AspNetCore.OData
                 throw Error.ArgumentNull(nameof(model));
             }
 
-            if (RouteComponents.ContainsKey(routePrefix))
+            if (routePrefix == null)
             {
-                throw Error.InvalidOperation(SRResources.ModelPrefixAlreadyUsed, routePrefix);
+                throw Error.ArgumentNull(nameof(routePrefix));
             }
+
+            string sanitizedRoutePrefix = routePrefix.Trim('/');
+
+            if (RouteComponents.ContainsKey(sanitizedRoutePrefix))
+            {
+                throw Error.InvalidOperation(SRResources.ModelPrefixAlreadyUsed, sanitizedRoutePrefix);
+            }
+
 
             // Consider to use Lazy<IServiceProvider> ?
             IServiceProvider serviceProvider = BuildRouteContainer(model, configureServices);
-            RouteComponents[routePrefix] = (model, serviceProvider);
+            RouteComponents[sanitizedRoutePrefix] = (model, serviceProvider);
             return this;
         }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
@@ -221,6 +221,30 @@ namespace Microsoft.AspNetCore.OData.Tests
             Assert.NotNull(sp);
         }
 
+        [Theory]
+        [InlineData("/odata")]
+        [InlineData("/odata/")]
+        [InlineData("odata/")]
+        public void GetRouteServices_ReturnsCorrectServiceProvider_When_Leading_Or_Trailing_Slashes(string routePrefix)
+        {
+            // Arrange
+            ODataOptions options = new ODataOptions();
+            IEdmModel edmModel = EdmCoreModel.Instance;
+
+            // Act
+            options.AddRouteComponents(routePrefix, edmModel);
+
+            // & Assert
+            // can retrieve service provider using original routePrefix
+            IServiceProvider sp = options.GetRouteServices(routePrefix);
+            Assert.NotNull(sp);
+
+            // can retrieve service provider using sanitized routePrefix
+            string sanitizedRoutePrefix = "odata";
+            IServiceProvider sp2 = options.GetRouteServices(sanitizedRoutePrefix);
+            Assert.NotNull(sp2);
+        }
+
         #region QuerySetting
         [Fact]
         public void SetMaxTop_Throws_ForWrongValue()

--- a/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
@@ -140,6 +140,25 @@ namespace Microsoft.AspNetCore.OData.Tests
             Assert.IsType<ODataFeature>(actual);
         }
 
+        [Theory]
+        [InlineData("/odata")]
+        [InlineData("/odata/")]
+        [InlineData("odata/")]
+        public void AddRouteComponents_Strips_RoutePrefix_Leading_And_Trailing_Slashes(string routePrefix)
+        {
+            // Arrange
+            string expectedRoutePrefix = "odata";
+            ODataOptions options = new ODataOptions();
+            IEdmModel edmModel = EdmCoreModel.Instance;
+
+            // Act
+            options.AddRouteComponents(routePrefix, edmModel, services => services.AddSingleton<IODataFeature, ODataFeature>());
+
+            // Assert
+            Assert.False(options.RouteComponents.ContainsKey(routePrefix));
+            Assert.True(options.RouteComponents.ContainsKey(expectedRoutePrefix));
+        }
+
         [Fact]
         public void AddRouteComponents_Throws_IfModelNull()
         {
@@ -148,6 +167,16 @@ namespace Microsoft.AspNetCore.OData.Tests
 
             // Act & Assert
             ExceptionAssert.ThrowsArgumentNull(() => options.AddRouteComponents("odata", null, builder => { }), "model");
+        }
+
+        [Fact]
+        public void AddRouteComponents_Throws_IfRoutePrefixNull()
+        {
+            // Arrange
+            ODataOptions options = new ODataOptions();
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgumentNull(() => options.AddRouteComponents(null, EdmCoreModel.Instance, builder => { }), "routePrefix");
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
@@ -141,13 +141,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         }
 
         [Theory]
-        [InlineData("/odata")]
-        [InlineData("/odata/")]
-        [InlineData("odata/")]
-        public void AddRouteComponents_Strips_RoutePrefix_Leading_And_Trailing_Slashes(string routePrefix)
+        [InlineData("/odata", "odata")]
+        [InlineData("/odata/", "odata")]
+        [InlineData("odata/", "odata")]
+        [InlineData("/", "")]
+        public void AddRouteComponents_Strips_RoutePrefix_Leading_And_Trailing_Slashes(string routePrefix, string expectedRoutePrefix)
         {
             // Arrange
-            string expectedRoutePrefix = "odata";
             ODataOptions options = new ODataOptions();
             IEdmModel edmModel = EdmCoreModel.Instance;
 


### PR DESCRIPTION
Fix #382 

This PR strips leading and trailing forward slashes from the OData path route prefix before registering route components service provider. This avoids the issues mentioned in #382 which result in the route prefix with leading slashes not being routed to OData endpoints. Route prefix with trailing slashes were causing an exception to be thrown because it would be combined with the endpoint path leading to 2 consecutive forward slashes.