### PR TITLE
Fix reference handling in $batch

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
@@ -44,8 +44,9 @@ namespace Microsoft.AspNetCore.OData.Batch
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
             List<HttpContext> responseContexts = new List<HttpContext>();
+
+            IDictionary<string, string> contentIdToLocationMapping = this.ContentIdToLocationMapping ?? new Dictionary<string, string>();
 
             foreach (HttpContext context in Contexts)
             {

--- a/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
@@ -109,6 +109,8 @@ namespace Microsoft.AspNetCore.OData.Batch
                 List<ODataBatchRequestItem> requests = new List<ODataBatchRequestItem>();
                 ODataBatchReader batchReader = await reader.CreateODataBatchReaderAsync().ConfigureAwait(false);
                 Guid batchId = Guid.NewGuid();
+                Dictionary<string, string> contentToLocationMapping = new Dictionary<string, string>();
+
                 while (await batchReader.ReadAsync().ConfigureAwait(false))
                 {
                     if (batchReader.State == ODataBatchReaderState.ChangesetStart)
@@ -118,13 +120,18 @@ namespace Microsoft.AspNetCore.OData.Batch
                         {
                             changeSetContext.Request.ClearRouteServices();
                         }
-                        requests.Add(new ChangeSetRequestItem(changeSetContexts));
+
+                        ChangeSetRequestItem requestItem = new ChangeSetRequestItem(changeSetContexts);
+                        requestItem.ContentIdToLocationMapping = contentToLocationMapping;
+                        requests.Add(requestItem);
                     }
                     else if (batchReader.State == ODataBatchReaderState.Operation)
                     {
                         HttpContext operationContext = await batchReader.ReadOperationRequestAsync(context, batchId, cancellationToken).ConfigureAwait(false);
                         operationContext.Request.ClearRouteServices();
-                        requests.Add(new OperationRequestItem(operationContext));
+                        OperationRequestItem requestItem = new OperationRequestItem(operationContext);
+                        requestItem.ContentIdToLocationMapping = contentToLocationMapping;
+                        requests.Add(requestItem);
                     }
                 }
 

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -132,9 +132,16 @@ namespace Microsoft.AspNetCore.OData.Batch
 
             HttpContext context = CreateHttpContext(originalContext);
             HttpRequest request = context.Request;
+            Uri requestUri = batchRequest.Url;
+
+            if (!requestUri.IsAbsoluteUri)
+            {
+                Uri baseUri = batchRequest.Container.GetRequiredService<ODataMessageReaderSettings>().BaseUri;
+                requestUri = new Uri(baseUri, requestUri);
+            }
 
             request.Method = batchRequest.Method;
-            request.CopyAbsoluteUrl(batchRequest.Url);
+            request.CopyAbsoluteUrl(requestUri);
 
             // Not using bufferContentStream. Unlike AspNet, AspNetCore cannot guarantee the disposal
             // of the stream in the context of execution so there is no choice but to copy the stream

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.OData.Batch
         /// <param name="contentIdToLocationMapping">The Content-ID to Location mapping.</param>
         /// <returns></returns>
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
-        public static async Task SendRequestAsync(RequestDelegate handler, HttpContext context, Dictionary<string, string> contentIdToLocationMapping)
+        public static async Task SendRequestAsync(RequestDelegate handler, HttpContext context, IDictionary<string, string> contentIdToLocationMapping)
         {
             if (handler == null)
             {
@@ -82,6 +82,12 @@ namespace Microsoft.AspNetCore.OData.Batch
         /// <param name="handler">The handler for processing a message.</param>
         /// <returns>A <see cref="ODataBatchResponseItem"/>.</returns>
         public abstract Task<ODataBatchResponseItem> SendRequestAsync(RequestDelegate handler);
+
+        /// <summary>
+        /// Default dictionary that ODataBatchRequestItems should use when mapping ID references to URLs
+        /// </summary>
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Collection needs to be provided externally.")]
+        public IDictionary<string, string> ContentIdToLocationMapping { get; set; }
 
         private static void AddLocationHeaderToMapping(HttpResponse response, IDictionary<string, string> contentIdToLocationMapping, string contentId)
         {

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.OData.Batch
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            await SendRequestAsync(handler, Context, null).ConfigureAwait(false);
+            await SendRequestAsync(handler, Context, this.ContentIdToLocationMapping).ConfigureAwait(false);
 
             return new OperationResponseItem(Context);
         }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -713,7 +713,7 @@
             Represents an OData batch request.
             </summary>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.SendRequestAsync(Microsoft.AspNetCore.Http.RequestDelegate,Microsoft.AspNetCore.Http.HttpContext,System.Collections.Generic.Dictionary{System.String,System.String})">
+        <member name="M:Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.SendRequestAsync(Microsoft.AspNetCore.Http.RequestDelegate,Microsoft.AspNetCore.Http.HttpContext,System.Collections.Generic.IDictionary{System.String,System.String})">
             <summary>
             Routes a single OData batch request.
             </summary>
@@ -728,6 +728,11 @@
             </summary>
             <param name="handler">The handler for processing a message.</param>
             <returns>A <see cref="T:Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem"/>.</returns>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.ContentIdToLocationMapping">
+            <summary>
+            Default dictionary that ODataBatchRequestItems should use when mapping ID references to URLs
+            </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem">
             <summary>
@@ -1088,20 +1093,6 @@
             </summary>
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.DateOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a DateOnly; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.TimeOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a TimeOnly; false otherwise.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1094,6 +1094,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -157,6 +157,8 @@ Microsoft.AspNetCore.OData.Batch.ODataBatchMiddleware.Invoke(Microsoft.AspNetCor
 Microsoft.AspNetCore.OData.Batch.ODataBatchMiddleware.ODataBatchMiddleware(System.IServiceProvider serviceProvider, Microsoft.AspNetCore.Http.RequestDelegate next) -> void
 Microsoft.AspNetCore.OData.Batch.ODataBatchReaderExtensions
 Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem
+Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.ContentIdToLocationMapping.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.ContentIdToLocationMapping.set -> void
 Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.ODataBatchRequestItem() -> void
 Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem
 Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem.ODataBatchResponseItem() -> void
@@ -1529,7 +1531,7 @@ static Microsoft.AspNetCore.OData.Batch.ODataBatchHttpRequestExtensions.SetOData
 static Microsoft.AspNetCore.OData.Batch.ODataBatchReaderExtensions.ReadChangeSetOperationRequestAsync(this Microsoft.OData.ODataBatchReader reader, Microsoft.AspNetCore.Http.HttpContext context, System.Guid batchId, System.Guid changeSetId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Http.HttpContext>
 static Microsoft.AspNetCore.OData.Batch.ODataBatchReaderExtensions.ReadChangeSetRequestAsync(this Microsoft.OData.ODataBatchReader reader, Microsoft.AspNetCore.Http.HttpContext context, System.Guid batchId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.AspNetCore.Http.HttpContext>>
 static Microsoft.AspNetCore.OData.Batch.ODataBatchReaderExtensions.ReadOperationRequestAsync(this Microsoft.OData.ODataBatchReader reader, Microsoft.AspNetCore.Http.HttpContext context, System.Guid batchId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Http.HttpContext>
-static Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.SendRequestAsync(Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.Dictionary<string, string> contentIdToLocationMapping) -> System.Threading.Tasks.Task
+static Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem.SendRequestAsync(Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IDictionary<string, string> contentIdToLocationMapping) -> System.Threading.Tasks.Task
 static Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem.WriteMessageAsync(Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context) -> System.Threading.Tasks.Task
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetAlternateKeys(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmEntityType entityType) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IDictionary<string, Microsoft.OData.Edm.IEdmPathExpression>>
 static Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions.GetClrEnumMemberAnnotation(this Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmEnumType enumType) -> Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerController.cs
@@ -49,16 +49,28 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Batch
             return Created(customer);
         }
 
-        public Task CreateRef([FromODataUri] int key, string navigationProperty, [FromBody] Uri link)
+        public IActionResult CreateRef([FromODataUri] int key, string navigationProperty, [FromBody] Uri link)
         {
-            return Task.FromResult(StatusCode(StatusCodes.Status204NoContent));
+            return NoContent();
         }
     }
 
     public class DefaultBatchOrdersController : ODataController
     {
+        private static IList<DefaultBatchOrder> _orders = Enumerable.Range(0, 13).Select(i =>
+            new DefaultBatchOrder
+            {
+                Id = i
+            }).ToList();
+
         public DefaultBatchOrdersController()
         {
+        }
+
+        public IActionResult Post([FromBody] DefaultBatchOrder order)
+        {
+            _orders.Add(order);
+            return Created(order);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/DefaultODataBatchHandlerTests.cs
@@ -250,7 +250,7 @@ Content-Type: application/json;odata.metadata=minimal
         {
             // Arrange
             HttpClient client = CreateClient();
-            var requestUri ="DefaultBatch/$batch";
+            var requestUri = "DefaultBatch/$batch";
             string absoluteUri = "http://localhost/DefaultBatch/DefaultBatchCustomers";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
@@ -373,6 +373,189 @@ GET " + absoluteUri + @"(1) HTTP/1.1
                     }
                 }
             }
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleContentIDInRelativeUrl()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            string requestUri = "DefaultBatch/$batch";
+
+            string defaultBatchCustomersAbsoluteUri = "http://localhost/DefaultBatch/DefaultBatchCustomers";
+            string defaultBatchOrdersAbsoluteUri = "http://localhost/DefaultBatch/DefaultBatchOrders";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            HttpContent content = new StringContent(@"
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: multipart/mixed; boundary=changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST " + defaultBatchCustomersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{'Id':13,'Name':'Customer 13'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST " + defaultBatchOrdersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'Id':13}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST $1/Orders/$ref HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'@odata.id':'$2'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc--
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            // string b = await content.ReadAsStringAsync();
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                var subResponseStatusCodes = new int[] { 201, 201, 204 /*CreateRef*/ };
+
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            var subResponseStatusCode = subResponseCount < subResponseStatusCodes.Length ? subResponseStatusCodes[subResponseCount] : 201;
+
+                            subResponseCount++;
+                            Assert.Equal(subResponseStatusCode, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleReferencingOfRequestsNotSharingAutomicityGroup()
+        {
+            // Arrange
+            var client = CreateClient();
+
+            var requestUri = "DefaultBatch/$batch";
+            var defaultBatchCustomersRelativeUri = "DefaultBatchCustomers";
+            var defaultBatchOrdersRelativeUri = "DefaultBatchOrders";
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+        {
+            ""requests"": [{
+                    ""id"": ""1"",
+                    ""method"": ""POST"",
+                    ""url"": """ + defaultBatchCustomersRelativeUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":7,
+                        ""Name"":""Customer 7""
+                    }
+                }, {
+                    ""id"": ""2"",
+                    ""dependsOn"": [""1""],
+                    ""method"": ""POST"",
+                    ""url"": """ + defaultBatchOrdersRelativeUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":7
+                    }
+                }, {
+                    ""id"": ""3"",
+                    ""dependsOn"": [""1"", ""2""],
+                    ""method"": ""POST"",
+                    ""url"": ""$1/Orders/$ref"",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""@odata.id"":""$2""
+                    }
+                }
+            ]
+        }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                var subResponseStatusCodes = new int[] { 201, 201, 204 /*CreateRef*/ };
+                
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            var subResponseStatusCode = subResponseCount < subResponseStatusCodes.Length ? subResponseStatusCodes[subResponseCount] : 201;
+                            
+                            subResponseCount++;
+                            Assert.Equal(subResponseStatusCode, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
             Assert.Equal(3, subResponseCount);
         }
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/UnbufferedODataBatchHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Batch/UnbufferedODataBatchHandlerTests.cs
@@ -1,0 +1,562 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="UnbufferedODataBatchHandlerTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.E2E.Tests.Commons;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Batch
+{
+    public class UnbufferedBatchHandlerCUDBatchTests : WebApiTestBase<UnbufferedBatchHandlerCUDBatchTests>
+    {
+        private static IEdmModel edmModel;
+
+        public UnbufferedBatchHandlerCUDBatchTests(WebApiTestFixture<UnbufferedBatchHandlerCUDBatchTests> fixture)
+            : base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(DefaultBatchCustomersController), typeof(DefaultBatchOrdersController));
+
+            edmModel = GetEdmModel();
+            services.AddControllers().AddOData(opt =>
+            {
+                opt.EnableQueryFeatures();
+                opt.EnableContinueOnErrorHeader = true;
+                opt.AddRouteComponents("UnbufferedBatch", edmModel, new UnbufferedODataBatchHandler());
+            });
+        }
+
+        protected static void UpdateConfigure(IApplicationBuilder app)
+        {
+            app.UseODataBatching();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+
+        protected static IEdmModel GetEdmModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            EntitySetConfiguration<DefaultBatchCustomer> customers = builder.EntitySet<DefaultBatchCustomer>("DefaultBatchCustomers");
+            builder.EntitySet<DefaultBatchOrder>("DefaultBatchOrders");
+            customers.EntityType.Collection.Action("OddCustomers").ReturnsCollectionFromEntitySet<DefaultBatchCustomer>("DefaultBatchCustomers");
+            builder.MaxDataServiceVersion = builder.DataServiceVersion;
+            builder.Namespace = typeof(DefaultBatchCustomer).Namespace;
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task CanHandleAbsoluteAndRelativeUrls()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            string requestUri = "UnbufferedBatch/$batch";
+
+            string host = client.BaseAddress.Host;
+            string relativeToServiceRootUri = "DefaultBatchCustomers";
+            string relativeToHostUri = "/UnbufferedBatch/DefaultBatchCustomers";
+            string absoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchCustomers";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            HttpContent content = new StringContent(@"
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: multipart/mixed; boundary=changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST " + relativeToServiceRootUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{'Id':11,'Name':'MyName11'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST " + relativeToHostUri + @" HTTP/1.1
+Host: " + host + @"
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'Id':12,'Name':'MyName12'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 4
+
+POST " + absoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'Id':13,'Name':'MyName13'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc--
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            // string b = await content.ReadAsStringAsync();
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            //string a = await response.Content.ReadAsStringAsync();
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            Assert.Equal(201, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleAutomicityGroupRequestsAndUngroupedRequest_JsonBatch()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            string requestUri = "UnbufferedBatch/$batch";
+            string absoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchCustomers";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+        {
+            ""requests"": [{
+                    ""id"": ""1"",
+                    ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
+                    ""method"": ""POST"",
+                    ""url"": """ + absoluteUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":11,
+                        ""Name"":""CreatedByJsonBatch_11""
+                    }
+                }, {
+                    ""id"": ""2"",
+                    ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
+                    ""method"": ""POST"",
+                    ""url"": """ + absoluteUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":12,
+                        ""Name"":""CreatedByJsonBatch_12""
+                    }
+                }, {
+                    ""id"": ""3"",
+                    ""method"": ""POST"",
+                    ""url"": """ + absoluteUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":13,
+                        ""Name"":""CreatedByJsonBatch_3""
+                    }
+                }
+            ]
+        }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            Assert.Equal(201, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanNotContinueOnErrorWhenHeaderNotSet()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            var requestUri = "UnbufferedBatch/$batch";
+            string absoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchCustomers";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            HttpContent content = new StringContent(
+@"--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(0) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(-1) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(1) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+
+            // Assert
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            if (subResponseCount == 2)
+                            {
+                                Assert.Equal(400, operationMessage.StatusCode);
+                            }
+                            else
+                            {
+                                Assert.Equal(200, operationMessage.StatusCode);
+                            }
+                            break;
+                    }
+                }
+            }
+            Assert.Equal(2, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanContinueOnErrorWhenHeaderSet()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            var requestUri = "UnbufferedBatch/$batch";
+            string absoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchCustomers";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            request.Headers.Add("prefer", "odata.continue-on-error");
+            HttpContent content = new StringContent(
+@"--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(0) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(-1) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET " + absoluteUri + @"(1) HTTP/1.1
+
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+
+            // Assert
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            if (subResponseCount == 2)
+                            {
+                                Assert.Equal(400, operationMessage.StatusCode);
+                            }
+                            else
+                            {
+                                Assert.Equal(200, operationMessage.StatusCode);
+                            }
+                            break;
+                    }
+                }
+            }
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleContentIDInRelativeUrl()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+            string requestUri = "UnbufferedBatch/$batch";
+
+            string defaultBatchCustomersAbsoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchCustomers";
+            string defaultBatchOrdersAbsoluteUri = "http://localhost/UnbufferedBatch/DefaultBatchOrders";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("multipart/mixed"));
+            HttpContent content = new StringContent(@"
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0
+Content-Type: multipart/mixed; boundary=changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST " + defaultBatchCustomersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{'Id':13,'Name':'Customer 13'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST " + defaultBatchOrdersAbsoluteUri + @" HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'Id':13}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST $1/Orders/$ref HTTP/1.1
+OData-Version: 4.0;NetFx
+OData-MaxVersion: 4.0;NetFx
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+Content-Type: application/json;odata.metadata=minimal
+
+{'@odata.id':'$2'}
+--changeset_6c67825c-8938-4f11-af6b-a25861ee53cc--
+--batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0--
+");
+            // string b = await content.ReadAsStringAsync();
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/mixed; boundary=batch_abbe2e6f-e45b-4458-9555-5fc70e3aebe0");
+            request.Content = content;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                var subResponseStatusCodes = new int[] { 201, 201, 204 /*CreateRef*/ };
+
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            var subResponseStatusCode = subResponseCount < subResponseStatusCodes.Length ? subResponseStatusCodes[subResponseCount] : 201;
+
+                            subResponseCount++;
+                            Assert.Equal(subResponseStatusCode, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleReferencingOfRequestsNotSharingAutomicityGroup()
+        {
+            // Arrange
+            var client = CreateClient();
+
+            var requestUri = "UnbufferedBatch/$batch";
+            var defaultBatchCustomersRelativeUri = "DefaultBatchCustomers";
+            var defaultBatchOrdersRelativeUri = "DefaultBatchOrders";
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+        {
+            ""requests"": [{
+                    ""id"": ""1"",
+                    ""method"": ""POST"",
+                    ""url"": """ + defaultBatchCustomersRelativeUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":7,
+                        ""Name"":""Customer 7""
+                    }
+                }, {
+                    ""id"": ""2"",
+                    ""dependsOn"": [""1""],
+                    ""method"": ""POST"",
+                    ""url"": """ + defaultBatchOrdersRelativeUri + @""",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""Id"":7
+                    }
+                }, {
+                    ""id"": ""3"",
+                    ""dependsOn"": [""1"", ""2""],
+                    ""method"": ""POST"",
+                    ""url"": ""$1/Orders/$ref"",
+                    ""headers"": {
+                        ""OData-Version"": ""4.0"",
+                        ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                        ""Accept"": ""application/json;odata.metadata=minimal""
+                    },
+                    ""body"": {
+                        ""@odata.id"":""$2""
+                    }
+                }
+            ]
+        }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), edmModel))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                var subResponseStatusCodes = new int[] { 201, 201, 204 /*CreateRef*/ };
+                
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            var subResponseStatusCode = subResponseCount < subResponseStatusCodes.Length ? subResponseStatusCodes[subResponseCount] : 201;
+                            
+                            subResponseCount++;
+                            Assert.Equal(subResponseStatusCode, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+
+            Assert.Equal(3, subResponseCount);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -234,11 +234,13 @@ public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchHandler {
 public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem {
 	protected ODataBatchRequestItem ()
 
+	System.Collections.Generic.IDictionary`2[[System.String],[System.String]] ContentIdToLocationMapping  { public get; public set; }
+
 	public abstract System.Threading.Tasks.Task`1[[Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
+	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -234,11 +234,13 @@ public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchHandler {
 public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem {
 	protected ODataBatchRequestItem ()
 
+	System.Collections.Generic.IDictionary`2[[System.String],[System.String]] ContentIdToLocationMapping  { public get; public set; }
+
 	public abstract System.Threading.Tasks.Task`1[[Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
+	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
 }
 
 public abstract class Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem {


### PR DESCRIPTION
Fixes #360
Fixes #481
Fixes #365

-Handle relative references in $batch by making URL absolute before copying.
-Allow requests within a batch to reference other requests within the batch whether or not they are in the same changeset.
-Added a using for ODataMessageReader in UnbufferedODataBatchHandler.

Work remaining:
[x] Add Tests
[x] Fix Reference Handling in UnbufferedODataBatchHandler.