### PR TITLE
Adding support for case insensitive action names

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
@@ -392,13 +392,15 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <param name="structuralType">The starting structural type.</param>
         /// <param name="model">The Edm model.</param>
         /// <param name="typeName">The searching type name.</param>
+        /// <param name="caseInsensitive">If true, performs case insensitive search</param>
         /// <returns>The found type.</returns>
-        public static IEdmStructuredType FindTypeInInheritance(this IEdmStructuredType structuralType, IEdmModel model, string typeName)
+        public static IEdmStructuredType FindTypeInInheritance(this IEdmStructuredType structuralType, IEdmModel model, string typeName, bool caseInsensitive = false)
         {
+            StringComparison typeStringComparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;   
             IEdmStructuredType baseType = structuralType;
             while (baseType != null)
             {
-                if (GetName(baseType) == typeName)
+                if (GetName(baseType).Equals(typeName, typeStringComparison))
                 {
                     return baseType;
                 }
@@ -406,7 +408,7 @@ namespace Microsoft.AspNetCore.OData.Edm
                 baseType = baseType.BaseType;
             }
 
-            return model.FindAllDerivedTypes(structuralType).FirstOrDefault(c => GetName(c) == typeName);
+            return model.FindAllDerivedTypes(structuralType).FirstOrDefault(c => GetName(c).Equals(typeName, typeStringComparison));
         }
 
         private static string GetName(IEdmStructuredType type)

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -12855,6 +12855,11 @@
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.ODataRouteOptions" /> class.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableActionNameCaseInsensitive">
+            <summary>
+            Gets/sets a value indicating whether to enable case insensitive for the action name in conventional routing.
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableControllerNameCaseInsensitive">
             <summary>
             Gets/sets a value indicating whether to enable case insensitive for the controller name in conventional routing.

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2271,13 +2271,14 @@
             <param name="edmType"></param>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.FindTypeInInheritance(Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmModel,System.String)">
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.FindTypeInInheritance(Microsoft.OData.Edm.IEdmStructuredType,Microsoft.OData.Edm.IEdmModel,System.String,System.Boolean)">
             <summary>
             Find the given type in a structured type inheritance, include itself.
             </summary>
             <param name="structuralType">The starting structural type.</param>
             <param name="model">The Edm model.</param>
             <param name="typeName">The searching type name.</param>
+            <param name="caseInsensitive">If true, performs case insensitive search</param>
             <returns>The found type.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.GetAvailableActions(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmEntityType)">

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1225,6 +1225,8 @@ Microsoft.AspNetCore.OData.Routing.ODataPathSegmentHandler.PathLiteral.get -> st
 Microsoft.AspNetCore.OData.Routing.ODataPathSegmentTranslator
 Microsoft.AspNetCore.OData.Routing.ODataPathSegmentTranslator.ODataPathSegmentTranslator() -> void
 Microsoft.AspNetCore.OData.Routing.ODataRouteOptions
+Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableActionNameCaseInsensitive.get -> bool
+Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableActionNameCaseInsensitive.set -> void
 Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableControllerNameCaseInsensitive.get -> bool
 Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableControllerNameCaseInsensitive.set -> void
 Microsoft.AspNetCore.OData.Routing.ODataRouteOptions.EnableKeyAsSegment.get -> bool

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntityRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntityRoutingConvention.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             IEdmStructuredType castType = null;
             if (castTypeName != null)
             {
-                castType = entityType.FindTypeInInheritance(context.Model, castTypeName);
+                castType = entityType.FindTypeInInheritance(context.Model, castTypeName, context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true);
                 if (castType == null)
                 {
                     return false;

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntitySetRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntitySetRoutingConvention.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                 return false;
             }
 
-            IEdmStructuredType castType = entityType.FindTypeInInheritance(context.Model, castTypeName);
+            IEdmStructuredType castType = entityType.FindTypeInInheritance(context.Model, castTypeName, context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true);
             if (castType == null)
             {
                 return false;
@@ -100,7 +100,9 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
         private static bool ProcessEntitySetAction(string actionName, IEdmEntitySet entitySet, IEdmStructuredType castType,
             ODataControllerActionContext context, ActionModel action)
         {
-            if (actionName == "Get" || actionName == $"Get{entitySet.Name}")
+            StringComparison actionNameComparison = context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+                 
+            if (actionName.Equals("Get", actionNameComparison) || actionName.Equals($"Get{entitySet.Name}", actionNameComparison))
             {
                 IEdmCollectionType castCollectionType = null;
                 if (castType != null)
@@ -141,7 +143,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                 action.AddSelector("Get", context.Prefix, context.Model, template, context.Options?.RouteOptions);
                 return true;
             }
-            else if (actionName == "Post" || actionName == $"Post{entitySet.EntityType().Name}")
+            else if (actionName.Equals("Post", actionNameComparison) || actionName.Equals($"Post{entitySet.EntityType().Name}", actionNameComparison))
             {
                 // POST ~/Customers
                 IList<ODataSegmentTemplate> segments = new List<ODataSegmentTemplate>
@@ -159,7 +161,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                 action.AddSelector("Post", context.Prefix, context.Model, template, context.Options?.RouteOptions);
                 return true;
             }
-            else if (actionName == "Patch" || actionName == $"Patch{entitySet.Name}")
+            else if (actionName.Equals("Patch", actionNameComparison) || actionName.Equals($"Patch{entitySet.Name}", actionNameComparison))
             {
                 // PATCH ~/Patch  , ~/PatchCustomers
                 IList<ODataSegmentTemplate> segments = new List<ODataSegmentTemplate>

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
@@ -88,7 +88,12 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
 
             // TODO: refactor here
             // If we have multiple same function defined, we should match the best one?
-            IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && f.Name == operationName);
+            StringComparison actionNameComparison = context.Options?.RouteOptions?.EnableActionNameCaseInsensitive switch
+            {
+                true => StringComparison.InvariantCultureIgnoreCase,
+                _ => StringComparison.InvariantCulture
+            };
+            IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && string.Equals(f.Name, operationName, actionNameComparison));
             foreach (IEdmOperation edmOperation in candidates)
             {
                 IEdmOperationParameter bindingParameter = edmOperation.Parameters.FirstOrDefault();

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                     return;
                 }
 
-                castTypeFromActionName = entityType.FindTypeInInheritance(context.Model, cast) as IEdmEntityType;
+                castTypeFromActionName = entityType.FindTypeInInheritance(context.Model, cast, context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true) as IEdmEntityType;
                 if (castTypeFromActionName == null)
                 {
                     return;
@@ -88,12 +88,8 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
 
             // TODO: refactor here
             // If we have multiple same function defined, we should match the best one?
-            StringComparison actionNameComparison = context.Options?.RouteOptions?.EnableActionNameCaseInsensitive switch
-            {
-                true => StringComparison.InvariantCultureIgnoreCase,
-                _ => StringComparison.InvariantCulture
-            };
-            IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && string.Equals(f.Name, operationName, actionNameComparison));
+            StringComparison actionNameComparison = context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && f.Name.Equals(operationName, actionNameComparison));
             foreach (IEdmOperation edmOperation in candidates)
             {
                 IEdmOperationParameter bindingParameter = edmOperation.Parameters.FirstOrDefault();

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRouteOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRouteOptions.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AspNetCore.OData.Routing
         }
 
         /// <summary>
+        /// Gets/sets a value indicating whether to enable case insensitive for the action name in conventional routing.
+        /// </summary>
+        public bool EnableActionNameCaseInsensitive { get; set; } = false;
+        
+        /// <summary>
         /// Gets/sets a value indicating whether to enable case insensitive for the controller name in conventional routing.
         /// </summary>
         public bool EnableControllerNameCaseInsensitive { get; set; } = false;

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net5.bsl
@@ -1760,6 +1760,7 @@ public class Microsoft.AspNetCore.OData.Routing.ODataPathSegmentTranslator : Mic
 public class Microsoft.AspNetCore.OData.Routing.ODataRouteOptions {
 	public ODataRouteOptions ()
 
+	bool EnableActionNameCaseInsensitive  { public get; public set; }
 	bool EnableControllerNameCaseInsensitive  { public get; public set; }
 	bool EnableKeyAsSegment  { public get; public set; }
 	bool EnableKeyInParenthesis  { public get; public set; }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -1760,6 +1760,7 @@ public class Microsoft.AspNetCore.OData.Routing.ODataPathSegmentTranslator : Mic
 public class Microsoft.AspNetCore.OData.Routing.ODataRouteOptions {
 	public ODataRouteOptions ()
 
+	bool EnableActionNameCaseInsensitive  { public get; public set; }
 	bool EnableControllerNameCaseInsensitive  { public get; public set; }
 	bool EnableKeyAsSegment  { public get; public set; }
 	bool EnableKeyInParenthesis  { public get; public set; }

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/ActionRoutingConventionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/ActionRoutingConventionTests.cs
@@ -17,13 +17,20 @@ using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.AspNetCore.OData.Tests.Extensions;
 using Microsoft.OData.Edm;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
 {
     public class ActionRoutingConventionTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
         private static ActionRoutingConvention ActionConvention = ConventionHelpers.CreateConvention<ActionRoutingConvention>();
         private static IEdmModel EdmModel = GetEdmModel();
+
+        public ActionRoutingConventionTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         [Fact]
         public void AppliesToActionOnActionRoutingConvention_Throws_Context()
@@ -178,6 +185,90 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                 };
             }
         }
+        
+        public static TheoryDataSet<Type, string, string[]> ActionRoutingConventionCaseInsensitiveTestData
+        {
+            get
+            {
+                return new TheoryDataSet<Type, string, string[]>()
+                {
+                    // Bound to single
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "ISBASEUPGRADED",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive({key})/NS.IsBaseUpgraded",
+                            "/CustomersCaseInsensitive({key})/IsBaseUpgraded",
+                            "/CustomersCaseInsensitive/{key}/NS.IsBaseUpgraded",
+                            "/CustomersCaseInsensitive/{key}/IsBaseUpgraded",
+                        }
+                    },
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "ISUPGRADED",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive({key})/NS.IsUpgraded",
+                            "/CustomersCaseInsensitive({key})/IsUpgraded",
+                            "/CustomersCaseInsensitive/{key}/NS.IsUpgraded",
+                            "/CustomersCaseInsensitive/{key}/IsUpgraded"
+                        }
+                    },
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "ISVIPUPGRADED",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive({key})/NS.VipCustomer/NS.IsVipUpgraded",
+                            "/CustomersCaseInsensitive({key})/NS.VipCustomer/IsVipUpgraded",
+                            "/CustomersCaseInsensitive/{key}/NS.VipCustomer/NS.IsVipUpgraded",
+                            "/CustomersCaseInsensitive/{key}/NS.VipCustomer/IsVipUpgraded"
+                        }
+                    },
+                    // bound to collection
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "ISBASEALLUPGRADED",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive/NS.IsBaseAllUpgraded",
+                            "/CustomersCaseInsensitive/IsBaseAllUpgraded"
+                        }
+                    },
+                    // overload
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "UPGRADEDALLOnCustomer",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive({key})/NS.UpgradedAll",
+                            "/CustomersCaseInsensitive({key})/UpgradedAll",
+                            "/CustomersCaseInsensitive/{key}/NS.UpgradedAll",
+                            "/CustomersCaseInsensitive/{key}/UpgradedAll"
+                        }
+                    },
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "UPGRADEDALLOnCollectionOfCustomer",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive/NS.UpgradedAll",
+                            "/CustomersCaseInsensitive/UpgradedAll"
+                        }
+                    },
+                    {
+                        typeof(CustomersCaseInsensitiveController),
+                        "UPGRADEDALLOnCollectionOfVipCustomer",
+                        new[]
+                        {
+                            "/CustomersCaseInsensitive/NS.VipCustomer/NS.UpgradedAll",
+                            "/CustomersCaseInsensitive/NS.VipCustomer/UpgradedAll"
+                        }
+                    }
+                };
+            }
+        }
 
         [Theory]
         [MemberData(nameof(ActionRoutingConventionTestData))]
@@ -193,6 +284,28 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             // Act
             ActionConvention.AppliesToAction(context);
 
+            // Assert
+            Assert.Equal(templates.Length, action.Selectors.Count);
+            Assert.Equal(templates, action.Selectors.Select(s => s.AttributeRouteModel.Template));
+        }
+
+        [Theory]
+        [MemberData(nameof(ActionRoutingConventionCaseInsensitiveTestData))]
+        [MemberData(nameof(ActionRoutingConventionTestData))]
+        public void ActionRoutingConventionTestDataWithCaseInsensitiveActionNameRunsAsExpected(Type controllerType, string actionName, string[] templates)
+        {
+            // Arrange
+            ControllerModel controller = ControllerModelHelpers.BuildControllerModel(controllerType, actionName);
+            ActionModel action = controller.Actions.First();
+
+            ODataControllerActionContext context = ODataControllerActionContextHelpers.BuildContext(string.Empty, EdmModel, controller);
+            context.Options.RouteOptions.EnableActionNameCaseInsensitive = true;
+            context.Action = action;
+
+            // Act
+            ActionConvention.AppliesToAction(context);
+
+            
             // Assert
             Assert.Equal(templates.Length, action.Selectors.Count);
             Assert.Equal(templates, action.Selectors.Select(s => s.AttributeRouteModel.Template));
@@ -295,6 +408,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
 
             EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
             container.AddEntitySet("Customers", customer);
+            container.AddEntitySet("CustomersCaseInsensitive", customer);
             container.AddSingleton("Me", customer);
             model.AddElement(container);
             return model;
@@ -370,6 +484,37 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             [HttpPost]
             public void IsVipUpgraded(ODataActionParameters parameters, string param)
             { }
+        }
+        
+        private class CustomersCaseInsensitiveController
+        {
+            [HttpPost]
+            public void ISBASEUPGRADED(int key, CancellationToken cancellation, ODataActionParameters parameters)
+            { }            
+            
+            [HttpPost]
+            public void ISUPGRADED(int key, CancellationToken cancellation)
+            { }
+            
+            [HttpPost]
+            public void ISVIPUPGRADED(int key, ODataActionParameters parameters)
+            { }
+            
+            [HttpPost]
+            public void ISBASEALLUPGRADED(ODataActionParameters parameters)
+            { }
+            
+            [HttpPost]
+            public void UPGRADEDALLOnCustomer(int key, ODataActionParameters parameters)
+            { }            
+            
+            [HttpPost]
+            public void UPGRADEDALLOnCollectionOfCustomer(ODataActionParameters parameters)
+            { }
+            
+            [HttpPost]
+            public void UPGRADEDALLOnCollectionOfVipCustomer(ODataActionParameters parameters)
+            { }            
         }
 
         private class AnotherCustomersController

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/ActionRoutingConventionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/ActionRoutingConventionTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                     // overload
                     {
                         typeof(CustomersCaseInsensitiveController),
-                        "UPGRADEDALLOnCustomer",
+                        "UPGRADEDALLOnCUSTOMER",
                         new[]
                         {
                             "/CustomersCaseInsensitive({key})/NS.UpgradedAll",
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                     },
                     {
                         typeof(CustomersCaseInsensitiveController),
-                        "UPGRADEDALLOnCollectionOfCustomer",
+                        "UPGRADEDALLOnCollectionOfCUSTOMER",
                         new[]
                         {
                             "/CustomersCaseInsensitive/NS.UpgradedAll",
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                     },
                     {
                         typeof(CustomersCaseInsensitiveController),
-                        "UPGRADEDALLOnCollectionOfVipCustomer",
+                        "UPGRADEDALLOnCollectionOfVIPCUSTOMER",
                         new[]
                         {
                             "/CustomersCaseInsensitive/NS.VipCustomer/NS.UpgradedAll",
@@ -310,6 +310,25 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             Assert.Equal(templates.Length, action.Selectors.Count);
             Assert.Equal(templates, action.Selectors.Select(s => s.AttributeRouteModel.Template));
         }
+        
+        [Theory]
+        [MemberData(nameof(ActionRoutingConventionCaseInsensitiveTestData))]
+        public void ActionRoutingConventionDoesCaseSensitiveMatchingByDefault(Type controllerType, string actionName, string[] templates)
+        {
+            // Arrange
+            ControllerModel controller = ControllerModelHelpers.BuildControllerModel(controllerType, actionName);
+            ActionModel action = controller.Actions.First();
+
+            ODataControllerActionContext context = ODataControllerActionContextHelpers.BuildContext(string.Empty, EdmModel, controller);
+            context.Action = action;
+
+            // Act
+            ActionConvention.AppliesToAction(context);
+
+            // Assert
+            SelectorModel selector = Assert.Single(action.Selectors);
+            Assert.Null(selector.AttributeRouteModel);
+        }        
 
         [Theory]
         [InlineData("Post")]
@@ -505,15 +524,15 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             { }
             
             [HttpPost]
-            public void UPGRADEDALLOnCustomer(int key, ODataActionParameters parameters)
+            public void UPGRADEDALLOnCUSTOMER(int key, ODataActionParameters parameters)
             { }            
             
             [HttpPost]
-            public void UPGRADEDALLOnCollectionOfCustomer(ODataActionParameters parameters)
+            public void UPGRADEDALLOnCollectionOfCUSTOMER(ODataActionParameters parameters)
             { }
             
             [HttpPost]
-            public void UPGRADEDALLOnCollectionOfVipCustomer(ODataActionParameters parameters)
+            public void UPGRADEDALLOnCollectionOfVIPCUSTOMER(ODataActionParameters parameters)
             { }            
         }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/SingletonRoutingConventionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/SingletonRoutingConventionTests.cs
@@ -71,6 +71,23 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                 };
             }
         }
+        
+        public static TheoryDataSet<string, string[]> SingletonConventionCaseInsensitiveTestData
+        {
+            get
+            {
+                return new TheoryDataSet<string, string[]>()
+                {
+                    // Bound to single
+                    { "GET", new[] { "/CaseInsensitiveMe" } },
+                    { "GETFromVIPCUSTOMER", new[] { "/CaseInsensitiveMe/NS.VipCustomer" } },
+                    { "PUT", new[] { "/CaseInsensitiveMe" } },
+                    { "PUTFromVIPCUSTOMER", new[] { "/CaseInsensitiveMe/NS.VipCustomer" } },
+                    { "PATCH", new[] { "/CaseInsensitiveMe" } },
+                    { "PATCHFromVIPCUSTOMER", new[] { "/CaseInsensitiveMe/NS.VipCustomer" } },
+                };
+            }
+        }
 
         [Theory]
         [MemberData(nameof(SingletonConventionTestData))]
@@ -82,6 +99,26 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
 
             ODataControllerActionContext context = ODataControllerActionContextHelpers.BuildContext(string.Empty, EdmModel, controller);
             context.Action = action;
+
+            // Act
+            SingletonConvention.AppliesToAction(context);
+
+            // Assert
+            Assert.Equal(templates.Length, action.Selectors.Count);
+            Assert.Equal(templates, action.Selectors.Select(s => s.AttributeRouteModel.Template));
+        }
+        
+        [Theory]
+        [MemberData(nameof(SingletonConventionCaseInsensitiveTestData))]
+        public void SingletonRoutingConventionCaseInsensitiveTestDataRunsAsExpected(string actionName, string[] templates)
+        {
+            // Arrange
+            ControllerModel controller = ControllerModelHelpers.BuildControllerModel<CaseInsensitiveMeController>(actionName);
+            ActionModel action = controller.Actions.First();
+
+            ODataControllerActionContext context = ODataControllerActionContextHelpers.BuildContext(string.Empty, EdmModel, controller);
+            context.Action = action;
+            context.Options.RouteOptions.EnableActionNameCaseInsensitive = true;
 
             // Act
             SingletonConvention.AppliesToAction(context);
@@ -124,6 +161,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             model.AddElement(vipCustomer);
             var entityContainer = new EdmEntityContainer("NS", "Default");
             entityContainer.AddSingleton("Me", customer);
+            entityContainer.AddSingleton("CaseInsensitiveMe", customer);
             model.AddElement(entityContainer);
             return model;
         }
@@ -163,6 +201,33 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             }
 
             public void PatchFrom()
+            {
+            }
+        }        
+        
+        private class CaseInsensitiveMeController
+        {
+            public void GET()
+            {
+            }
+
+            public void GETFromVIPCUSTOMER()
+            {
+            }
+
+            public void PUT()
+            {
+            }
+
+            public void PUTFromVIPCUSTOMER()
+            {
+            }
+
+            public void PATCH()
+            {
+            }
+
+            public void PATCHFromVIPCUSTOMER()
             {
             }
         }

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/ODataRouteOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/ODataRouteOptionsTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing
             Assert.True(options.EnableQualifiedOperationCall);
             Assert.True(options.EnableUnqualifiedOperationCall);
             Assert.False(options.EnableNonParenthesisForEmptyParameterFunction);
+            Assert.False(options.EnableActionNameCaseInsensitive);
             Assert.False(options.EnableControllerNameCaseInsensitive);
             Assert.False(options.EnablePropertyNameCaseInsensitive);
         }
@@ -43,6 +44,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing
             Assert.True(options.EnableQualifiedOperationCall);
             Assert.True(options.EnableUnqualifiedOperationCall);
             Assert.False(options.EnableNonParenthesisForEmptyParameterFunction);
+            Assert.False(options.EnableActionNameCaseInsensitive);
             Assert.False(options.EnableControllerNameCaseInsensitive);
             Assert.False(options.EnablePropertyNameCaseInsensitive);
         }
@@ -55,6 +57,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing
             Verify(opt => opt.EnableQualifiedOperationCall, (opt, b) => opt.EnableQualifiedOperationCall = b);
             Verify(opt => opt.EnableUnqualifiedOperationCall, (opt, b) => opt.EnableUnqualifiedOperationCall = b);
             Verify(opt => opt.EnableNonParenthesisForEmptyParameterFunction, (opt, b) => opt.EnableNonParenthesisForEmptyParameterFunction = b, false);
+            Verify(opt => opt.EnableActionNameCaseInsensitive, (opt, b) => opt.EnableActionNameCaseInsensitive = b, false);
             Verify(opt => opt.EnableControllerNameCaseInsensitive, (opt, b) => opt.EnableControllerNameCaseInsensitive = b, false);
             Verify(opt => opt.EnablePropertyNameCaseInsensitive, (opt, b) => opt.EnablePropertyNameCaseInsensitive = b, false);
         }


### PR DESCRIPTION
I am working with an API which uses camel case OData action names but these are not found because the routing is case sensitive. For example, the following will not work:
```diff
// sample/ODataCustomizedSample/Models/EnumsEdmModel.cs:75
- var actionConfiguration = employee.Action("AddSkill");
+ var actionConfiguration = employee.Action("addSkill");
```
This fails because `OperationRoutingConvension` is case sensitive. Changing the following makes it work.
```diff
// src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs:91
- IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && f.Name == operationName);
+ IEnumerable<IEdmOperation> candidates = context.Model.SchemaElements.OfType<IEdmOperation>().Where(f => f.IsBound && string.Equals(f.Name, operationName, StringComparison.InvariantCultureIgnoreCase));
```

I have introduced the property `EnableActionNameCaseInsensitive` to optionally enable case insensitive action names.