### PR TITLE
Avoid generating wrapper for simple element types

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -943,10 +943,15 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
 
             propertyValue = CreatePropertyValueExpression(context, structuredType, structuralProperty, source, pathSelectItem.FilterOption, pathSelectItem.ComputeOption);
             Type propertyValueType = propertyValue.Type;
-            if (propertyValueType == typeof(char[]) || propertyValueType == typeof(byte[]))
+            if (TypeHelper.IsCollection(propertyValueType))
             {
-                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
-                return;
+                Type elementType = TypeHelper.GetInnerElementType(propertyValueType);
+
+                if (elementType.IsValueType || elementType == typeof(string))
+                {
+                    includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
+                    return;
+                }
             }
 
             Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);


### PR DESCRIPTION
Currently a wrapper is generated for any IEnumerable other than byte[] and char[]. This can be optimized by avoiding the wrapper for any IEnumerable with a value type or string type as element type.