### PR TITLE
Support FromBody parameters with actions and functions

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
             IODataSerializer serializer = GetSerializer(type, value, request, serializerProvider);
 
             ODataPath path = request.ODataFeature().Path;
-            IEdmNavigationSource targetNavigationSource = GetTargetNavigationSource(path, model);
+            IEdmNavigationSource targetNavigationSource = path.GetNavigationSource();
             HttpResponse response = request.HttpContext.Response;
 
             // serialize a response
@@ -194,30 +194,6 @@ namespace Microsoft.AspNetCore.OData.Formatter
             }
 
             return serializer;
-        }
-
-        private static IEdmNavigationSource GetTargetNavigationSource(ODataPath path, IEdmModel model)
-        {
-            if (path == null)
-            {
-                return null;
-            }
-
-            Contract.Assert(model != null);
-
-            OperationSegment operationSegment = path.LastSegment as OperationSegment;
-            if (operationSegment != null)
-            {
-                // OData model builder uses an annotation to save the function returned entity set.
-                // TODO: we need to refactor it later.
-                ReturnedEntitySetAnnotation entitySetAnnotation = model.GetAnnotationValue<ReturnedEntitySetAnnotation>(operationSegment.Operations.Single());
-                if (entitySetAnnotation != null)
-                {
-                    return model.EntityContainer.FindEntitySet(entitySetAnnotation.EntitySetName);
-                }
-            }
-
-            return path.GetNavigationSource();
         }
 
         private static string GetRootElementName(ODataPath path)

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/ActionSegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/ActionSegmentTemplate.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Routing.Template
@@ -104,7 +105,15 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 throw Error.ArgumentNull(nameof(context));
             }
 
-            context.Segments.Add(Segment);
+            if (NavigationSource != null)
+            {
+                context.Segments.Add(Segment);
+                return true;
+            }
+
+            IEdmNavigationSource navigationSource = SegmentTemplateHelpers.GetNavigationSourceFromEdmOperation(context.Model, Action);
+            OperationSegment actionSegment = new OperationSegment(Action, navigationSource as IEdmEntitySetBase);
+            context.Segments.Add(actionSegment);
             return true;
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/FunctionSegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/FunctionSegmentTemplate.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Routing.Template
@@ -144,10 +145,16 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 throw Error.ArgumentNull(nameof(context));
             }
 
+            IEdmNavigationSource navigationSource = NavigationSource;
+            if (navigationSource == null)
+            {
+                navigationSource = SegmentTemplateHelpers.GetNavigationSourceFromEdmOperation(context.Model, Function);
+            }
+
             // If the function has no parameter, we don't need to do anything and just return an operation segment.
             if (ParameterMappings.Count == 0)
             {
-                context.Segments.Add(new OperationSegment(Function, NavigationSource as IEdmEntitySetBase));
+                context.Segments.Add(new OperationSegment(Function, navigationSource as IEdmEntitySetBase));
                 return true;
             }
 
@@ -172,7 +179,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 return false;
             }
 
-            context.Segments.Add(new OperationSegment(Function, parameters, NavigationSource as IEdmEntitySetBase));
+            context.Segments.Add(new OperationSegment(Function, parameters, navigationSource as IEdmEntitySetBase));
             return true;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Routing.Template
@@ -172,6 +173,26 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
 
             // 3) now the parsedKeyValues (p1, p3) is not equal to actualParameters (p1, p2, p3)
             return parameterMappings.Count == parsedKeyValues.Count;
+        }
+
+        /// <summary>
+        /// Gets the navigation source from an Edm operation.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="operation">The Edm operation.</param>
+        /// <returns>
+        /// The navigation source or null if the annotation indicating the mapping from an Edm operation to an entity set is not found.
+        /// </returns>
+        internal static IEdmNavigationSource GetNavigationSourceFromEdmOperation(IEdmModel model, IEdmOperation operation)
+        {
+            ReturnedEntitySetAnnotation entitySetAnnotation = model?.GetAnnotationValue<ReturnedEntitySetAnnotation>(operation);
+
+            if (entitySetAnnotation != null)
+            {
+                return model.EntityContainer.FindEntitySet(entitySetAnnotation.EntitySetName);
+            }
+
+            return null;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ComplexTypeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ComplexTypeTests.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Formatter.MediaType;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.OData.Tests.Formatter.Models;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
+using Microsoft.OData.UriParser;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
@@ -26,6 +28,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             string routeName = "OData";
             IEdmModel model = GetSampleModel();
             var request = RequestFactory.Create("Get", "http://localhost/property", opt => opt.AddRouteComponents(routeName, model));
+            var addressComplexType = model.SchemaElements.OfType<IEdmComplexType>().Single(d => d.Name.Equals("Address"));
+            request.ODataFeature().Path = new ODataPath(new ValueSegment(addressComplexType));
             request.ODataFeature().Model = model;
             request.ODataFeature().RoutePrefix = routeName;
 


### PR DESCRIPTION
Fixes #571 

The target navigation source is unresolved at the time of initializing an `ActionSegmentTemplate` and a `FunctionSegmentTemplate`. For that reason, the `NavigationSource` property of the `ODataSegmentTemplate` is initialized to `null`. Subsequently when we create an `OperationSegment` from the `TryTranslate` method of either of the two templates, the `EdmType` and `EntitySet` properties of the segment are initialized to null. This is the reason for the error exhibited in the [reported issue](https://github.com/OData/AspNetCoreOData/issues/571).

We fix the issue in this PR by using the entity set annotation to get the target navigation source. This annotation is set when `ReturnsFromEntitySet` method (and similar variants) are called when using the model builder to initialize the Edm model.
By fixing this we dealt with a technical debt in the form of a comment left in [`ODataOutputFormatterHelper`](https://github.com/OData/AspNetCoreOData/blob/eea3a95a4831432d08fcdd5beaea0ec791d642ce/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs#L211)