### PR TITLE
issue #568: Error when function/action name contains keyword "On"

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1094,20 +1094,6 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.DateOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a DateOnly; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.TimeOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a TimeOnly; false otherwise.</returns>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -14103,6 +14089,22 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
+            <param name="segment">The value segment.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
+            <summary>
+            Gets the value segment.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
+            <inheritdoc />
+        </member>
+    </members>
+</doc>
+ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1094,6 +1094,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -12413,13 +12427,14 @@
             <param name="entityType">The Edm entity type.</param>
             <param name="navigationSource">The Edm navigation source.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Conventions.OperationRoutingConvention.SplitActionName(System.String,System.String@,System.Boolean@)">
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Conventions.OperationRoutingConvention.SplitActionName(System.String,System.String@,System.Boolean@,System.StringComparison)">
             <summary>
             Split the action based on supporting pattern.
             </summary>
             <param name="actionName">The input action name.</param>
             <param name="cast">The out of cast type name.</param>
             <param name="isOnCollection">The out of collection binding flag.</param>
+            <param name="comparison">The case comparision flag.</param>
             <returns>The operation name.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Routing.Conventions.OperationRoutingConvention.IsOperationParameterMatched(Microsoft.OData.Edm.IEdmOperation,Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel)">
@@ -14089,22 +14104,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
@@ -177,7 +177,11 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             out IEdmEntityType castTypeFromActionName, out bool isOnCollection)
         {
             // OperationNameOnCollectionOfEntityType
-            string operationName = SplitActionName(actionName, out string cast, out isOnCollection);
+            StringComparison caseComparision = context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true ?
+                StringComparison.OrdinalIgnoreCase :
+                StringComparison.Ordinal;
+
+            string operationName = SplitActionName(actionName, out string cast, out isOnCollection, caseComparision);
 
             castTypeFromActionName = null;
             if (cast != null)
@@ -206,8 +210,10 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
         /// <param name="actionName">The input action name.</param>
         /// <param name="cast">The out of cast type name.</param>
         /// <param name="isOnCollection">The out of collection binding flag.</param>
+        /// <param name="comparison">The case comparision flag.</param>
         /// <returns>The operation name.</returns>
-        internal static string SplitActionName(string actionName, out string cast, out bool isOnCollection)
+        internal static string SplitActionName(string actionName, out string cast, out bool isOnCollection,
+            StringComparison comparison = StringComparison.Ordinal)
         {
             Contract.Assert(actionName != null);
 
@@ -218,7 +224,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             cast = null;
             isOnCollection = false;
             string operation;
-            int index = actionName.LastIndexOf("OnCollectionOf", StringComparison.Ordinal);
+            int index = actionName.LastIndexOf("OnCollectionOf", comparison);
             if (index > 0)
             {
                 operation = actionName.Substring(0, index);
@@ -227,7 +233,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                 return operation;
             }
 
-            index = actionName.LastIndexOf("On", StringComparison.Ordinal);
+            index = actionName.LastIndexOf("On", comparison);
             if (index > 0)
             {
                 operation = actionName.Substring(0, index);

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
@@ -76,11 +76,6 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                 candidates = FindCandidates(context, entityType, actionName, out castTypeFromActionName, out isOnCollection);
             }
 
-            if (candidates == null || candidates.Length == 0)
-            {
-                return;
-            }
-
             foreach (IEdmOperation edmOperation in candidates)
             {
                 IEdmOperationParameter bindingParameter = edmOperation.Parameters.FirstOrDefault();
@@ -192,13 +187,13 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                     // Early return for the following cases:
                     // - {OperationName}On
                     // - {OperationName}OnCollectionOf
-                    return null;
+                    return Array.Empty<IEdmOperation>();
                 }
 
                 castTypeFromActionName = entityType.FindTypeInInheritance(context.Model, cast, context.Options?.RouteOptions?.EnableActionNameCaseInsensitive == true) as IEdmEntityType;
                 if (castTypeFromActionName == null)
                 {
-                    return null;
+                    return Array.Empty<IEdmOperation>();
                 }
             }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/FunctionRoutingConventionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Conventions/FunctionRoutingConventionTests.cs
@@ -154,11 +154,47 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
                             "/Customers/NS.GetWholeSalary(minSalary={minSalary},maxSalary={maxSalary},aveSalary={aveSalary})",
                             "/Customers/GetWholeSalary(minSalary={minSalary},maxSalary={maxSalary},aveSalary={aveSalary})"
                         }
+                    },
+                    {
+                        typeof(CustomersController),
+                        "GetStatusOnLineOfflineUser",
+                        new[]
+                        {
+                            "/Customers/NS.GetStatusOnLineOfflineUser()",
+                            "/Customers/GetStatusOnLineOfflineUser()"
+                        }
+                    },
+                    {
+                        typeof(CustomersController),
+                        "GetStatusOnLineOfflineUser",
+                        new[]
+                        {
+                            "/Customers/NS.GetStatusOnLineOfflineUser()",
+                            "/Customers/GetStatusOnLineOfflineUser()"
+                        }
+                    },
+                    {
+                        typeof(CustomersController),
+                        "StatusLineOfflineUserOn",
+                        new[]
+                        {
+                            "/Customers/NS.StatusLineOfflineUserOn()",
+                            "/Customers/StatusLineOfflineUserOn()"
+                        }
+                    },
+                    {
+                        typeof(CustomersController),
+                        "GetStatusOnLineOfflineUserOnVipCustomer",
+                        new[]
+                        {
+                            "/Customers/NS.VipCustomer/NS.GetStatusOnLineOfflineUser(param={param})",
+                            "/Customers/NS.VipCustomer/GetStatusOnLineOfflineUser(param={param})"
+                        }
                     }
                 };
             }
-        }        
-        
+        }
+
         public static TheoryDataSet<Type, string, string[]> FunctionRoutingConventionCaseInsensitiveTestData
         {
             get
@@ -448,6 +484,19 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
             getSalaray.AddOptionalParameter("aveSalary", intType, "129");
             model.AddElement(getSalaray);
 
+            EdmFunction f = new EdmFunction("NS", "GetStatusOnLineOfflineUser", intType, isBound: true, entitySetPathExpression: null, isComposable: false);
+            f.AddParameter("entityset", new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(customer, false))));
+            model.AddElement(f);
+
+            EdmFunction f2 = new EdmFunction("NS", "StatusLineOfflineUserOn", intType, isBound: true, entitySetPathExpression: null, isComposable: false);
+            f2.AddParameter("entityset", new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(customer, false))));
+            model.AddElement(f2);
+
+            EdmFunction f3 = new EdmFunction("NS", "GetStatusOnLineOfflineUser", intType, isBound: true, entitySetPathExpression: null, isComposable: false);
+            f3.AddParameter("entityset", new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(vipCustomer, false))));
+            f3.AddParameter("param", intType);
+            model.AddElement(f3);
+
             EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
             container.AddEntitySet("Customers", customer);
             container.AddEntitySet("CustomersCaseInsensitive", customer);
@@ -460,6 +509,15 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Conventions
         {
             public void Get()
             { }
+
+            [HttpGet]
+            public void GetStatusOnLineOfflineUser() { }
+
+            [HttpGet]
+            public void GetStatusOnLineOfflineUserOnVipCustomer(int param) { }
+
+            [HttpGet]
+            public void StatusLineOfflineUserOn() { }
 
             [HttpGet]
             public void IsBaseUpgraded(int key, CancellationToken cancellation)


### PR DESCRIPTION
issue #568

Describe the bug
when function/action name contains keyword "On", the operation convention can't correct parse the action name. 
/odata/SEChat/SE.GetStatusOnLineOfflineUser => error
/odata/SEChat/SE.StatusLineOfflineUserOn => error

What is in the PR:
1) Search the operation using the whole action name first, if found, use it.
2) Split the action name, and search again.