### PR TITLE
Issue #349: Per-request query options are not preserved with the new $batch execution

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -227,7 +227,8 @@ namespace Microsoft.AspNetCore.OData.Batch
                     kvp.Key == typeof(IODataFeature) ||
                     kvp.Key == typeof(IItemsFeature) ||
                     kvp.Key == typeof(IHttpRequestFeature) ||
-                    kvp.Key == typeof(IHttpResponseFeature))
+                    kvp.Key == typeof(IHttpResponseFeature) ||
+                    kvp.Key == typeof(IQueryFeature)) // Noted: we should not pass the QueryFeature from Main request to the sub request
                 {
                     continue;
                 }


### PR DESCRIPTION
#349

Customers may retrieve the query from the main request ($batch) that will create IQueryFeature into the Main HttpContext, Once created, it will cache in the main HttpContext. We should remove IQueryFeature and don't pass that to the subrequest. Otherwise, the sub-request query string will never be used.