### PR TITLE
Fix ArgumentNullException in SelectExpandQueryOption

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 binderContext.AddComputedProperties(Compute.ComputeClause.ComputedItems);
             }
 
-            return binder.ApplyBind(queryable, _selectExpandClause, binderContext);
+            return binder.ApplyBind(queryable, SelectExpandClause, binderContext);
         }
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 binderContext.AddComputedProperties(Compute.ComputeClause.ComputedItems);
             }
 
-            return binder.ApplyBind(entity, _selectExpandClause, binderContext);
+            return binder.ApplyBind(entity, SelectExpandClause, binderContext);
         }
 
         /// <summary>


### PR DESCRIPTION
The issue here is that the backing field _selectExpandClause isn't always initialized by the time ApplyTo is called unless the caller accesed the public SelectExpandClause property themselves. This causes the call to binder.ApplyBind to throw an ArgumentNullException.