### PR TITLE
Updated .NET Foundation Code of Conduct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Any contributions, feature requests, bugs and issues are welcome.
 
 ### Code of Conduct
 
-This project has adopted the [.NET Foundation Contributor Covenant Code of Conduct](https://dotnetfoundation.org/about/code-of-conduct). For more information see the [Code of Conduct FAQ](https://dotnetfoundation.org/about/faq).
+This project has adopted the [.NET Foundation Contributor Covenant Code of Conduct](https://dotnetfoundation.org/about/policies/code-of-conduct). For more information see the [Code of Conduct FAQ](https://dotnetfoundation.org/about/faq).
 
 ### .NET Foundation
 


### PR DESCRIPTION
Updated out-of-date .NET Foundation Code of Conduct Link

### Description 
We have modified the .NET Foundation Contributor Covenant Code of Conduct link under the project's root readme.md folder to point to the Foundation's new link here: https://dotnetfoundation.org/about/policies/code-of-conduct .

### Issues
This pull request fixes https://github.com/OData/AspNetCoreOData/issues/745
Updated the old link to be : https://dotnetfoundation.org/about/policies/code-of-conduct

### Additional Work Details

This is an update to the readme.md and shall not effect any assemblies or libraries. 