### PR TITLE
Issue #567: Escape character , for example ('/') is not proper handle at key or function in quoted string

### DIFF
--- a/sample/ODataRoutingSample/Controllers/PeopleController.cs
+++ b/sample/ODataRoutingSample/Controllers/PeopleController.cs
@@ -21,7 +21,7 @@ namespace ODataRoutingSample.Controllers
             new Person
             {
                 FirstName = "Goods",
-                LastName = "Zhangg",
+                LastName = "Zha/ngg",
             },
             new Person
             {
@@ -42,6 +42,7 @@ namespace ODataRoutingSample.Controllers
             return Ok(_persons);
         }
 
+        // People(FirstName='Goods',LastName='Zha%2Fngg')
         [HttpGet]
         [EnableQuery]
         public IActionResult Get(string keyFirstName, string keyLastName)

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -172,6 +173,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                     IEdmTypeReference edmType = keyProperty.Type;
                     string strValue = rawValue as string;
                     string newStrValue = context.GetParameterAliasOrSelf(strValue);
+                    newStrValue = Uri.UnescapeDataString(newStrValue);
                     if (newStrValue != strValue)
                     {
                         updateValues[templateName] = newStrValue;

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
@@ -58,6 +58,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 {
                     string strValue = rawValue as string;
                     string newStrValue = context.GetParameterAliasOrSelf(strValue);
+                    newStrValue = Uri.UnescapeDataString(newStrValue);
                     if (newStrValue != strValue)
                     {
                         updatedValues[parameterTemp] = newStrValue;

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/KeySegmentTemplateTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/KeySegmentTemplateTests.cs
@@ -485,6 +485,53 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Template
         }
 
         [Fact]
+        public void TryTranslateKeySegmentTemplate_WorksWithKeyValue_UsingEscapedString()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmEntityType customerType = new EdmEntityType("NS", "Customer");
+            EdmStructuralProperty firstName = customerType.AddStructuralProperty("FirstName", EdmPrimitiveTypeKind.String);
+            EdmStructuralProperty lastName = customerType.AddStructuralProperty("LastName", EdmPrimitiveTypeKind.String);
+            customerType.AddKeys(firstName, lastName);
+            model.AddElement(customerType);
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet customers = container.AddEntitySet("Customers", customerType);
+            model.AddElement(container);
+            RouteValueDictionary routeValueDictionary = new RouteValueDictionary(new { First = "'Zhang'", Last = "'Gan%2Fnng%23%20T'" });
+            IDictionary<string, string> keys = new Dictionary<string, string>
+            {
+                { "FirstName", "{first}" },
+                { "LastName", "{last}" }
+            };
+            KeySegmentTemplate template = new KeySegmentTemplate(keys, customerType, customers);
+
+            ODataTemplateTranslateContext context = new ODataTemplateTranslateContext
+            {
+                RouteValues = routeValueDictionary,
+                Model = model
+            };
+
+            // Act
+            bool ok = template.TryTranslate(context);
+
+            // Assert
+            Assert.True(ok);
+            ODataPathSegment actual = Assert.Single(context.Segments);
+            KeySegment keySegment = Assert.IsType<KeySegment>(actual);
+            Assert.Collection(keySegment.Keys,
+                e =>
+                {
+                    Assert.Equal("FirstName", e.Key);
+                    Assert.Equal("Zhang", e.Value);
+                },
+                e =>
+                {
+                    Assert.Equal("LastName", e.Key);
+                    Assert.Equal("Gan/nng# T", e.Value);
+                });
+        }
+
+        [Fact]
         public void CreateKeySegmentKeySegmentTemplate_ThrowsArgumentNull_EntityType()
         {
             // Arrange & Act & Assert


### PR DESCRIPTION
#567

When send a request contains the escaped string in the string key or function parameter as follows
`Get: /People(FirstName='Goods',LastName='Zha%2Fngg')`

We should unescape it before going to the parsing step.

