### PR TITLE
Adds dependency injection support in non-model scenario

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -271,12 +271,6 @@ namespace Microsoft.AspNetCore.OData.Extensions
                 return requestContainer;
             }
 
-            // if the prefixName == null, it's a non-model scenario
-            if (request.ODataFeature().RoutePrefix == null)
-            {
-                return null;
-            }
-
             // HTTP routes will not have chance to call CreateRequestContainer. We have to call it.
             return request.CreateRouteServices(request.ODataFeature().RoutePrefix);
         }
@@ -300,6 +294,11 @@ namespace Microsoft.AspNetCore.OData.Extensions
             }
 
             IServiceScope requestScope = request.CreateRequestScope(routePrefix);
+            if (requestScope == null)
+            {
+                // non-model scenario with dependency injection non enabled
+                return null;
+            }
             IServiceProvider requestContainer = requestScope.ServiceProvider;
 
             request.ODataFeature().RequestScope = requestScope;
@@ -342,13 +341,14 @@ namespace Microsoft.AspNetCore.OData.Extensions
             ODataOptions options = request.ODataOptions();
 
             IServiceProvider rootContainer = options.GetRouteServices(routePrefix);
+            if (rootContainer == null)
+            {
+                return null;
+            }
             IServiceScope scope = rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
 
-            // Bind scoping request into the OData container.
-            if (!string.IsNullOrEmpty(routePrefix))
-            {
-                scope.ServiceProvider.GetRequiredService<HttpRequestScope>().HttpRequest = request;
-            }
+            // Bind scoping request into the OData container.            
+            scope.ServiceProvider.GetRequiredService<HttpRequestScope>().HttpRequest = request;
 
             return scope;
         }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6102,6 +6102,13 @@
             Gets the <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.RouteOptions"/> instance responsible for configuring the route template.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataOptions.EnableDependencyInjection(System.Action{Microsoft.Extensions.DependencyInjection.IServiceCollection})">
+            <summary>
+            Enables dependency injection support for non-model scenario
+            </summary>
+            <param name="configureServices">The configuring action to add the services to the container.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataOptions"/> instance to enable fluent configuration.</returns>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.ODataOptions.RouteComponents">
             <summary>
             Contains the OData <see cref="T:Microsoft.OData.Edm.IEdmModel"/> instances and dependency injection containers for specific routes.
@@ -6218,12 +6225,12 @@
             Gets the query setting.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.ODataOptions.BuildRouteContainer(Microsoft.OData.Edm.IEdmModel,System.Action{Microsoft.Extensions.DependencyInjection.IServiceCollection})">
+        <member name="M:Microsoft.AspNetCore.OData.ODataOptions.BuildContainer(System.Action{Microsoft.Extensions.DependencyInjection.IServiceCollection},Microsoft.OData.Edm.IEdmModel)">
             <summary>
             Build the container.
             </summary>
-            <param name="model">The Edm model.</param>
             <param name="setupAction">The setup config.</param>
+            <param name="model">The Edm model.</param>
             <returns>The built service provider.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataOptions.SanitizeRoutePrefix(System.String)">

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -657,6 +657,7 @@ Microsoft.AspNetCore.OData.ODataOptions.EnableAttributeRouting.get -> bool
 Microsoft.AspNetCore.OData.ODataOptions.EnableAttributeRouting.set -> void
 Microsoft.AspNetCore.OData.ODataOptions.EnableContinueOnErrorHeader.get -> bool
 Microsoft.AspNetCore.OData.ODataOptions.EnableContinueOnErrorHeader.set -> void
+Microsoft.AspNetCore.OData.ODataOptions.EnableDependencyInjection(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configureServices) -> Microsoft.AspNetCore.OData.ODataOptions
 Microsoft.AspNetCore.OData.ODataOptions.EnableNoDollarQueryOptions.get -> bool
 Microsoft.AspNetCore.OData.ODataOptions.EnableNoDollarQueryOptions.set -> void
 Microsoft.AspNetCore.OData.ODataOptions.EnableQueryFeatures(int? maxTopValue = null) -> Microsoft.AspNetCore.OData.ODataOptions


### PR DESCRIPTION
Adds a `EnableDependencyInjection(Action<IServiceCollection> configureServices)` method in `ODataOptions` to be able to add services (`StringAsEnumResolver` for example) in non-model scenario.

Fixes #422