### PR TITLE
Support DateOnly and TimeOnly

### DIFF
--- a/src/Microsoft.AspNetCore.OData.Nightly.nuspec
+++ b/src/Microsoft.AspNetCore.OData.Nightly.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.AspNetCore.OData</id>
-    <title>Microsoft ASP.NET Core 3.x and 5.x for OData v4.0</title>
+    <title>Microsoft ASP.NET Core 3.x, 5.x and 6.x for OData v4.0</title>
     <version>$VersionFullSemantic$-Nightly$NightlyBuildVersion$</version>
     <authors>OData (.NET Foundation)</authors>
     <copyright>&#169; .NET Foundation and Contributors. All rights reserved.</copyright>
@@ -28,6 +28,12 @@
         <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
         <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
       </group>
+      <group targetFramework=".net6.0">
+        <dependency id="Microsoft.OData.ModelBuilder" version="$ODataModelBuilderPackageDependency$" />
+        <dependency id="Microsoft.OData.Core" version="$ODataLibPackageDependency$" />
+        <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
+        <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -37,6 +43,9 @@
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.dll" target="lib\net5.0" />
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.xml" target="lib\net5.0" />
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.pdb" target="lib\net5.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.dll" target="lib\net6.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.xml" target="lib\net6.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.pdb" target="lib\net6.0" />
     <file src="$SourcesRoot$\images\odata.png" target="images\" />
   </files>
 </package>

--- a/src/Microsoft.AspNetCore.OData.Release.nuspec
+++ b/src/Microsoft.AspNetCore.OData.Release.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.AspNetCore.OData</id>
-    <title>Microsoft ASP.NET Core 3.x and 5.x for OData v4.0</title>
+    <title>Microsoft ASP.NET Core 3.x, 5.x and 6.x for OData v4.0</title>
     <version>$VersionNuGetSemantic$</version>
     <authors>OData (.NET Foundation)</authors>
     <copyright>&#169; .NET Foundation and Contributors. All rights reserved.</copyright>
@@ -22,7 +22,13 @@
         <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
         <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
       </group>
-        <group targetFramework=".net5.0">
+      <group targetFramework=".net5.0">
+        <dependency id="Microsoft.OData.ModelBuilder" version="$ODataModelBuilderPackageDependency$" />
+        <dependency id="Microsoft.OData.Core" version="$ODataLibPackageDependency$" />
+        <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
+        <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
+      </group>
+      <group targetFramework=".net6.0">
         <dependency id="Microsoft.OData.ModelBuilder" version="$ODataModelBuilderPackageDependency$" />
         <dependency id="Microsoft.OData.Core" version="$ODataLibPackageDependency$" />
         <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
@@ -37,6 +43,9 @@
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.dll" target="lib\net5.0" />
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.xml" target="lib\net5.0" />
     <file src="$ProductRoot$\net5.0\Microsoft.AspNetCore.OData.pdb" target="lib\net5.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.dll" target="lib\net6.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.xml" target="lib\net6.0" />
+    <file src="$ProductRoot$\net6.0\Microsoft.AspNetCore.OData.pdb" target="lib\net6.0" />
     <file src="$SourcesRoot$\images\odata.png" target="images\" />
   </files>
 </package>

--- a/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
@@ -90,6 +90,19 @@ namespace Microsoft.AspNetCore.OData.Common
             return Type.GetTypeCode(underlyingTypeOrSelf) == TypeCode.DateTime;
         }
 
+#if NET6_0
+        internal static bool IsDateOnly(Type clrType)
+        {
+            Type underlyingTypeOrSelf = GetUnderlyingTypeOrSelf(clrType);
+            return underlyingTypeOrSelf == typeof(DateOnly);
+        }
+
+        internal static bool IsTimeOnly(Type clrType)
+        {
+            Type underlyingTypeOrSelf = GetUnderlyingTypeOrSelf(clrType);
+            return underlyingTypeOrSelf == typeof(TimeOnly);
+        }
+#endif
         /// <summary>
         /// Determine if a type is a TimeSpan.
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
@@ -91,18 +91,29 @@ namespace Microsoft.AspNetCore.OData.Common
         }
 
 #if NET6_0
-        internal static bool IsDateOnly(Type clrType)
+        /// <summary>
+        /// Determine if a type is a <see cref="DateOnly"/>.
+        /// </summary>
+        /// <param name="clrType">The type to test.</param>
+        /// <returns>True if the type is a DateOnly; false otherwise.</returns>
+        public static bool IsDateOnly(this Type clrType)
         {
             Type underlyingTypeOrSelf = GetUnderlyingTypeOrSelf(clrType);
             return underlyingTypeOrSelf == typeof(DateOnly);
         }
 
-        internal static bool IsTimeOnly(Type clrType)
+        /// <summary>
+        /// Determine if a type is a <see cref="TimeOnly"/>.
+        /// </summary>
+        /// <param name="clrType">The type to test.</param>
+        /// <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        public static bool IsTimeOnly(this Type clrType)
         {
             Type underlyingTypeOrSelf = GetUnderlyingTypeOrSelf(clrType);
             return underlyingTypeOrSelf == typeof(TimeOnly);
         }
 #endif
+
         /// <summary>
         /// Determine if a type is a TimeSpan.
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -111,6 +111,13 @@ namespace Microsoft.AspNetCore.OData.Edm
             BuildTypeMapping<char>(EdmPrimitiveTypeKind.String, isStandard: false);
             BuildTypeMapping<DateTime?>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
             BuildTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
+
+#if NET6_0
+            BuildTypeMapping<DateOnly>(EdmPrimitiveTypeKind.Date, isStandard: false);
+            BuildTypeMapping<DateOnly?>(EdmPrimitiveTypeKind.Date, isStandard: false);
+            BuildTypeMapping<TimeOnly>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
+            BuildTypeMapping<TimeOnly?>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
+#endif
         }
         #endregion
 

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -113,10 +113,10 @@ namespace Microsoft.AspNetCore.OData.Edm
             BuildTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
 
 #if NET6_0
-            BuildTypeMapping<DateOnly>(EdmPrimitiveTypeKind.Date, isStandard: false);
             BuildTypeMapping<DateOnly?>(EdmPrimitiveTypeKind.Date, isStandard: false);
-            BuildTypeMapping<TimeOnly>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
+            BuildTypeMapping<DateOnly>(EdmPrimitiveTypeKind.Date, isStandard: false);
             BuildTypeMapping<TimeOnly?>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
+            BuildTypeMapping<TimeOnly>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
 #endif
         }
         #endregion

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -137,6 +137,28 @@ namespace Microsoft.AspNetCore.OData.Edm
 
                     throw new ValidationException(Error.Format(SRResources.PropertyMustBeBoolean));
                 }
+#if NET6_0
+                else if (type == typeof(DateOnly))
+                {
+                    if (value is Date)
+                    {
+                        Date dt = (Date)value;
+                        return new DateOnly(dt.Year, dt.Month, dt.Day);
+                    }
+
+                    throw new ValidationException(Error.Format(SRResources.PropertyMustBeDateTimeOffsetOrDate));
+                }
+                else if (type == typeof(TimeOnly))
+                {
+                    if (value is TimeOfDay)
+                    {
+                        TimeOfDay tod = (TimeOfDay)value;
+                        return new TimeOnly(tod.Hours, tod.Minutes, tod.Seconds, (int)tod.Milliseconds);
+                    }
+
+                    throw new ValidationException(Error.Format(SRResources.PropertyMustBeTimeOfDay));
+                }
+#endif
                 else
                 {
                     if (TypeHelper.TryGetInstance(type, value, out var result))

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -140,9 +140,8 @@ namespace Microsoft.AspNetCore.OData.Edm
 #if NET6_0
                 else if (type == typeof(DateOnly))
                 {
-                    if (value is Date)
+                    if (value is Date dt)
                     {
-                        Date dt = (Date)value;
                         return new DateOnly(dt.Year, dt.Month, dt.Day);
                     }
 
@@ -150,9 +149,8 @@ namespace Microsoft.AspNetCore.OData.Edm
                 }
                 else if (type == typeof(TimeOnly))
                 {
-                    if (value is TimeOfDay)
+                    if (value is TimeOfDay tod)
                     {
-                        TimeOfDay tod = (TimeOfDay)value;
                         return new TimeOnly(tod.Hours, tod.Minutes, tod.Seconds, (int)tod.Milliseconds);
                     }
 

--- a/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.OData.Extensions
 
         // Convert the model state errors in to a string (for debugging only).
         // This should be improved once ODataError allows more details.
-        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
+        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "The default format provider is fine here.")]
         private static string ConvertModelStateErrors(this IReadOnlyDictionary<string, object> errors)
         {
             StringBuilder builder = new StringBuilder();

--- a/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
@@ -102,6 +104,7 @@ namespace Microsoft.AspNetCore.OData.Extensions
 
         // Convert the model state errors in to a string (for debugging only).
         // This should be improved once ODataError allows more details.
+        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
         private static string ConvertModelStateErrors(this IReadOnlyDictionary<string, object> errors)
         {
             StringBuilder builder = new StringBuilder();

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -145,19 +145,18 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             }
 
 #if NET6_0
-            // Since ODL doesn't support "DateOnly" and "TimeOnly", we have to use Date and TimeOfDay defined in ODL as a bridge.
+            // Since ODL doesn't support "DateOnly", we have to use Date defined in ODL.
             if (primitiveType != null && primitiveType.IsDate() && TypeHelper.IsDateOnly(type))
             {
                 DateOnly dateOnly = (DateOnly)value;
-                Date dt = new Date(dateOnly.Year, dateOnly.Month, dateOnly.Day);
-                return dt;
+                return new Date(dateOnly.Year, dateOnly.Month, dateOnly.Day);
             }
 
+            // Since ODL doesn't support "TimeOnly", we have to use TimeOfDay defined in ODL.
             if (primitiveType != null && primitiveType.IsTimeOfDay() && TypeHelper.IsTimeOnly(type))
             {
                 TimeOnly timeOnly = (TimeOnly)value;
-                TimeOfDay tod = new TimeOfDay(timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond);
-                return tod;
+                return new TimeOfDay(timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond);
             }
 #endif
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -144,6 +144,23 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 return tod;
             }
 
+#if NET6_0
+            // Since ODL doesn't support "DateOnly" and "TimeOnly", we have to use Date and TimeOfDay defined in ODL as a bridge.
+            if (primitiveType != null && primitiveType.IsDate() && TypeHelper.IsDateOnly(type))
+            {
+                DateOnly dateOnly = (DateOnly)value;
+                Date dt = new Date(dateOnly.Year, dateOnly.Month, dateOnly.Day);
+                return dt;
+            }
+
+            if (primitiveType != null && primitiveType.IsTimeOfDay() && TypeHelper.IsTimeOnly(type))
+            {
+                TimeOnly timeOnly = (TimeOnly)value;
+                TimeOfDay tod = new TimeOfDay(timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond);
+                return tod;
+            }
+#endif
+
             return ConvertUnsupportedPrimitives(value, timeZoneInfo);
         }
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.AspNetCore.OData</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1089,6 +1089,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.

--- a/src/Microsoft.AspNetCore.OData/Query/ClrCanonicalFunctions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ClrCanonicalFunctions.cs
@@ -123,21 +123,21 @@ namespace Microsoft.AspNetCore.OData.Query
 
 #if NET6_0
         // DateOnly properties
-        public static readonly Dictionary<string, PropertyInfo> DateOnlyProperties = new[]
+        public static readonly Dictionary<string, PropertyInfo> DateOnlyProperties = new Dictionary<string, PropertyInfo>
         {
-            new KeyValuePair<string, PropertyInfo>(YearFunctionName, typeof(DateOnly).GetProperty("Year")),
-            new KeyValuePair<string, PropertyInfo>(MonthFunctionName, typeof(DateOnly).GetProperty("Month")),
-            new KeyValuePair<string, PropertyInfo>(DayFunctionName, typeof(DateOnly).GetProperty("Day")),
-        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            { YearFunctionName, typeof(DateOnly).GetProperty(nameof(DateOnly.Year)) },
+            { MonthFunctionName, typeof(DateOnly).GetProperty(nameof(DateOnly.Month)) },
+            { DayFunctionName, typeof(DateOnly).GetProperty(nameof(DateOnly.Day)) }
+        };
 
-        // TimeOnly
-        public static readonly Dictionary<string, PropertyInfo> TimeOnlyProperties = new[]
+        // TimeOnly properties
+        public static readonly Dictionary<string, PropertyInfo> TimeOnlyProperties = new Dictionary<string, PropertyInfo>
         {
-            new KeyValuePair<string, PropertyInfo>(HourFunctionName, typeof(TimeOnly).GetProperty("Hour")),
-            new KeyValuePair<string, PropertyInfo>(MinuteFunctionName, typeof(TimeOnly).GetProperty("Minute")),
-            new KeyValuePair<string, PropertyInfo>(SecondFunctionName, typeof(TimeOnly).GetProperty("Second")),
-            new KeyValuePair<string, PropertyInfo>(MillisecondFunctionName, typeof(TimeOnly).GetProperty("Millisecond")),
-        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            { HourFunctionName, typeof(TimeOnly).GetProperty(nameof(TimeOnly.Hour)) },
+            { MinuteFunctionName, typeof(TimeOnly).GetProperty(nameof(TimeOnly.Minute)) },
+            { SecondFunctionName, typeof(TimeOnly).GetProperty(nameof(TimeOnly.Second)) },
+            { MillisecondFunctionName, typeof(TimeOnly).GetProperty(nameof(TimeOnly.Millisecond)) }
+        };
 #endif
 
         // TimeSpan properties

--- a/src/Microsoft.AspNetCore.OData/Query/ClrCanonicalFunctions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ClrCanonicalFunctions.cs
@@ -121,6 +121,25 @@ namespace Microsoft.AspNetCore.OData.Query
             new KeyValuePair<string, PropertyInfo>(MillisecondFunctionName, typeof(TimeOfDay).GetProperty("Milliseconds")),
         }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
+#if NET6_0
+        // DateOnly properties
+        public static readonly Dictionary<string, PropertyInfo> DateOnlyProperties = new[]
+        {
+            new KeyValuePair<string, PropertyInfo>(YearFunctionName, typeof(DateOnly).GetProperty("Year")),
+            new KeyValuePair<string, PropertyInfo>(MonthFunctionName, typeof(DateOnly).GetProperty("Month")),
+            new KeyValuePair<string, PropertyInfo>(DayFunctionName, typeof(DateOnly).GetProperty("Day")),
+        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        // TimeOnly
+        public static readonly Dictionary<string, PropertyInfo> TimeOnlyProperties = new[]
+        {
+            new KeyValuePair<string, PropertyInfo>(HourFunctionName, typeof(TimeOnly).GetProperty("Hour")),
+            new KeyValuePair<string, PropertyInfo>(MinuteFunctionName, typeof(TimeOnly).GetProperty("Minute")),
+            new KeyValuePair<string, PropertyInfo>(SecondFunctionName, typeof(TimeOnly).GetProperty("Second")),
+            new KeyValuePair<string, PropertyInfo>(MillisecondFunctionName, typeof(TimeOnly).GetProperty("Millisecond")),
+        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+#endif
+
         // TimeSpan properties
         public static readonly Dictionary<string, PropertyInfo> TimeSpanProperties = new[]
         {

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -348,11 +348,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             CheckArgumentNull(node, context);
 
             Expression[] arguments = BindArguments(node.Parameters, context);
-            Contract.Assert(arguments.Length == 1 && (ExpressionBinderHelper.IsDateRelated(arguments[0].Type)
-#if NET6_0
-                || ExpressionBinderHelper.IsType<DateOnly>(arguments[0].Type)
-#endif
-                ));
+            Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateRelated(arguments[0].Type));
 
             // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
             Expression parameter = arguments[0];
@@ -364,7 +360,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 property = ClrCanonicalFunctions.DateProperties[node.Name];
             }
 #if NET6_0
-            else if (ExpressionBinderHelper.IsType<DateOnly>(parameter.Type))
+            else if (parameter.Type.IsDateOnly())
             {
                 Contract.Assert(ClrCanonicalFunctions.DateOnlyProperties.ContainsKey(node.Name));
                 property = ClrCanonicalFunctions.DateOnlyProperties[node.Name];
@@ -396,11 +392,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             Expression[] arguments = BindArguments(node.Parameters, context);
 
-            Contract.Assert(arguments.Length == 1 && (ExpressionBinderHelper.IsTimeRelated(arguments[0].Type)
-#if NET6_0
-                || ExpressionBinderHelper.IsType<TimeOnly>(arguments[0].Type)
-#endif
-                ));
+            Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsTimeRelated(arguments[0].Type));
 
             // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
             Expression parameter = arguments[0];
@@ -412,7 +404,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 property = ClrCanonicalFunctions.TimeOfDayProperties[node.Name];
             }
 #if NET6_0
-            else if (ExpressionBinderHelper.IsType<TimeOnly>(parameter.Type))
+            else if (parameter.Type.IsTimeOnly())
             {
                 Contract.Assert(ClrCanonicalFunctions.TimeOnlyProperties.ContainsKey(node.Name));
                 property = ClrCanonicalFunctions.TimeOnlyProperties[node.Name];

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -348,7 +348,11 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             CheckArgumentNull(node, context);
 
             Expression[] arguments = BindArguments(node.Parameters, context);
-            Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateRelated(arguments[0].Type));
+            Contract.Assert(arguments.Length == 1 && (ExpressionBinderHelper.IsDateRelated(arguments[0].Type)
+#if NET6_0
+                || ExpressionBinderHelper.IsType<DateOnly>(arguments[0].Type)
+#endif
+                ));
 
             // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
             Expression parameter = arguments[0];
@@ -359,6 +363,13 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 Contract.Assert(ClrCanonicalFunctions.DateProperties.ContainsKey(node.Name));
                 property = ClrCanonicalFunctions.DateProperties[node.Name];
             }
+#if NET6_0
+            else if (ExpressionBinderHelper.IsType<DateOnly>(parameter.Type))
+            {
+                Contract.Assert(ClrCanonicalFunctions.DateOnlyProperties.ContainsKey(node.Name));
+                property = ClrCanonicalFunctions.DateOnlyProperties[node.Name];
+            }
+#endif
             else if (ExpressionBinderHelper.IsDateTime(parameter.Type))
             {
                 Contract.Assert(ClrCanonicalFunctions.DateTimeProperties.ContainsKey(node.Name));
@@ -384,7 +395,12 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             CheckArgumentNull(node, context);
 
             Expression[] arguments = BindArguments(node.Parameters, context);
-            Contract.Assert(arguments.Length == 1 && (ExpressionBinderHelper.IsTimeRelated(arguments[0].Type)));
+
+            Contract.Assert(arguments.Length == 1 && (ExpressionBinderHelper.IsTimeRelated(arguments[0].Type)
+#if NET6_0
+                || ExpressionBinderHelper.IsType<TimeOnly>(arguments[0].Type)
+#endif
+                ));
 
             // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
             Expression parameter = arguments[0];
@@ -395,6 +411,13 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 Contract.Assert(ClrCanonicalFunctions.TimeOfDayProperties.ContainsKey(node.Name));
                 property = ClrCanonicalFunctions.TimeOfDayProperties[node.Name];
             }
+#if NET6_0
+            else if (ExpressionBinderHelper.IsType<TimeOnly>(parameter.Type))
+            {
+                Contract.Assert(ClrCanonicalFunctions.TimeOnlyProperties.ContainsKey(node.Name));
+                property = ClrCanonicalFunctions.TimeOnlyProperties[node.Name];
+            }
+#endif
             else if (ExpressionBinderHelper.IsDateTime(parameter.Type))
             {
                 Contract.Assert(ClrCanonicalFunctions.DateTimeProperties.ContainsKey(node.Name));

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -1216,6 +1216,12 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                     // we handle enum conversions ourselves
                     convertedExpression = source;
                 }
+#if NET6_0
+                else if (TypeHelper.IsDateOnly(sourceType) || TypeHelper.IsTimeOnly(sourceType))
+                {
+                    convertedExpression = source;
+                }
+#endif
                 else
                 {
                     switch (Type.GetTypeCode(sourceType))

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Net.Mime;
 using System.Text;
@@ -163,6 +164,7 @@ namespace Microsoft.AspNetCore.OData.Routing
             return result;
         }
 
+        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
         private static void AppendRoute(StringBuilder builder, EndpointRouteInfo routeInfo)
         {
             builder.Append("<tr>");

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRouteDebugMiddleware.cs
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.OData.Routing
             return result;
         }
 
-        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
+        [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "The default format provider is fine here.")]
         private static void AppendRoute(StringBuilder builder, EndpointRouteInfo routeInfo)
         {
             builder.Append("<tr>");

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateOnlyTimeOnly/DateAndTimeOfDayWithEfTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateOnlyTimeOnly/DateAndTimeOfDayWithEfTest.cs
@@ -1,0 +1,399 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DateOnlyAndTimeOnlyWithEfTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NET6_0
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.DateOnlyTimeOnly
+{
+    public class DateOnlyAndTimeOnlyWithEfTest : WebApiTestBase<DateOnlyAndTimeOnlyWithEfTest>
+    {
+        public DateOnlyAndTimeOnlyWithEfTest(WebApiTestFixture<DateOnlyAndTimeOnlyWithEfTest> fixture)
+            :base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            string connectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=True;Initial Catalog=DateOnlyAndTimeOnlyModelContext8";
+            services.AddDbContext<DateAndOnlyTimeOnlyModelContext>(opt => opt.UseLazyLoadingProxies().UseSqlServer(connectionString));
+
+            services.ConfigureControllers(typeof(MetadataController), typeof(DateOnlyTimeOnlyModelsController));
+
+            services.AddControllers().AddOData(opt => opt.Count().Filter().OrderBy().Expand().SetMaxTop(null).Select()
+                .AddRouteComponents("odata", BuildEdmModel()));
+        }
+
+        [Fact]
+        public async Task MetadataDocument_IncludesDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            string Uri = "odata/$metadata";
+            string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
+"<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">\r\n" +
+"  <edmx:DataServices>\r\n" +
+"    <Schema Namespace=\"Microsoft.AspNetCore.OData.E2E.Tests.DateOnlyTimeOnly\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">\r\n" +
+"      <EntityType Name=\"DateOnyTimeOnlyModel\">\r\n" +
+"        <Key>\r\n" +
+"          <PropertyRef Name=\"Id\" />\r\n" +
+"        </Key>\r\n" +
+"        <Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />\r\n" +
+"        <Property Name=\"Birthday\" Type=\"Edm.Date\" Nullable=\"false\" />\r\n" +
+"        <Property Name=\"PublishDay\" Type=\"Edm.Date\" />\r\n" +
+"        <Property Name=\"EndDay\" Type=\"Edm.Date\" Nullable=\"false\" />\r\n" +
+"        <Property Name=\"CreatedTime\" Type=\"Edm.TimeOfDay\" Nullable=\"false\" />\r\n" +
+"        <Property Name=\"EndTime\" Type=\"Edm.TimeOfDay\" />\r\n" +
+"        <Property Name=\"ResumeTime\" Type=\"Edm.TimeOfDay\" Nullable=\"false\" />\r\n" +
+"      </EntityType>\r\n" +
+"    </Schema>\r\n" +
+"    <Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">\r\n" +
+"      <EntityContainer Name=\"Container\">\r\n" +
+"        <EntitySet Name=\"DateOnlyTimeOnlyModels\" EntityType=\"Microsoft.AspNetCore.OData.E2E.Tests.DateOnlyTimeOnly.DateOnyTimeOnlyModel\" />\r\n" +
+"      </EntityContainer>\r\n" +
+"    </Schema>\r\n" +
+"  </edmx:DataServices>\r\n" +
+"</edmx:Edmx>";
+
+            // Remove indentation
+            expected = Regex.Replace(expected, @"\r\n\s*<", @"<");
+            HttpClient client = CreateClient();
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Uri);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(expected, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task CanQueryEntitySet_WithDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            string Uri = "odata/DateOnlyTimeOnlyModels";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Uri);
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+            Assert.Equal(5, result["value"].Count());
+
+            // test one for each entity
+            Assert.Equal("2012-03-07", result["value"][0]["EndDay"]);
+            Assert.Equal(JValue.CreateNull(), result["value"][1]["PublishDay"]);
+            Assert.Equal("03:13:06.0080000", result["value"][2]["ResumeTime"]);
+            Assert.Equal(JValue.CreateNull(), result["value"][3]["EndTime"]);
+            Assert.Equal("00:05:03.0050000", result["value"][4]["CreatedTime"]);
+        }
+
+        [Fact]
+        public async Task CanQuerySingleEntity_WithDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            string Uri = "odata/DateOnlyTimeOnlyModels(2)";
+
+            string expect = @"{
+  ""@odata.context"": ""http://localhost/odata/$metadata#DateOnlyTimeOnlyModels/$entity"",
+  ""@odata.type"": ""#Microsoft.AspNetCore.OData.E2E.Tests.DateOnlyTimeOnly.DateOnyTimeOnlyModel"",
+  ""@odata.id"": ""http://localhost/odata/DateOnlyTimeOnlyModels(2)"",
+  ""@odata.editLink"": ""DateOnlyTimeOnlyModels(2)"",
+  ""Id"": 2,
+  ""Birthday@odata.type"": ""#Date"",
+  ""Birthday"": ""2012-03-07"",
+  ""PublishDay"": null,
+  ""EndDay@odata.type"": ""#Date"",
+  ""EndDay"": ""2013-04-08"",
+  ""CreatedTime@odata.type"": ""#TimeOfDay"",
+  ""CreatedTime"": ""00:02:03.0050000"",
+  ""EndTime"": null,
+  ""ResumeTime@odata.type"": ""#TimeOfDay"",
+  ""ResumeTime"": ""02:12:05.0070000""
+}";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Uri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(JObject.Parse(expect), result);
+        }
+
+        [Fact]
+        public async Task CanSelect_OnDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            string Uri = "odata/DateOnlyTimeOnlyModels(3)?$select=Birthday,PublishDay,CreatedTime,ResumeTime";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Uri);
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal("2013-04-08", result["Birthday"]);
+            Assert.Equal("2018-09-18", result["PublishDay"]);
+            Assert.Equal("00:03:03.0050000", result["CreatedTime"]);
+            Assert.Equal("03:13:06.0080000", result["ResumeTime"]);
+        }
+
+        [Theory]
+        [InlineData("?$filter=year(Birthday) eq 2015", "5")]
+        [InlineData("?$filter=month(PublishDay) eq 11", "1")]
+        [InlineData("?$filter=day(EndDay) ne 09", "1,2,4,5")]
+        [InlineData("?$filter=Birthday gt 2013-04-08", "4,5")]
+        [InlineData("?$filter=PublishDay eq null", "2,4")] // the following four cases are for nullable
+        [InlineData("?$filter=PublishDay eq 2018-09-18", "3")]
+        [InlineData("?$filter=PublishDay ne 2018-09-18", "1,5")]
+        [InlineData("?$filter=PublishDay lt 2019-12-31", "1,3")]
+        [InlineData("?$filter=EndTime ne null", "1,3,5")]
+        [InlineData("?$filter=CreatedTime eq 00:01:03.0050000", "1")]
+        [InlineData("?$filter=hour(EndTime) eq 01", "1")]
+        [InlineData("?$filter=minute(EndTime) eq 15", "5")]
+        [InlineData("?$filter=second(EndTime) eq 06", "3")]
+        [InlineData("?$filter=EndTime eq null", "2,4")]
+        [InlineData("?$filter=EndTime ge 00:03:05.0790000", "1,3,5")]
+        public async Task CanFilter_OnDateOnlyAndTimeOnlyProperties(string filter, string expect)
+        {
+            // Arrange
+            string Uri = "odata/DateOnlyTimeOnlyModels" + filter;
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Uri);
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            string payload = await response.Content.ReadAsStringAsync();
+            Assert.True(response.IsSuccessStatusCode);
+
+            JObject result = await response.Content.ReadAsObject<JObject>();
+            Assert.Equal(expect, string.Join(",", result["value"].Select(e => e["Id"].ToString())));
+        }
+
+        [Theory]
+        [InlineData("?$orderby=Birthday", "1,2,3,4,5")]
+        [InlineData("?$orderby=Birthday desc", "5,4,3,2,1")]
+        [InlineData("?$orderby=PublishDay", "2,4,1,3,5")]
+        [InlineData("?$orderby=PublishDay desc", "5,3,1,2,4")]
+        [InlineData("?$orderby=CreatedTime", "1,2,3,4,5")]
+        [InlineData("?$orderby=CreatedTime desc", "5,4,3,2,1")]
+        public async Task CanOrderBy_OnDateOnlyAndTimeOnlyProperties(string orderby, string expect)
+        {
+            // Arrange
+            string Uri = "odata/DateOnlyTimeOnlyModels" + orderby;
+            var request = new HttpRequestMessage(HttpMethod.Get, Uri);
+            HttpClient client = CreateClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(5, result["value"].Count());
+
+            Assert.Equal(expect, string.Join(",", result["value"].Select(e => e["Id"].ToString())));
+        }
+
+        [Fact]
+        public async Task PostEntity_WithDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            const string Payload = "{" +
+                "\"Id\":99," +
+                "\"Birthday\":\"2099-01-01\"," +
+                "\"CreatedTime\":\"14:13:15.1790000\"," +
+                "\"EndDay\":\"1990-12-22\"}";
+
+            string Uri = "odata/DateOnlyTimeOnlyModels";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, Uri);
+
+            request.Content = new StringContent(Payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = Payload.Length;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PutEntity_WithDateOnlyAndTimeOnlyProperties()
+        {
+            // Arrange
+            const string Payload = "{" +
+                "\"Birthday\":\"2199-01-02\"," +
+                "\"CreatedTime\":\"14:13:15.1790000\"}";
+
+            string Uri = "odata/DateOnlyTimeOnlyModels(3)";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, Uri);
+
+            request.Content = new StringContent(Payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = Payload.Length;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        private static IEdmModel BuildEdmModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<DateOnyTimeOnlyModel>("DateOnlyTimeOnlyModels");
+            return builder.GetEdmModel();
+        }
+    }
+
+    public class DateOnlyTimeOnlyModelsController : ODataController
+    {
+      //  private DateAndOnlyTimeOnlyModelContext _db;
+        private static IList<DateOnyTimeOnlyModel> _dateTimes = Enumerable.Range(1, 5).Select(i =>
+            new DateOnyTimeOnlyModel
+            {
+                Id = i,
+                Birthday = new DateOnly(2010 + i, 1 + i, 5 + i),
+
+                PublishDay = i % 2 == 0 ? null : new DateOnly(2015 + i, 12 - i, 15 + i),
+
+                EndDay = new DateOnly(2010 + i + 1, 2 + i, 6 + i),
+
+                CreatedTime = new TimeOnly(0, i, 3, 5),
+
+                EndTime = i % 2 == 0 ? null : new TimeOnly(i, 10 + i, 3 + i, 5 + i),
+
+                ResumeTime = new TimeOnly(i, 10 + i, 3 + i, 5 + i)
+
+            }).ToList();
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(_dateTimes);
+        }
+
+        [EnableQuery]
+        public IActionResult Get(int key)
+        {
+            DateOnyTimeOnlyModel dtm = _dateTimes.FirstOrDefault(e => e.Id == key);
+            if (dtm == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(dtm);
+        }
+
+        public IActionResult Post([FromBody]DateOnyTimeOnlyModel dt)
+        {
+            Assert.NotNull(dt);
+
+            Assert.Equal(99, dt.Id);
+            Assert.Equal(new DateOnly(2099, 1, 1), dt.Birthday);
+            Assert.Equal(new TimeOnly(14, 13, 15, 179), dt.CreatedTime);
+            Assert.Equal(new DateOnly(1990, 12, 22), dt.EndDay);
+
+            return Created(dt);
+        }
+
+        public IActionResult Put(int key, [FromBody]Delta<DateOnyTimeOnlyModel> dt)
+        {
+            Assert.Equal(new[] { "Birthday", "CreatedTime" }, dt.GetChangedPropertyNames());
+
+            // Birthday
+            object value;
+            bool success = dt.TryGetPropertyValue("Birthday", out value);
+            Assert.True(success);
+            DateOnly dateOnly = Assert.IsType<DateOnly>(value);
+            Assert.Equal(new DateOnly(2199, 1, 2), dateOnly);
+
+            // CreatedTime
+            success = dt.TryGetPropertyValue("CreatedTime", out value);
+            Assert.True(success);
+            TimeOnly timeOnly = Assert.IsType<TimeOnly>(value);
+            Assert.Equal(new TimeOnly(14, 13, 15, 179), timeOnly);
+            return Updated(dt);
+        }
+    }
+
+    // EF Core 6 doesn't support DateOnly and TimeOnly yet
+    public class DateAndOnlyTimeOnlyModelContext : DbContext
+    {
+        public DateAndOnlyTimeOnlyModelContext(DbContextOptions<DateAndOnlyTimeOnlyModelContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<DateOnyTimeOnlyModel> DateTimes { get; set; }
+
+        //protected override void OnModelCreating(ModelBuilder modelBuilder)
+        //{
+        //    modelBuilder.Entity<DateAndTimeOfDayModel>().Property(c => c.EndDay).HasColumnType("date");
+        //    modelBuilder.Entity<DateAndTimeOfDayModel>().Property(c => c.DeliverDay).HasColumnType("date");
+        //}
+    }
+
+    public class DateOnyTimeOnlyModel
+    {
+        public int Id { get; set; }
+
+        public DateOnly Birthday { get; set; }
+
+        public DateOnly? PublishDay { get; set; }
+
+        public DateOnly EndDay { get; set; }
+
+        public TimeOnly CreatedTime { get; set; }
+
+        public TimeOnly? EndTime { get; set; }
+
+        public TimeOnly ResumeTime { get; set; }
+    }
+}
+#endif

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Microsoft.AspNetCore.OData.E2E.Tests.csproj
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Microsoft.AspNetCore.OData.E2E.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.AspNetCore.OData.E2E.Tests</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.OData.E2E.Tests</RootNamespace>
 
@@ -38,7 +38,13 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.0" />
   </ItemGroup>
-  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.0" />
+  </ItemGroup>
+    
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.OData.TestCommon\Microsoft.AspNetCore.OData.TestCommon.csproj" />

--- a/test/Microsoft.AspNetCore.OData.Tests/Microsoft.AspNetCore.OData.Tests.csproj
+++ b/test/Microsoft.AspNetCore.OData.Tests/Microsoft.AspNetCore.OData.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.AspNetCore.OData.Tests</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.OData.Tests</RootNamespace>
 


### PR DESCRIPTION
#413 

Support DateOnly & TimeOnly new types defined in .NET 6.

1) Add the .NET 6.0 target framework to introduce new types (DateOnly and TimeOnly)
2) Support serialize of DateOnly & TimeOnly as "Date" and "TimeOfDay"
3) Support deserialize of DateOnly & TimeOnly from "Date" and "TimeOfDay".
4) Support the query option on DateOnly & TimeOnly, for example $filter.

To be clear: EF core 6.0 doesn't support DateOnly and TimeOnly. See https://github.com/dotnet/efcore/issues/24507