### PR TITLE
Get value of property with data member consideration

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -9,7 +9,6 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.Serialization;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Query.Container;

--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -281,11 +281,8 @@ namespace Microsoft.AspNetCore.OData.Query
 
         public static LambdaExpression GetPropertyAccessLambda(Type type, string propertyName)
         {
-            var dataMemberProps = type.GetProperties().Where(p => Attribute.IsDefined(p, typeof(DataMemberAttribute)));
-            var actualPropName = dataMemberProps
-                                    .SingleOrDefault(p => ((DataMemberAttribute)Attribute.GetCustomAttribute(p, typeof(DataMemberAttribute))).Name?.ToLower() == propertyName.ToLower())?.Name ?? propertyName;
             ParameterExpression odataItParameter = Expression.Parameter(type, "$it");
-            MemberExpression propertyAccess = Expression.Property(odataItParameter, actualPropName);
+            MemberExpression propertyAccess = Expression.Property(odataItParameter, propertyName);
             return Expression.Lambda(propertyAccess, odataItParameter);
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Query.Container;
@@ -280,8 +281,11 @@ namespace Microsoft.AspNetCore.OData.Query
 
         public static LambdaExpression GetPropertyAccessLambda(Type type, string propertyName)
         {
+            var dataMemberProps = type.GetProperties().Where(p => Attribute.IsDefined(p, typeof(DataMemberAttribute)));
+            var actualPropName = dataMemberProps
+                                    .SingleOrDefault(p => ((DataMemberAttribute)Attribute.GetCustomAttribute(p, typeof(DataMemberAttribute))).Name?.ToLower() == propertyName.ToLower())?.Name ?? propertyName;
             ParameterExpression odataItParameter = Expression.Parameter(type, "$it");
-            MemberExpression propertyAccess = Expression.Property(odataItParameter, propertyName);
+            MemberExpression propertyAccess = Expression.Property(odataItParameter, actualPropName);
             return Expression.Lambda(propertyAccess, odataItParameter);
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -1205,7 +1205,8 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                         bool alreadyOrdered = false;
                         foreach (var prop in properties)
                         {
-                            source = ExpressionHelpers.OrderByPropertyExpression(source, prop.Name, elementType,
+                            string propertyName = context.Model.GetClrPropertyName(prop);
+                            source = ExpressionHelpers.OrderByPropertyExpression(source, propertyName, elementType,
                                 alreadyOrdered);
                             if (!alreadyOrdered)
                             {

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -1208,6 +1208,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                             string propertyName = context.Model.GetClrPropertyName(prop);
                             source = ExpressionHelpers.OrderByPropertyExpression(source, propertyName, elementType,
                                 alreadyOrdered);
+
                             if (!alreadyOrdered)
                             {
                                 alreadyOrdered = true;

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -142,6 +142,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
 
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: null, expand: expand, context: context);
 
+            _settings.PageSize = 2;
+
             QueryBinderContext queryBinderContext = new QueryBinderContext(_model, _settings, selectExpand.Context.ElementClrType)
             {
                 NavigationSource = context.NavigationSource
@@ -170,12 +172,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             if (expand.EndsWith("desc)"))
             {
                 Assert.Equal("Tag 4", firstTag.Instance.Name);
-                Assert.Equal("Tag 1", lastTag.Instance.Name);
+                Assert.Equal("Tag 3", lastTag.Instance.Name);
             }
             else
             {
                 Assert.Equal("Tag 1", firstTag.Instance.Name);
-                Assert.Equal("Tag 4", lastTag.Instance.Name);
+                Assert.Equal("Tag 2", lastTag.Instance.Name);
             }
         }
 


### PR DESCRIPTION
### Issues
When DataMember is applied in an entity, the `entityType.Key()` returns a DataMember name and the `MemberExpression propertyAccess = Expression.Property(odataItParameter, propertyName);` was crashed because the DataMember name couldn't be found in the actual object.

For more details, I setup `pageSize=100` in my ODataConfig, and  I applied DataMember on the key of an entity
```
        [DataMember(Name = "Id")]
        [Key]
        public string Name { get; set; }
```
When I do the `$expand` on a collection of the entity, the function `entityType.Key()` in the [SelectExpandBinder.cs](https://github.com/OData/AspNetCoreOData/blob/f675f6c6abe2cd10bfa00ce8c4f7dc83b49e1293/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs#L1194) returns my DataMember name `id`, then it could not be found at the line ` Expression.Property(odataItParameter, propertyName)` because it's not actual a property name of the object.

Relate issue: [#2443](https://github.com/OData/WebApi/issues/2443)

### Description

The change is to find the actual property name from the DataMemeber name if the data member name is existing. Otherwise, use the property name from the input.