### PR TITLE
Unmapped properties are in Delta<T>

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
@@ -8,11 +8,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Common;
 
@@ -521,7 +523,7 @@ namespace Microsoft.AspNetCore.OData.Deltas
                 _structuredType,
                 (backingType) => backingType
                     .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                    .Where(p => (p.GetSetMethod() != null || TypeHelper.IsCollection(p.PropertyType)) && p.GetGetMethod() != null)
+                    .Where(p => !IsIgnoredProperty(backingType.GetCustomAttributes(typeof(DataContractAttribute), inherit: true).Any(), p) && (p.GetSetMethod() != null || TypeHelper.IsCollection(p.PropertyType)) && p.GetGetMethod() != null)
                     .Select<PropertyInfo, PropertyAccessor<T>>(p => new FastPropertyAccessor<T>(p))
                     .ToDictionary(p => p.Property.Name));
 
@@ -538,6 +540,28 @@ namespace Microsoft.AspNetCore.OData.Deltas
             {
                 _updatableProperties.Remove(_dynamicDictionaryPropertyinfo.Name);
             }
+        }
+
+        private bool IsIgnoredProperty(bool isTypeDataContract, PropertyInfo propertyInfo)
+        {
+            //This is for Ignoring the property that matches below criteria
+            //1. Its marked as NotMapped
+            //2. Its a datacontract type but property is not marked as datamember
+            //3. Its marked with IgnoreDataMember (but not where types datacontract and property marked with datamember)
+
+            bool hasNotMappedAttr = propertyInfo.GetCustomAttributes(typeof(NotMappedAttribute), inherit: true).Any();
+
+            if (hasNotMappedAttr)
+            {
+                return true;
+            }
+
+            if (isTypeDataContract)
+            {
+                return !propertyInfo.GetCustomAttributes(typeof(DataMemberAttribute), inherit: true).Any();
+            }
+
+            return propertyInfo.GetCustomAttributes(typeof(IgnoreDataMemberAttribute), inherit: true).Any();
         }
 
         // Copy changed dynamic properties and leave the unchanged dynamic properties

--- a/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
@@ -498,6 +498,37 @@ namespace Microsoft.AspNetCore.OData.Tests.Deltas
         }
 
         [Fact]
+        public void TestDelta_IgnoresUnmapped()
+        {
+            //Arrange
+            var delta = new Delta<NewCustomerUnmapped>();
+
+            //Act
+            var properties = delta.GetUnchangedPropertyNames().ToList();
+
+            //Assert
+            Assert.Equal(3, properties.Count);
+            Assert.Equal("Id", properties.First());
+            Assert.Equal("City", properties[1]);
+            Assert.Equal("State", properties[2]);
+        }
+
+        [Fact]
+        public void TestDelta_IgnoredMember()
+        {
+            //Arrange
+            var delta = new Delta<NewCustomerDataContract>();
+
+            //Act
+            var properties = delta.GetUnchangedPropertyNames().ToList();
+
+            //Assert
+            Assert.Equal(2, properties.Count);
+            Assert.Equal("Name", properties[0]);
+            Assert.Equal("Street", properties[1]);
+        }
+
+        [Fact]
         public void CanPut_OpenType()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.OData.Tests/Models/NewCustomerDataContract.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Models/NewCustomerDataContract.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Microsoft.AspNetCore.OData.Tests.Models
+{
+    [DataContract]
+    public class NewCustomerDataContract
+    {
+        [Key]
+        public int Id { get; set; }
+        [IgnoreDataMember]
+        [DataMember]
+        public string Name { get; set; }
+        [IgnoreDataMember]
+        public int Age { get; set; }
+
+        [DataMember]
+        public string Street { get; set; }
+
+        public string City { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Models/NewCustomerUnmapped.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Models/NewCustomerUnmapped.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.Serialization;
+
+namespace Microsoft.AspNetCore.OData.Tests.Models
+{
+    public class NewCustomerUnmapped
+    {
+        [Key]
+        public int Id { get; set; }
+        [IgnoreDataMember]
+        public string Name { get; set; }
+        [NotMapped]
+        public int Age { get; set; }
+
+        [DataMember]
+        [IgnoreDataMember]
+        public string Street { get; set; }
+
+        [DataMember]
+        public string City { get; set; }
+
+        public string State { get; set; }
+    }
+}


### PR DESCRIPTION
Same issue as WebApi 2532

Fixes #347

Ported from WebAPI.

**Notes**
The two new test classes are split into separate files due because the monolithic TestDataModels doesn't exist in this repro
Ported from master to main
