### PR TITLE
Correct operation routing conventions docs

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/ActionRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/ActionRoutingConvention.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
     /// <summary>
     /// The convention for <see cref="IEdmAction"/>.
     /// Post ~/entityset|singleton/action,  ~/entityset|singleton/cast/action
-    /// Post ~/entityset|singleton/key/action,  ~/entityset|singleton/key/cast/action
+    /// Post ~/entityset/key/action,  ~/entityset/key/cast/action
     /// </summary>
     public class ActionRoutingConvention : OperationRoutingConvention
     {

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/FunctionRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/FunctionRoutingConvention.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
     /// <summary>
     /// The convention for <see cref="IEdmFunction"/>.
     /// Get ~/entityset|singleton/function,  ~/entityset|singleton/cast/function
-    /// Get ~/entityset|singleton/key/function, ~/entityset|singleton/key/cast/function
+    /// Get ~/entityset/key/function, ~/entityset/key/cast/function
     /// </summary>
     public class FunctionRoutingConvention : OperationRoutingConvention
     {

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/OperationRoutingConvention.cs
@@ -20,9 +20,9 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
     /// <summary>
     /// Conventions for <see cref="IEdmAction"/> and <see cref="IEdmFunction"/>.
     /// Get ~/entityset|singleton/function,  ~/entityset|singleton/cast/function
-    /// Get ~/entityset|singleton/key/function, ~/entityset|singleton/key/cast/function
+    /// Get ~/entityset/key/function, ~/entityset/key/cast/function
     /// Post ~/entityset|singleton/action,  ~/entityset|singleton/cast/action
-    /// Post ~/entityset|singleton/key/action,  ~/entityset|singleton/key/cast/action
+    /// Post ~/entityset/key/action,  ~/entityset/key/cast/action
     /// </summary>
     public abstract class OperationRoutingConvention : IODataControllerActionConvention
     {


### PR DESCRIPTION
Correct operation routing conventions docs - key segment does not apply to singletons