### PR TITLE
Enable the nested delta collection deep update

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
@@ -351,8 +351,8 @@ namespace Microsoft.AspNetCore.OData.Deltas
                 if (deltaNestedResource is IDeltaSet)
                 {
                     // TODO: That's the bulk insert OData Path handler feature,
-                    // Let's figure out it later.
-                    // So far, for the DeltaSet, let's skip it now.
+                    // See the comments in https://github.com/OData/AspNetCoreOData/issues/748
+                    // So far, Let's skip DeltaSet and figure it out later.
                     continue;
                 }
 

--- a/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.OData.Deltas
                 }
             }
 
-            if (value is IDelta)
+            if (value is IDelta || value is IDeltaSet)
             {
                 return TrySetNestedResourceInternal(name, value);
             }
@@ -225,6 +225,14 @@ namespace Microsoft.AspNetCore.OData.Deltas
             object deltaNestedResource = _deltaNestedResources[name];
 
             Contract.Assert(deltaNestedResource != null, "deltaNestedResource != null");
+
+            //If DeltaSet collection, we are handling delta collections so the value will be that itself and no need to get instance value
+            if (deltaNestedResource is IDeltaSet)
+            {
+                value = deltaNestedResource;
+                return true;
+            }
+
             Contract.Assert(DeltaHelper.IsDeltaOfT(deltaNestedResource.GetType()));
 
             value = deltaNestedResource;
@@ -339,6 +347,15 @@ namespace Microsoft.AspNetCore.OData.Deltas
             {
                 // Patch for each nested resource changed under this T.
                 dynamic deltaNestedResource = _deltaNestedResources[nestedResourceName];
+
+                if (deltaNestedResource is IDeltaSet)
+                {
+                    // TODO: That's the bulk insert OData Path handler feature,
+                    // Let's figure out it later.
+                    // So far, for the DeltaSet, let's skip it now.
+                    continue;
+                }
+
                 dynamic originalNestedResource = null;
                 if (!TryGetPropertyRef(original, nestedResourceName, out originalNestedResource))
                 {
@@ -705,11 +722,14 @@ namespace Microsoft.AspNetCore.OData.Deltas
                 return false;
             }
 
-            PropertyAccessor<T> cacheHit = _allProperties[name];
-            // Get the Delta<{NestedResourceType}>._instance using Reflection.
-            FieldInfo field = deltaNestedResource.GetType().GetField("_instance", BindingFlags.NonPublic | BindingFlags.Instance);
-            Contract.Assert(field != null, "field != null");
-            cacheHit.SetValue(_instance, field.GetValue(deltaNestedResource));
+            if (!(deltaNestedResource is IDeltaSet))
+            {
+                PropertyAccessor<T> cacheHit = _allProperties[name];
+                // Get the Delta<{NestedResourceType}>._instance using Reflection.
+                FieldInfo field = deltaNestedResource.GetType().GetField("_instance", BindingFlags.NonPublic | BindingFlags.Instance);
+                Contract.Assert(field != null, "field != null");
+                cacheHit.SetValue(_instance, field.GetValue(deltaNestedResource));
+            }
 
             // Add the nested resource in the hierarchy.
             // Note: We shouldn't add the structural properties to the <code>_changedProperties</code>, which

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         /// <param name="model">The Edm model.</param>
         /// <param name="structuredType">The given structured type.</param>
         /// <returns>All property names.</returns>
-        public static IList<string> GetAllProperties(this IEdmModel model, IEdmStructuredType structuredType)
+        public static ICollection<string> GetAllProperties(this IEdmModel model, IEdmStructuredType structuredType)
         {
             if (model == null)
             {

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
@@ -19,6 +19,38 @@ namespace Microsoft.AspNetCore.OData.Edm
     internal static class EdmModelExtensions
     {
         /// <summary>
+        /// Get all property names for the given structured type.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="structuredType">The given structured type.</param>
+        /// <returns>All property names.</returns>
+        public static IList<string> GetAllProperties(this IEdmModel model, IEdmStructuredType structuredType)
+        {
+            if (model == null)
+            {
+                throw Error.ArgumentNull(nameof(model));
+            }
+
+            if (structuredType == null)
+            {
+                throw Error.ArgumentNull(nameof(structuredType));
+            }
+
+            IList<string> allProperties = new List<string>();
+            foreach (var property in structuredType.StructuralProperties())
+            {
+                allProperties.Add(model.GetClrPropertyName(property));
+            }
+
+            foreach (var property in structuredType.NavigationProperties())
+            {
+                allProperties.Add(model.GetClrPropertyName(property));
+            }
+
+            return allProperties;
+        }
+
+        /// <summary>
         /// Resolve the alternate key properties.
         /// </summary>
         /// <param name="model">The Edm model.</param>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -116,8 +116,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             if (value != null)
             {
                 // If the setting value is a delta set, we don't need to create a new collection, just use it.
-                IDeltaSet set = value as IDeltaSet;
-                if (set != null)
+                if (value is IDeltaSet set)
                 {
                     SetProperty(resource, propertyName, set);
                     return;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/DeserializationHelper.cs
@@ -115,6 +115,14 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
         {
             if (value != null)
             {
+                // If the setting value is a delta set, we don't need to create a new collection, just use it.
+                IDeltaSet set = value as IDeltaSet;
+                if (set != null)
+                {
+                    SetProperty(resource, propertyName, set);
+                    return;
+                }
+
                 IEnumerable collection = value as IEnumerable;
                 Contract.Assert(collection != null,
                     "SetCollectionProperty is always passed the result of ODataFeedDeserializer or ODataCollectionDeserializer");

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -263,20 +263,19 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 
                 if (readContext.IsDeltaOfT || readContext.IsDeltaDeleted)
                 {
-                    IEnumerable<string> structuralProperties = structuredType.StructuralProperties()
-                        .Select(edmProperty => model.GetClrPropertyName(edmProperty));
+                    IEnumerable<string> updatablePoperties = model.GetAllProperties(structuredType.StructuredDefinition());
 
                     if (structuredType.IsOpen())
                     {
                         PropertyInfo dynamicDictionaryPropertyInfo = model.GetDynamicPropertyDictionary(
                             structuredType.StructuredDefinition());
 
-                        return Activator.CreateInstance(readContext.ResourceType, clrType, structuralProperties,
+                        return Activator.CreateInstance(readContext.ResourceType, clrType, updatablePoperties,
                             dynamicDictionaryPropertyInfo);
                     }
                     else
                     {
-                        return Activator.CreateInstance(readContext.ResourceType, clrType, structuralProperties);
+                        return Activator.CreateInstance(readContext.ResourceType, clrType, updatablePoperties);
                     }
                 }
                 else

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2221,6 +2221,14 @@
             <param name="entityType">The Edm entity type.</param>
             <returns>Alternate Keys of this type.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.GetAllProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType)">
+            <summary>
+            Get all property names for the given structured type.
+            </summary>
+            <param name="model">The Edm model.</param>
+            <param name="structuredType">The given structured type.</param>
+            <returns>All property names.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.ResolveAlternateKeyProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.KeySegment)">
             <summary>
             Resolve the alternate key properties.

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceDeserializerTests.cs
@@ -715,7 +715,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Deserialization
                 Model = _readContext.Model,
                 ResourceType = typeof(Delta<Product>)
             };
-            var structuralProperties = _productEdmType.StructuralProperties().Select(p => p.Name);
+            var structuralProperties = _readContext.Model.GetAllProperties(_productEdmType.StructuredDefinition());
 
             // Act
             Delta<Product> resource = deserializer.CreateResourceInstance(_productEdmType, readContext) as Delta<Product>;


### PR DESCRIPTION
Issue #743 

Enable the deep update for the nested delta collection.

Request Header:
```txt 
Content-Type: application/json
OData-Version: 4.01
OData-MaxVersion: 4.01
```

Patch to single entity with nested delta collection:

```json
{
	"name":"anothertest",
	"@id": "Order(2)",
	"items@delta":[
	  {
		"@id": "OrderItems(2, 1)",
		"price":0
	  },
	  {
	    "@removed":{
			"reason":"deleted"
			},
		"@id": "OrderItems(2, 2)"
		}
     ]
}
```

Patch to single entity with nested collection:
```json
{
	"name":"anothertest",
	"@id": "Order(2)",
	"items":[
	  {
		"price":0
	  },
	  {
	    "price":1
      }
  ]
}
```