### PR TITLE
✏️ Fix 'none OData' -> 'non-OData' typo

### DIFF
--- a/sample/ODataSampleCommon/ODataEndpointController.cs
+++ b/sample/ODataSampleCommon/ODataEndpointController.cs
@@ -128,7 +128,7 @@ namespace ODataSampleCommon
 <body>
     <h1 id=""odata"">OData Endpoint Mappings</h1>
     <p>
-        <a href=""#standard"">Got to none OData endpoint mappings</a>
+        <a href=""#standard"">Got to non-OData endpoint mappings</a>
     </p>
     <table>
         <tr>
@@ -138,7 +138,7 @@ namespace ODataSampleCommon
         </tr>
         ODATA_ROUTE_CONTENT
     </table>
-    <h1 id=""standard"">None OData Endpoint Mappings</h1>
+    <h1 id=""standard"">Non-OData Endpoint Mappings</h1>
     <p>
         <a href=""#odata"">Go to OData endpoint mappings</a>
     </p>

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.OData.Routing
 <body>
     <h1 id=""odata"">OData Endpoint Mappings</h1>
     <p>
-        <a href=""#standard"">Go to none OData endpoint mappings</a>
+        <a href=""#standard"">Go to non-OData endpoint mappings</a>
     </p>
     <table>
         <tr>
@@ -218,7 +218,7 @@ namespace Microsoft.AspNetCore.OData.Routing
         </tr>
         ODATA_ROUTE_CONTENT
     </table>
-    <h1 id=""standard"">None OData Endpoint Mappings</h1>
+    <h1 id=""standard"">Non-OData Endpoint Mappings</h1>
     <p>
         <a href=""#odata"">Go to OData endpoint mappings</a>
     </p>


### PR DESCRIPTION
This PR changes all occurrences of "none OData" (referring to "not of OData type") to the correct "non-OData" wording.

Fixes #427 