### PR TITLE
Fix to defer resolution of ContentID in Uri

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -134,7 +134,14 @@ namespace Microsoft.AspNetCore.OData.Batch
             HttpRequest request = context.Request;
 
             request.Method = batchRequest.Method;
-            request.CopyAbsoluteUrl(batchRequest.Url);
+            if (batchRequest.Url.IsAbsoluteUri)
+            {
+                request.CopyAbsoluteUrl(batchRequest.Url);
+            }
+            else
+            {
+                request.Path = new PathString(string.Concat("/", batchRequest.Url.OriginalString));
+            }
 
             // Not using bufferContentStream. Unlike AspNet, AspNetCore cannot guarantee the disposal
             // of the stream in the context of execution so there is no choice but to copy the stream

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1089,6 +1089,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1089,20 +1089,6 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.DateOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a DateOnly; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.TimeOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a TimeOnly; false otherwise.</returns>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerController.cs
@@ -49,16 +49,28 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Batch
             return Created(customer);
         }
 
-        public Task CreateRef([FromODataUri] int key, string navigationProperty, [FromBody] Uri link)
+        public IActionResult CreateRef([FromODataUri] int key, string navigationProperty, [FromBody] Uri link)
         {
-            return Task.FromResult(StatusCode(StatusCodes.Status204NoContent));
+            return NoContent();
         }
     }
 
     public class DefaultBatchOrdersController : ODataController
     {
+        private static IList<DefaultBatchOrder> _orders = Enumerable.Range(0, 13).Select(i =>
+            new DefaultBatchOrder
+            {
+                Id = i
+            }).ToList();
+
         public DefaultBatchOrdersController()
         {
+        }
+
+        public IActionResult Post([FromBody] DefaultBatchOrder order)
+        {
+            _orders.Add(order);
+            return Created(order);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerTests.cs
@@ -375,5 +375,98 @@ GET " + absoluteUri + @"(1) HTTP/1.1
             }
             Assert.Equal(3, subResponseCount);
         }
+
+        [Fact]
+        public async Task CanHandleContentIDInRelativeUrl()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            string requestUri = "DefaultBatch/$batch";
+
+            string defaultBatchCustomersAbsoluteUri = "http://localhost/DefaultBatch/DefaultBatchCustomers";
+            string defaultBatchOrdersAbsoluteUri = "http://localhost/DefaultBatch/DefaultBatchOrders";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            HttpContent content = new StringContent(@"
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: multipart/mixed; boundary=changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST " + defaultBatchCustomersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{'Id':13,'Name':'Customer 13'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST " + defaultBatchOrdersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'Id':13}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST $1/Orders/$ref HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'@odata.id':'$2'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc--
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            // string b = await content.ReadAsStringAsync();
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                var subResponseStatusCodes = new int[] { 201, 201, 204 /*CreateRef*/ };
+
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            var subResponseStatusCode = subResponseCount < subResponseStatusCodes.Length ? subResponseStatusCodes[subResponseCount] : 201;
+
+                            subResponseCount++;
+                            Assert.Equal(subResponseStatusCode, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
     }
 }


### PR DESCRIPTION
Fixes #365

This PR fixes the issue by deferring resolution of ContentID in Uri (e.g. `$1/TestBs/$ref`) to much later when the dependent operations have already been executed and the ContentID mapped to a location for a resource. That will be done here:
https://github.com/OData/AspNetCoreOData/blob/69eec03c7003fe12d92cdc619efdc16781683694/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs#L44-L56
`CopyAbsoluteUrl(Uri)` is called and the request Url has been resolved