### PR TITLE
Remove ErrorCode validation

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Common/Error.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/Error.cs
@@ -229,13 +229,5 @@ namespace Microsoft.AspNetCore.OData
         {
             return new NotSupportedException(Error.Format(messageFormat, messageArgs));
         }
-
-        internal static void ValidateErrorCode(string expectedErrorCode, Microsoft.OData.ODataError error)
-        {
-            if (expectedErrorCode != error.ErrorCode)
-            {
-                throw Argument(error.ErrorCode, "Invalid error code");
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Results/BadRequestODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/BadRequestODataResult.cs
@@ -55,8 +55,6 @@ namespace Microsoft.AspNetCore.OData.Results
                 throw ErrorUtils.ArgumentNull(nameof(odataError));
             }
 
-            ErrorUtils.ValidateErrorCode(errorCode, odataError);
-
             Error = odataError;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/ConflictODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ConflictODataResult.cs
@@ -55,8 +55,6 @@ namespace Microsoft.AspNetCore.OData.Results
                 throw ErrorUtils.ArgumentNull(nameof(odataError));
             }
 
-            ErrorUtils.ValidateErrorCode(errorCode, odataError);
-
             Error = odataError;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/NotFoundODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/NotFoundODataResult.cs
@@ -55,8 +55,6 @@ namespace Microsoft.AspNetCore.OData.Results
                 throw ErrorUtils.ArgumentNull(nameof(odataError));
             }
 
-            ErrorUtils.ValidateErrorCode(errorCode, odataError);
-
             Error = odataError;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/UnauthorizedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/UnauthorizedODataResult.cs
@@ -55,8 +55,6 @@ namespace Microsoft.AspNetCore.OData.Results
                 throw ErrorUtils.ArgumentNull(nameof(odataError));
             }
 
-            ErrorUtils.ValidateErrorCode(errorCode, odataError);
-
             Error = odataError;
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/UnprocessableEntityODataResult .cs
+++ b/src/Microsoft.AspNetCore.OData/Results/UnprocessableEntityODataResult .cs
@@ -55,8 +55,6 @@ namespace Microsoft.AspNetCore.OData.Results
                 throw ErrorUtils.ArgumentNull(nameof(odataError));
             }
 
-            ErrorUtils.ValidateErrorCode(errorCode, odataError);
-
             Error = odataError;
         }
 


### PR DESCRIPTION
According to the [spec](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ErrorResponseBody),
the error code is service defined and MAY be different from the HttpCode. So the validation that we previously added is not valid.

*Spec*
```
The representation of an error response body is format-specific. It consists at least of the following information:

·code: required non-null, non-empty, language-independent string. Its value is a service-defined error code. This code serves as a sub-status for the HTTP error code specified in the response.

·message: required non-null, non-empty, language-dependent, human-readable string describing the error. The [Content-Language](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_HeaderContentLanguage) header MUST contain the language code from [[RFC5646]](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#rfc5646) corresponding to the language in which the value for message is written.

·target: optional nullable, potentially empty string indicating the target of the error, for example, the name of the property in error.

·details: optional, potentially empty collection of structured instances with code, message, and target following the rules above.

·innererror: optional structured instance with service-defined content.
```
A customer has raised this issue here https://github.com/OData/AspNetCoreOData/pull/623#discussion_r972463011