### PR TITLE
fixes issue 727 [JsonIgnore] attribute ignored when using $expand

### DIFF
--- a/src/Microsoft.AspNetCore.OData.NewtonsoftJson/JsonPropertyNameMapper.cs
+++ b/src/Microsoft.AspNetCore.OData.NewtonsoftJson/JsonPropertyNameMapper.cs
@@ -49,6 +49,13 @@ namespace Microsoft.AspNetCore.OData.NewtonsoftJson
 
             IEdmProperty property = _type.Properties().Single(s => s.Name == propertyName);
             PropertyInfo info = GetPropertyInfo(property);
+
+            JsonIgnoreAttribute jsonIgnore = GetJsonIgnore(info);
+            if (jsonIgnore != null)
+            {
+                return null;
+            }
+
             JsonPropertyAttribute jsonProperty = GetJsonProperty(info);
             if (jsonProperty != null && !string.IsNullOrWhiteSpace(jsonProperty.PropertyName))
             {
@@ -81,6 +88,12 @@ namespace Microsoft.AspNetCore.OData.NewtonsoftJson
         {
             return property.GetCustomAttributes(typeof(JsonPropertyAttribute), inherit: false)
                    .OfType<JsonPropertyAttribute>().SingleOrDefault();
+        }
+
+        private static JsonIgnoreAttribute GetJsonIgnore(PropertyInfo property)
+        {
+            return property.GetCustomAttributes(typeof(JsonIgnoreAttribute), inherit: false)
+                   .OfType<JsonIgnoreAttribute>().SingleOrDefault();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6822,7 +6822,7 @@
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.InvalidPropertyMapping">
             <summary>
-              Looks up a localized string similar to The key mapping for the property &apos;{0}&apos; can&apos;t be null or empty..
+              Looks up a localized string similar to The key mapping for the property &apos;{0}&apos; can&apos;t be empty..
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.InvalidSegmentInSelectExpandPath">
@@ -7792,6 +7792,9 @@
             properties in the <see cref="T:Microsoft.OData.Edm.IEdmStructuredType"/> that will be used during the serialization of the $select
             and $expand projection by a given formatter. For example, to support custom serialization attributes of a
             particular formatter.
+            
+            It also allows you to ignore a field (ensure that the returned <see cref="T:System.Collections.Generic.IDictionary`2"/>
+            does not have a key for that field), by mapping the property name to null.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper.MapProperty(System.String)">

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -880,7 +880,7 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The key mapping for the property &apos;{0}&apos; can&apos;t be null or empty..
+        ///   Looks up a localized string similar to The key mapping for the property &apos;{0}&apos; can&apos;t be empty..
         /// </summary>
         internal static string InvalidPropertyMapping {
             get {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -496,7 +496,7 @@
     <value>A binary operator with incompatible types was detected. Found operand types '{0}' and '{1}' for operator kind '{2}'.</value>
   </data>
   <data name="InvalidPropertyMapping" xml:space="preserve">
-    <value>The key mapping for the property '{0}' can't be null or empty.</value>
+    <value>The key mapping for the property '{0}' can't be empty.</value>
   </data>
   <data name="ODataFunctionNotSupported" xml:space="preserve">
     <value>Unknown function '{0}'.</value>

--- a/src/Microsoft.AspNetCore.OData/Query/Container/IPropertyMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/IPropertyMapper.cs
@@ -23,6 +23,9 @@ namespace Microsoft.AspNetCore.OData.Query.Container
     /// properties in the <see cref="IEdmStructuredType"/> that will be used during the serialization of the $select
     /// and $expand projection by a given formatter. For example, to support custom serialization attributes of a
     /// particular formatter.
+    /// 
+    /// It also allows you to ignore a field (ensure that the returned <see cref="IDictionary{TKey,TValue}"/>
+    /// does not have a key for that field), by mapping the property name to null.
     /// </summary>
     public interface IPropertyMapper
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Container/JsonPropertyNameMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/JsonPropertyNameMapper.cs
@@ -30,6 +30,13 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         {
             IEdmProperty property = _type.Properties().Single(s => s.Name == propertyName);
             PropertyInfo info = GetPropertyInfo(property);
+
+            JsonIgnoreAttribute jsonIgnore = GetJsonIgnore(info);
+            if (jsonIgnore != null)
+            {
+                return null;
+            }
+
             JsonPropertyNameAttribute jsonProperty = GetJsonProperty(info);
             if (jsonProperty != null && !String.IsNullOrWhiteSpace(jsonProperty.Name))
             {
@@ -62,6 +69,12 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         {
             return property.GetCustomAttributes(typeof(JsonPropertyNameAttribute), inherit: false)
                    .OfType<JsonPropertyNameAttribute>().SingleOrDefault();
+        }
+
+        private static JsonIgnoreAttribute GetJsonIgnore(PropertyInfo property)
+        {
+            return property.GetCustomAttributes(typeof(JsonIgnoreAttribute), inherit: false)
+                   .OfType<JsonIgnoreAttribute>().SingleOrDefault();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Container/NamedPropertyOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/NamedPropertyOfT.cs
@@ -27,12 +27,15 @@ namespace Microsoft.AspNetCore.OData.Query.Container
             if (Name != null && (includeAutoSelected || !AutoSelected))
             {
                 string mappedName = propertyMapper.MapProperty(Name);
-                if (String.IsNullOrEmpty(mappedName))
+                if (mappedName != null)
                 {
-                    throw Error.InvalidOperation(SRResources.InvalidPropertyMapping, Name);
-                }
+                    if (String.IsNullOrEmpty(mappedName))
+                    {
+                        throw Error.InvalidOperation(SRResources.InvalidPropertyMapping, Name);
+                    }
 
-                dictionary.Add(mappedName, GetValue());
+                    dictionary.Add(mappedName, GetValue());
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
@@ -144,12 +144,15 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
                     if (TryGetPropertyValue(property.Name, out propertyValue))
                     {
                         string mappingName = mapper.MapProperty(property.Name);
-                        if (String.IsNullOrWhiteSpace(mappingName))
+                        if (mappingName != null)
                         {
-                            throw Error.InvalidOperation(SRResources.InvalidPropertyMapping, property.Name);
-                        }
+                            if (String.IsNullOrWhiteSpace(mappingName))
+                            {
+                                throw Error.InvalidOperation(SRResources.InvalidPropertyMapping, property.Name);
+                            }
 
-                        dictionary[mappingName] = propertyValue;
+                            dictionary[mappingName] = propertyValue;
+                        }
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.OData.NewtonsoftJson.Tests/JsonPropertyNameMapperTest.cs
+++ b/test/Microsoft.AspNetCore.OData.NewtonsoftJson.Tests/JsonPropertyNameMapperTest.cs
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------------------------
+// <copyright file="JsonPropertyNameMapperTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using Microsoft.AspNetCore.OData.NewtonsoftJson;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Query.Container
+{
+    public class JsonPropertyNameMapperTests
+    {
+        [Fact]
+        public void MapProperty_Maps_PropertyName()
+        {
+            // Arrange
+            (IEdmModel model, IEdmStructuredType address) = GetOData();
+            JsonPropertyNameMapper mapper = new JsonPropertyNameMapper(model, address);
+
+            // Act & Assert
+            Assert.Equal("Road", mapper.MapProperty("Street"));
+
+            // Act & Assert
+            Assert.Equal("City", mapper.MapProperty("City"));
+
+            // Act & Assert
+            Assert.Null(mapper.MapProperty("IgnoreThis"));
+        }
+
+        private static (IEdmModel, IEdmStructuredType) GetOData()
+        {
+            EdmModel model = new EdmModel();
+            EdmComplexType address = new EdmComplexType("NS", "Address");
+            address.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+            address.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            address.AddStructuralProperty("IgnoreThis", EdmPrimitiveTypeKind.String);
+            model.AddElement(address);
+
+            model.SetAnnotationValue(address, new ClrTypeAnnotation(typeof(JAddress)));
+
+            model.SetAnnotationValue(address.FindProperty("Street"),
+                new ClrPropertyInfoAnnotation(typeof(JAddress).GetProperty("Street")));
+
+            model.SetAnnotationValue(address.FindProperty("IgnoreThis"),
+                new ClrPropertyInfoAnnotation(typeof(JAddress).GetProperty("IgnoreThis")));
+
+            return (model, address);
+        }
+
+        private class JAddress
+        {
+            public string City { get; set; }
+
+            [JsonProperty("Road")]
+            public string Street { get; set; }
+
+            [JsonIgnore]
+            public string IgnoreThis { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Container/JsonPropertyNameMapperTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Container/JsonPropertyNameMapperTest.cs
@@ -27,6 +27,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
 
             // Act & Assert
             Assert.Equal("City", mapper.MapProperty("City"));
+
+            // Act & Assert
+            Assert.Null(mapper.MapProperty("IgnoreThis"));
         }
 
         private static (IEdmModel, IEdmStructuredType) GetOData()
@@ -35,12 +38,16 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
             EdmComplexType address = new EdmComplexType("NS", "Address");
             address.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
             address.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            address.AddStructuralProperty("IgnoreThis", EdmPrimitiveTypeKind.String);
             model.AddElement(address);
 
             model.SetAnnotationValue(address, new ClrTypeAnnotation(typeof(JAddress)));
 
             model.SetAnnotationValue(address.FindProperty("Street"),
                 new ClrPropertyInfoAnnotation(typeof(JAddress).GetProperty("Street")));
+
+            model.SetAnnotationValue(address.FindProperty("IgnoreThis"),
+                new ClrPropertyInfoAnnotation(typeof(JAddress).GetProperty("IgnoreThis")));
 
             return (model, address);
         }
@@ -51,6 +58,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
 
             [JsonPropertyName("Road")]
             public string Street { get; set; }
+
+            [JsonIgnore]
+            public string IgnoreThis { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Container/PropertyContainerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Container/PropertyContainerTest.cs
@@ -203,7 +203,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
             IList<NamedPropertyExpression> properties = new NamedPropertyExpression[]
             {
                 new NamedPropertyExpression(name: Expression.Constant("PropA"), value: Expression.Constant(3)),
-                new NamedPropertyExpression(name: Expression.Constant("PropB"), value: Expression.Constant(6))
+                new NamedPropertyExpression(name: Expression.Constant("PropB"), value: Expression.Constant(6)),
+                new NamedPropertyExpression(name: Expression.Constant("PropC"), value: Expression.Constant(9))
             };
             Expression containerExpression = PropertyContainer.CreatePropertyContainer(properties);
             PropertyContainer container = ToContainer(containerExpression);
@@ -211,6 +212,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
             Mock<IPropertyMapper> mapperMock = new Mock<IPropertyMapper>();
             mapperMock.Setup(m => m.MapProperty("PropA")).Returns("PropertyA");
             mapperMock.Setup(m => m.MapProperty("PropB")).Returns("PropB");
+            mapperMock.Setup(m => m.MapProperty("PropC")).Returns((string)null);
 
             //Act
             IDictionary<string, object> result = container.ToDictionary(mapperMock.Object);
@@ -219,12 +221,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
             Assert.NotNull(result);
             Assert.True(result.ContainsKey("PropertyA"));
             Assert.True(result.ContainsKey("PropB"));
+            Assert.False(result.ContainsKey("PropC"));
         }
 
         [Theory]
-        [InlineData(null)]
         [InlineData("")]
-        public void ToDictionary_Throws_IfMappingFunctionReturns_NullOrEmpty(string mappedName)
+        public void ToDictionary_Throws_IfMappingFunctionReturns_Empty(string mappedName)
         {
             // Arrange
             IList<NamedPropertyExpression> properties = new NamedPropertyExpression[]
@@ -239,7 +241,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
 
             // Act & Assert
             ExceptionAssert.Throws<InvalidOperationException>(() =>
-                container.ToDictionary(mapperMock.Object), "The key mapping for the property 'PropA' can't be null or empty.");
+                container.ToDictionary(mapperMock.Object), "The key mapping for the property 'PropA' can't be empty.");
         }
 
         private static PropertyContainer ToContainer(Expression containerCreationExpression)


### PR DESCRIPTION
Fixes https://github.com/OData/AspNetCoreOData/issues/727

**Cause of the bug**

I found that when using $expand, the MapProperty methods of the default implementations for IPropertyMapper (for System.Text.Json and Newtonsoft.Json) contain code to interpret attributes applied to fields in the view model on their own. That is, they do not rely on the standard libraries to serialise the object, apply attributes, etc. 

Also, the only attribute they support is the property to rename a field - JsonProperty for Newtonsoft.Json, JsonPropertyName for System.Text.Json. Every other attribute would be ignored, including JsonIgnore. This explains why the bug is happening.

**Solution in this pull request**

1. Updated the MapProperty methods, so they check whether the field has the JsonIgnore attribute, and if so, return null (to indicate to ignore the field).
2. Updated the ToDictionary.... methods calling MapProperty so they no longer throw when MapProperty returns null. Instead, they simply do not add the field to the dictionairy. Also updated comments and error messages to reflect this change in the contract of the MapProperty method.
3. Updated affected unit tests, making sure that the new contract for MapProperty etc. is tested properly. Added unit tests for Newtonsoft Json version of MapProperty.
