### PR TITLE
♻️ Nullable and non nullable type mapping registration simplification

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -47,39 +47,23 @@ namespace Microsoft.AspNetCore.OData.Edm
 
         static DefaultODataTypeMapper()
         {
-            // Do not change the order for the nullable or non-nullable. Put nullable ahead of non-nullable.
-            // By design: non-nullable will overwrite the item1.
             BuildTypeMapping<string>(EdmPrimitiveTypeKind.String);
-            BuildTypeMapping<bool?>(EdmPrimitiveTypeKind.Boolean);
-            BuildTypeMapping<bool>(EdmPrimitiveTypeKind.Boolean);
-            BuildTypeMapping<byte?>(EdmPrimitiveTypeKind.Byte);
-            BuildTypeMapping<byte>(EdmPrimitiveTypeKind.Byte);
-            BuildTypeMapping<decimal?>(EdmPrimitiveTypeKind.Decimal);
-            BuildTypeMapping<decimal>(EdmPrimitiveTypeKind.Decimal);
-            BuildTypeMapping<double?>(EdmPrimitiveTypeKind.Double);
-            BuildTypeMapping<double>(EdmPrimitiveTypeKind.Double);
-            BuildTypeMapping<Guid?>(EdmPrimitiveTypeKind.Guid);
-            BuildTypeMapping<Guid>(EdmPrimitiveTypeKind.Guid);
-            BuildTypeMapping<short?>(EdmPrimitiveTypeKind.Int16);
-            BuildTypeMapping<short>(EdmPrimitiveTypeKind.Int16);
-            BuildTypeMapping<int?>(EdmPrimitiveTypeKind.Int32);
-            BuildTypeMapping<int>(EdmPrimitiveTypeKind.Int32);
-            BuildTypeMapping<long?>(EdmPrimitiveTypeKind.Int64);
-            BuildTypeMapping<long>(EdmPrimitiveTypeKind.Int64);
-            BuildTypeMapping<sbyte?>(EdmPrimitiveTypeKind.SByte);
-            BuildTypeMapping<sbyte>(EdmPrimitiveTypeKind.SByte);
-            BuildTypeMapping<float?>(EdmPrimitiveTypeKind.Single);
-            BuildTypeMapping<float>(EdmPrimitiveTypeKind.Single);
+            BuildValueTypeMapping<bool>(EdmPrimitiveTypeKind.Boolean);
+            BuildValueTypeMapping<byte>(EdmPrimitiveTypeKind.Byte);
+            BuildValueTypeMapping<decimal>(EdmPrimitiveTypeKind.Decimal);
+            BuildValueTypeMapping<double>(EdmPrimitiveTypeKind.Double);
+            BuildValueTypeMapping<Guid>(EdmPrimitiveTypeKind.Guid);
+            BuildValueTypeMapping<short>(EdmPrimitiveTypeKind.Int16);
+            BuildValueTypeMapping<int>(EdmPrimitiveTypeKind.Int32);
+            BuildValueTypeMapping<long>(EdmPrimitiveTypeKind.Int64);
+            BuildValueTypeMapping<sbyte>(EdmPrimitiveTypeKind.SByte);
+            BuildValueTypeMapping<float>(EdmPrimitiveTypeKind.Single);
             BuildTypeMapping<byte[]>(EdmPrimitiveTypeKind.Binary);
             BuildTypeMapping<Stream>(EdmPrimitiveTypeKind.Stream);
-            BuildTypeMapping<DateTimeOffset?>(EdmPrimitiveTypeKind.DateTimeOffset);
-            BuildTypeMapping<DateTimeOffset>(EdmPrimitiveTypeKind.DateTimeOffset);
-            BuildTypeMapping<TimeSpan?>(EdmPrimitiveTypeKind.Duration);
-            BuildTypeMapping<TimeSpan>(EdmPrimitiveTypeKind.Duration);
-            BuildTypeMapping<Date?>(EdmPrimitiveTypeKind.Date);
-            BuildTypeMapping<Date>(EdmPrimitiveTypeKind.Date);
-            BuildTypeMapping<TimeOfDay?>(EdmPrimitiveTypeKind.TimeOfDay);
-            BuildTypeMapping<TimeOfDay>(EdmPrimitiveTypeKind.TimeOfDay);
+            BuildValueTypeMapping<DateTimeOffset>(EdmPrimitiveTypeKind.DateTimeOffset);
+            BuildValueTypeMapping<TimeSpan>(EdmPrimitiveTypeKind.Duration);
+            BuildValueTypeMapping<Date>(EdmPrimitiveTypeKind.Date);
+            BuildValueTypeMapping<TimeOfDay>(EdmPrimitiveTypeKind.TimeOfDay);
 
             BuildTypeMapping<Geography>(EdmPrimitiveTypeKind.Geography);
             BuildTypeMapping<GeographyPoint>(EdmPrimitiveTypeKind.GeographyPoint);
@@ -100,23 +84,16 @@ namespace Microsoft.AspNetCore.OData.Edm
 
             // non-standard mappings
             BuildTypeMapping<XElement>(EdmPrimitiveTypeKind.String, isStandard: false);
-            BuildTypeMapping<ushort?>(EdmPrimitiveTypeKind.Int32, isStandard: false);
-            BuildTypeMapping<ushort>(EdmPrimitiveTypeKind.Int32, isStandard: false);
-            BuildTypeMapping<uint?>(EdmPrimitiveTypeKind.Int64, isStandard: false);
-            BuildTypeMapping<uint>(EdmPrimitiveTypeKind.Int64, isStandard: false);
-            BuildTypeMapping<ulong?>(EdmPrimitiveTypeKind.Int64, isStandard: false);
-            BuildTypeMapping<ulong>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildValueTypeMapping<ushort>(EdmPrimitiveTypeKind.Int32, isStandard: false);
+            BuildValueTypeMapping<uint>(EdmPrimitiveTypeKind.Int64, isStandard: false);
+            BuildValueTypeMapping<ulong>(EdmPrimitiveTypeKind.Int64, isStandard: false);
             BuildTypeMapping<char[]>(EdmPrimitiveTypeKind.String, isStandard: false);
-            BuildTypeMapping<char?>(EdmPrimitiveTypeKind.String, isStandard: false);
-            BuildTypeMapping<char>(EdmPrimitiveTypeKind.String, isStandard: false);
-            BuildTypeMapping<DateTime?>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
-            BuildTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
+            BuildValueTypeMapping<char>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildValueTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
 
 #if NET6_0
-            BuildTypeMapping<DateOnly?>(EdmPrimitiveTypeKind.Date, isStandard: false);
-            BuildTypeMapping<DateOnly>(EdmPrimitiveTypeKind.Date, isStandard: false);
-            BuildTypeMapping<TimeOnly?>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
-            BuildTypeMapping<TimeOnly>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
+            BuildValueTypeMapping<DateOnly>(EdmPrimitiveTypeKind.Date, isStandard: false);
+            BuildValueTypeMapping<TimeOnly>(EdmPrimitiveTypeKind.TimeOfDay, isStandard: false);
 #endif
         }
         #endregion
@@ -440,6 +417,16 @@ namespace Microsoft.AspNetCore.OData.Edm
                     }
                 }
             }
+        }
+
+        private static void BuildValueTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind, bool isStandard = true)
+            where T : struct
+        {
+            // Do not change the order for the nullable or non-nullable. Put nullable ahead of non-nullable.
+            // By design: non-nullable will overwrite the item1.
+
+            BuildTypeMapping<T?>(primitiveKind, isStandard);
+            BuildTypeMapping<T>(primitiveKind, isStandard);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.OData.Edm
 
         static DefaultODataTypeMapper()
         {
-            BuildTypeMapping<string>(EdmPrimitiveTypeKind.String);
+            BuildReferenceTypeMapping<string>(EdmPrimitiveTypeKind.String);
             BuildValueTypeMapping<bool>(EdmPrimitiveTypeKind.Boolean);
             BuildValueTypeMapping<byte>(EdmPrimitiveTypeKind.Byte);
             BuildValueTypeMapping<decimal>(EdmPrimitiveTypeKind.Decimal);
@@ -58,36 +58,36 @@ namespace Microsoft.AspNetCore.OData.Edm
             BuildValueTypeMapping<long>(EdmPrimitiveTypeKind.Int64);
             BuildValueTypeMapping<sbyte>(EdmPrimitiveTypeKind.SByte);
             BuildValueTypeMapping<float>(EdmPrimitiveTypeKind.Single);
-            BuildTypeMapping<byte[]>(EdmPrimitiveTypeKind.Binary);
-            BuildTypeMapping<Stream>(EdmPrimitiveTypeKind.Stream);
+            BuildReferenceTypeMapping<byte[]>(EdmPrimitiveTypeKind.Binary);
+            BuildReferenceTypeMapping<Stream>(EdmPrimitiveTypeKind.Stream);
             BuildValueTypeMapping<DateTimeOffset>(EdmPrimitiveTypeKind.DateTimeOffset);
             BuildValueTypeMapping<TimeSpan>(EdmPrimitiveTypeKind.Duration);
             BuildValueTypeMapping<Date>(EdmPrimitiveTypeKind.Date);
             BuildValueTypeMapping<TimeOfDay>(EdmPrimitiveTypeKind.TimeOfDay);
 
-            BuildTypeMapping<Geography>(EdmPrimitiveTypeKind.Geography);
-            BuildTypeMapping<GeographyPoint>(EdmPrimitiveTypeKind.GeographyPoint);
-            BuildTypeMapping<GeographyLineString>(EdmPrimitiveTypeKind.GeographyLineString);
-            BuildTypeMapping<GeographyPolygon>(EdmPrimitiveTypeKind.GeographyPolygon);
-            BuildTypeMapping<GeographyCollection>(EdmPrimitiveTypeKind.GeographyCollection);
-            BuildTypeMapping<GeographyMultiLineString>(EdmPrimitiveTypeKind.GeographyMultiLineString);
-            BuildTypeMapping<GeographyMultiPoint>(EdmPrimitiveTypeKind.GeographyMultiPoint);
-            BuildTypeMapping<GeographyMultiPolygon>(EdmPrimitiveTypeKind.GeographyMultiPolygon);
-            BuildTypeMapping<Geometry>(EdmPrimitiveTypeKind.Geometry);
-            BuildTypeMapping<GeometryPoint>(EdmPrimitiveTypeKind.GeometryPoint);
-            BuildTypeMapping<GeometryLineString>(EdmPrimitiveTypeKind.GeometryLineString);
-            BuildTypeMapping<GeometryPolygon>(EdmPrimitiveTypeKind.GeometryPolygon);
-            BuildTypeMapping<GeometryCollection>(EdmPrimitiveTypeKind.GeometryCollection);
-            BuildTypeMapping<GeometryMultiLineString>(EdmPrimitiveTypeKind.GeometryMultiLineString);
-            BuildTypeMapping<GeometryMultiPoint>(EdmPrimitiveTypeKind.GeometryMultiPoint);
-            BuildTypeMapping<GeometryMultiPolygon>(EdmPrimitiveTypeKind.GeometryMultiPolygon);
+            BuildReferenceTypeMapping<Geography>(EdmPrimitiveTypeKind.Geography);
+            BuildReferenceTypeMapping<GeographyPoint>(EdmPrimitiveTypeKind.GeographyPoint);
+            BuildReferenceTypeMapping<GeographyLineString>(EdmPrimitiveTypeKind.GeographyLineString);
+            BuildReferenceTypeMapping<GeographyPolygon>(EdmPrimitiveTypeKind.GeographyPolygon);
+            BuildReferenceTypeMapping<GeographyCollection>(EdmPrimitiveTypeKind.GeographyCollection);
+            BuildReferenceTypeMapping<GeographyMultiLineString>(EdmPrimitiveTypeKind.GeographyMultiLineString);
+            BuildReferenceTypeMapping<GeographyMultiPoint>(EdmPrimitiveTypeKind.GeographyMultiPoint);
+            BuildReferenceTypeMapping<GeographyMultiPolygon>(EdmPrimitiveTypeKind.GeographyMultiPolygon);
+            BuildReferenceTypeMapping<Geometry>(EdmPrimitiveTypeKind.Geometry);
+            BuildReferenceTypeMapping<GeometryPoint>(EdmPrimitiveTypeKind.GeometryPoint);
+            BuildReferenceTypeMapping<GeometryLineString>(EdmPrimitiveTypeKind.GeometryLineString);
+            BuildReferenceTypeMapping<GeometryPolygon>(EdmPrimitiveTypeKind.GeometryPolygon);
+            BuildReferenceTypeMapping<GeometryCollection>(EdmPrimitiveTypeKind.GeometryCollection);
+            BuildReferenceTypeMapping<GeometryMultiLineString>(EdmPrimitiveTypeKind.GeometryMultiLineString);
+            BuildReferenceTypeMapping<GeometryMultiPoint>(EdmPrimitiveTypeKind.GeometryMultiPoint);
+            BuildReferenceTypeMapping<GeometryMultiPolygon>(EdmPrimitiveTypeKind.GeometryMultiPolygon);
 
             // non-standard mappings
-            BuildTypeMapping<XElement>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildReferenceTypeMapping<XElement>(EdmPrimitiveTypeKind.String, isStandard: false);
             BuildValueTypeMapping<ushort>(EdmPrimitiveTypeKind.Int32, isStandard: false);
             BuildValueTypeMapping<uint>(EdmPrimitiveTypeKind.Int64, isStandard: false);
             BuildValueTypeMapping<ulong>(EdmPrimitiveTypeKind.Int64, isStandard: false);
-            BuildTypeMapping<char[]>(EdmPrimitiveTypeKind.String, isStandard: false);
+            BuildReferenceTypeMapping<char[]>(EdmPrimitiveTypeKind.String, isStandard: false);
             BuildValueTypeMapping<char>(EdmPrimitiveTypeKind.String, isStandard: false);
             BuildValueTypeMapping<DateTime>(EdmPrimitiveTypeKind.DateTimeOffset, isStandard: false);
 
@@ -426,6 +426,12 @@ namespace Microsoft.AspNetCore.OData.Edm
             // By design: non-nullable will overwrite the item1.
 
             BuildTypeMapping<T?>(primitiveKind, isStandard);
+            BuildTypeMapping<T>(primitiveKind, isStandard);
+        }
+
+        private static void BuildReferenceTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind, bool isStandard = true)
+            where T : class
+        {
             BuildTypeMapping<T>(primitiveKind, isStandard);
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataTypeMapper.cs
@@ -387,7 +387,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         private static IEnumerable<Type> GetMatchingTypes(string edmFullName, IAssemblyResolver assembliesResolver)
             => TypeHelper.GetLoadedTypes(assembliesResolver).Where(t => t.IsPublic && t.EdmFullName() == edmFullName);
 
-        private static void BuildTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind, bool isStandard = true)
+        private static void BuildTypeMapping<T>(EdmPrimitiveTypeKind primitiveKind, bool isStandard)
         {
             Type type = typeof(T);
             bool isNullable = type.IsNullable();


### PR DESCRIPTION
This PR simplifies type mapping registrations by extracting a common method that enforces the ordering rules of nullable vs non-nullable type registrations.

This should prevent mistakes when managing these types or introducing new types in the future as well as reduce the overall amount of code duplication in the class.