### PR TITLE
add omit-values supports

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Formatter.Deserialization;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.Extensions.DependencyInjection;
@@ -69,6 +70,44 @@ namespace Microsoft.AspNetCore.OData.Extensions
             }
 
             return request.HttpContext.ODataOptions();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="OmitValuesKind"/> from the request.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/> instance to access.</param>
+        /// <returns>The <see cref="OmitValuesKind"/> from the request.</returns>
+        public static OmitValuesKind GetOmitValuesKind(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull(nameof(request));
+            }
+
+            // The 'Prefer' header from client has the top priority
+            string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(request.Headers);
+            if (preferHeader != null)
+            {
+                // simply use the string comparision case-insensitive
+                if (preferHeader.Contains("omit-values=nulls", StringComparison.OrdinalIgnoreCase))
+                {
+                    return OmitValuesKind.Nulls;
+                }
+
+                if (preferHeader.Contains("omit-values=defaults", StringComparison.OrdinalIgnoreCase))
+                {
+                    return OmitValuesKind.Defaults;
+                }
+            }
+
+            // If there's no setting from client, we move to use the configuration on the OData options.
+            ODataOptions options = request.ODataOptions();
+            if (options == null)
+            {
+                return OmitValuesKind.Unknown;
+            }
+
+            return options.OmitValuesKind;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -209,6 +209,9 @@ namespace Microsoft.AspNetCore.OData.Formatter
 
             // Add version header.
             response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(request.GetODataVersion());
+
+            // Set the prefer-applied header on response
+            ResponsePreferenceHelpers.SetResponsePreferAppliedHeader(response);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -24,7 +23,6 @@ using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
-using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Formatter
@@ -142,6 +140,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 writeContext.MetadataLevel = metadataLevel;
                 writeContext.QueryOptions = queryOptions;
                 writeContext.SetComputedProperties(queryOptions?.Compute?.ComputeClause);
+                writeContext.OmitValuesKind = request.GetOmitValuesKind();
 
                 //Set the SelectExpandClause on the context if it was explicitly specified.
                 if (selectExpandDifferentFromQueryOptions != null)

--- a/src/Microsoft.AspNetCore.OData/Formatter/OmitValuesKind.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/OmitValuesKind.cs
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------------
+// <copyright file="OmitValuesKind.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.AspNetCore.OData.Formatter
+{
+    /// <summary>
+    /// Omit-Values kind
+    /// </summary>
+    public enum OmitValuesKind
+    {
+        /// <summary>
+        /// Not set, unknown
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// If nulls is specified, then the service MAY omit properties containing null values from the response,
+        /// in which case it MUST specify the Preference-Applied response header with omit-values=nulls.
+        /// </summary>
+        Nulls,
+
+        /// <summary>
+        /// If defaults is specified, then the service MAY omit properties containing default values from the response, including nulls for properties that have no other defined default value.
+        /// Nulls MUST be included for properties that have a non-null default value defined.
+        /// If the service omits default values it MUST specify the Preference-Applied response header with omit-values=defaults.
+        /// </summary>
+        Defaults
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/ResponsePreferenceHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ResponsePreferenceHelpers.cs
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ResponsePreferenceHelpers.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.OData.Formatter
+{
+    internal static class ResponsePreferenceHelpers
+    {
+        public const string PreferAppliedHeaderName = "Preference-Applied";
+
+        public static void SetResponsePreferAppliedHeader(HttpResponse response)
+        {
+            if (response == null)
+            {
+                throw Error.ArgumentNull(nameof(response));
+            }
+
+            HttpRequest request = response.HttpContext.Request;
+
+            OmitValuesKind omitValuesKind = request.GetOmitValuesKind();
+            if (omitValuesKind == OmitValuesKind.Unknown)
+            {
+                return;
+            }
+
+            string prefer_applied = null;
+            if (response.Headers.TryGetValue(PreferAppliedHeaderName, out StringValues values))
+            {
+                // If there are many "Preference-Applied" headers, pick up the first one.
+                prefer_applied = values.FirstOrDefault();
+            }
+
+            string omitValuesHead = omitValuesKind == OmitValuesKind.Nulls ?
+                "omit-values=nulls" :
+                "omit-values=defaults";
+
+            if (prefer_applied == null)
+            {
+                response.Headers[PreferAppliedHeaderName] = omitValuesHead;
+            }
+            else
+            {
+                response.Headers[PreferAppliedHeaderName] = $"{prefer_applied},{omitValuesHead}";
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
@@ -78,6 +78,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             Items = context.Items;
             ExpandReference = context.ExpandReference;
             TimeZone = context.TimeZone;
+            OmitValuesKind = context.OmitValuesKind;
 
             QueryContext = queryContext;
 
@@ -179,6 +180,11 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         /// Gets or sets the <see cref="TimeZoneInfo"/>.
         /// </summary>
         public TimeZoneInfo TimeZone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="OmitValuesKind"/>.
+        /// </summary>
+        public OmitValuesKind OmitValuesKind { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="ODataQueryOptions"/>.

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1094,6 +1094,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -2894,6 +2908,13 @@
             <param name="request">The <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/> instance to extend.</param>
             <returns>The <see cref="M:Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.ODataOptions(Microsoft.AspNetCore.Http.HttpRequest)"/> instance from the DI container.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetOmitValuesKind(Microsoft.AspNetCore.Http.HttpRequest)">
+            <summary>
+            Returns the <see cref="T:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind"/> from the request.
+            </summary>
+            <param name="request">The <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/> instance to access.</param>
+            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind"/> from the request.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetModel(Microsoft.AspNetCore.Http.HttpRequest)">
             <summary>
             Gets the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> from the request container.
@@ -4076,6 +4097,29 @@
             Gets the OData action of this parameters.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind">
+            <summary>
+            Omit-Values kind
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Unknown">
+            <summary>
+            Not set, unknown
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Nulls">
+            <summary>
+            If nulls is specified, then the service MAY omit properties containing null values from the response,
+            in which case it MUST specify the Preference-Applied response header with omit-values=nulls.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Defaults">
+            <summary>
+            If defaults is specified, then the service MAY omit properties containing default values from the response, including nulls for properties that have no other defined default value.
+            Nulls MUST be included for properties that have a non-null default value defined.
+            If the service omits default values it MUST specify the Preference-Applied response header with omit-values=defaults.
+            </summary>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.ResourceContext">
             <summary>
              Contains context information about the resource currently being serialized.
@@ -4606,6 +4650,27 @@
             Write the navigation link for the select navigation properties.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateDynamicComplexNestedResourceInfo(System.String,System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.ResourceContext)">
+            <summary>
+            Creates the <see cref="T:Microsoft.OData.ODataNestedResourceInfo"/> to be written while writing this dynamic complex property.
+            </summary>
+            <param name="propertyName">The dynamic property name.</param>
+            <param name="propertyValue">The dynamic property value.</param>
+            <param name="edmType">The edm type reference.</param>
+            <param name="resourceContext">The context for the complex instance being written.</param>
+            <returns>The nested resource info to be written. Returns 'null' will omit this serialization.</returns>
+            <remarks>It enables customer to get more controll by overriding this method. </remarks>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateComplexNestedResourceInfo(Microsoft.OData.Edm.IEdmStructuralProperty,Microsoft.OData.UriParser.PathSelectItem,Microsoft.AspNetCore.OData.Formatter.ResourceContext)">
+            <summary>
+            Creates the <see cref="T:Microsoft.OData.ODataNestedResourceInfo"/> to be written while writing this complex property.
+            </summary>
+            <param name="complexProperty">The complex property for which the nested resource info is being created.</param>
+            <param name="pathSelectItem">The corresponding sub select item belongs to this complex property.</param>
+            <param name="resourceContext">The context for the complex instance being written.</param>
+            <returns>The nested resource info to be written. Returns 'null' will omit this complex serialization.</returns>
+            <remarks>It enables customer to get more controll by overriding this method. </remarks>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateNavigationLink(Microsoft.OData.Edm.IEdmNavigationProperty,Microsoft.AspNetCore.OData.Formatter.ResourceContext)">
             <summary>
             Creates the <see cref="T:Microsoft.OData.ODataNestedResourceInfo"/> to be written while writing this entity.
@@ -4800,6 +4865,11 @@
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.TimeZone">
             <summary>
             Gets or sets the <see cref="T:System.TimeZoneInfo"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.OmitValuesKind">
+            <summary>
+            Gets or sets the <see cref="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.OmitValuesKind"/>.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.QueryOptions">
@@ -6091,6 +6161,11 @@
         <member name="P:Microsoft.AspNetCore.OData.ODataOptions.TimeZone">
             <summary>
             Gets or sets a TimeZoneInfo for the <see cref="T:System.DateTime"/> serialization and deserialization.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataOptions.OmitValuesKind">
+            <summary>
+            Gets or sets a omit values kind for the property value serialization.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.ODataOptions.Conventions">
@@ -14367,22 +14442,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.AspNetCore.OData.Routing.Conventions;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +52,11 @@ namespace Microsoft.AspNetCore.OData
         /// Gets or sets a TimeZoneInfo for the <see cref="DateTime"/> serialization and deserialization.
         /// </summary>
         public TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
+
+        /// <summary>
+        /// Gets or sets a omit values kind for the property value serialization.
+        /// </summary>
+        public OmitValuesKind OmitValuesKind { get; set; } = OmitValuesKind.Unknown;
 
         /// <summary>
         /// Gets the routing conventions.

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -373,6 +373,10 @@ Microsoft.AspNetCore.OData.Formatter.ODataParameterValue.Value.get -> object
 Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters
 Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters.Action.get -> Microsoft.OData.Edm.IEdmAction
 Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters.ODataUntypedActionParameters(Microsoft.OData.Edm.IEdmAction action) -> void
+Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
+Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Defaults = 2 -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
+Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Nulls = 1 -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
+Microsoft.AspNetCore.OData.Formatter.OmitValuesKind.Unknown = 0 -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
 Microsoft.AspNetCore.OData.Formatter.ResourceContext
 Microsoft.AspNetCore.OData.Formatter.ResourceContext.DynamicComplexProperties.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.OData.Formatter.ResourceContext.DynamicComplexProperties.set -> void
@@ -460,6 +464,8 @@ Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Naviga
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.NavigationSource.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.ODataSerializerContext() -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.ODataSerializerContext(Microsoft.AspNetCore.OData.Formatter.ResourceContext resource, Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmProperty edmProperty) -> void
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.OmitValuesKind.get -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.OmitValuesKind.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Path.get -> Microsoft.OData.UriParser.ODataPath
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Path.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.QueryOptions.get -> Microsoft.AspNetCore.OData.Query.ODataQueryOptions
@@ -666,6 +672,8 @@ Microsoft.AspNetCore.OData.ODataOptions.Expand() -> Microsoft.AspNetCore.OData.O
 Microsoft.AspNetCore.OData.ODataOptions.Filter() -> Microsoft.AspNetCore.OData.ODataOptions
 Microsoft.AspNetCore.OData.ODataOptions.GetRouteServices(string routePrefix) -> System.IServiceProvider
 Microsoft.AspNetCore.OData.ODataOptions.ODataOptions() -> void
+Microsoft.AspNetCore.OData.ODataOptions.OmitValuesKind.get -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
+Microsoft.AspNetCore.OData.ODataOptions.OmitValuesKind.set -> void
 Microsoft.AspNetCore.OData.ODataOptions.OrderBy() -> Microsoft.AspNetCore.OData.ODataOptions
 Microsoft.AspNetCore.OData.ODataOptions.QuerySettings.get -> Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings
 Microsoft.AspNetCore.OData.ODataOptions.RouteComponents.get -> System.Collections.Generic.IDictionary<string, (Microsoft.OData.Edm.IEdmModel EdmModel, System.IServiceProvider ServiceProvider)>
@@ -1610,6 +1618,7 @@ static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetETagHandle
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetModel(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.OData.Edm.IEdmModel
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetNextPageLink(this Microsoft.AspNetCore.Http.HttpRequest request, int pageSize, object instance, System.Func<object, string> objectToSkipTokenValue) -> System.Uri
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetODataVersion(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.OData.ODataVersion
+static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetOmitValuesKind(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.AspNetCore.OData.Formatter.OmitValuesKind
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetReaderSettings(this Microsoft.AspNetCore.Http.HttpRequest request) -> Microsoft.OData.ODataMessageReaderSettings
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetRouteServices(this Microsoft.AspNetCore.Http.HttpRequest request) -> System.IServiceProvider
 static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.GetTimeZoneInfo(this Microsoft.AspNetCore.Http.HttpRequest request) -> System.TimeZoneInfo
@@ -1736,7 +1745,9 @@ virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEdmTypeSerialize
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.CreateODataEnumValue(object graph, Microsoft.OData.Edm.IEdmEnumTypeReference enumType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> Microsoft.OData.ODataEnumValue
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataPrimitiveSerializer.CreateODataPrimitiveValue(object graph, Microsoft.OData.Edm.IEdmPrimitiveTypeReference primitiveType, Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext writeContext) -> Microsoft.OData.ODataPrimitiveValue
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.AppendDynamicProperties(Microsoft.OData.ODataResource resource, Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode selectExpandNode, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> void
+virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateComplexNestedResourceInfo(Microsoft.OData.Edm.IEdmStructuralProperty complexProperty, Microsoft.OData.UriParser.PathSelectItem pathSelectItem, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> Microsoft.OData.ODataNestedResourceInfo
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateComputedProperty(string propertyName, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> Microsoft.OData.ODataProperty
+virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateDynamicComplexNestedResourceInfo(string propertyName, object propertyValue, Microsoft.OData.Edm.IEdmTypeReference edmType, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> Microsoft.OData.ODataNestedResourceInfo
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateETag(Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> string
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateNavigationLink(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> Microsoft.OData.ODataNestedResourceInfo
 virtual Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateODataAction(Microsoft.OData.Edm.IEdmAction action, Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext) -> Microsoft.OData.ODataAction


### PR DESCRIPTION
OData specs has the following at: http://docs.oasis-open.org/odata/odata/v4.01/cs01/part1-protocol/odata-v4.01-cs01-part1-protocol.html#_Toc505771137
```txt
 8.2.8.6 [Preference omit-values](http://docs.oasis-open.org/odata/odata/v4.01/cs01/part1-protocol/odata-v4.01-cs01-part1-protocol.html#sec_Preferenceomitvalues)
The omit-values preference specifies values that MAY be omitted from a response payload. Valid values are nulls or defaults.

If nulls is specified, then the service MAY omit properties containing null values from the response, in which case it MUST specify the Preference-Applied response header with omit-values=nulls.

If defaults is specified, then the service MAY omit properties containing default values from the response, including nulls for properties that have no other defined default value. Nulls MUST be included for properties that have a non-null default value defined. If the service omits default values it MUST specify the Preference-Applied response header with omit-values=defaults.

Properties with null or default values MUST be included in delta payloads, if modified.

The response to a POST operation MUST include any properties not set to their default value, and the response to a PUT/PATCH operation MUST include any properties whose values were changed as part of the operation.

The omit-values preference does not affect a request payload. 
```

This PR is used to discuss the service side support for omit_values prefer header. 

