### PR TITLE
fix #797 - Remove type-cast from SelfLinks.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/NavigationSourceLinkBuilderAnnotation.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/NavigationSourceLinkBuilderAnnotation.cs
@@ -60,12 +60,10 @@ namespace Microsoft.AspNetCore.OData.Edm
             }
 
             // Add navigation link builders for all navigation properties in derived types.
-            bool derivedTypesDefineNavigationProperty = false;
             foreach (IEdmEntityType derivedEntityType in derivedTypes)
             {
                 foreach (IEdmNavigationProperty navigationProperty in derivedEntityType.DeclaredNavigationProperties())
                 {
-                    derivedTypesDefineNavigationProperty = true;
                     Func<ResourceContext, IEdmNavigationProperty, Uri> navigationLinkFactory =
                     (resourceContext, navProperty) => resourceContext.GenerateNavigationPropertyLink(navProperty, includeCast: true);
                     AddNavigationPropertyLinkBuilder(navigationProperty, new NavigationLinkBuilder(navigationLinkFactory, followsConventions: true));
@@ -73,7 +71,7 @@ namespace Microsoft.AspNetCore.OData.Edm
             }
 
             Func<ResourceContext, Uri> selfLinkFactory =
-                (resourceContext) => resourceContext.GenerateSelfLink(includeCast: derivedTypesDefineNavigationProperty);
+                (resourceContext) => resourceContext.GenerateSelfLink(includeCast: false);
             IdLinkBuilder = new SelfLinkBuilder<Uri>(selfLinkFactory, followsConventions: true);
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesControllers.cs
@@ -47,6 +47,20 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
                     {
                         new Order { Id = 4, Amount = 170M }
                     }
+                },
+                new GoldCustomer {
+                    Id = 4,
+                    Name = "Customer 4",
+                    LoyaltyCardNo = "9876543211",
+                    Orders = new List<Order>
+                    {
+                        new Order { Id = 5, Amount = 2230M },
+                        new Order { Id = 6, Amount = 1150M }
+                    },
+                    BulkOrders = new List<Order>
+                    {
+                        new Order { Id = 7, Amount = 66832M }
+                    }
                 }
             };
         }
@@ -59,6 +73,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
 
         [EnableQuery]
         [HttpGet("odata/Customers/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.VipCustomer({key})")] // convention routing doesn't create this template.
+        [HttpGet("odata/Customers/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer({key})")] // convention routing doesn't create this template.
         public IActionResult Get(int key)
         {
             var customer = Customers.FirstOrDefault(c => c.Id == key);
@@ -83,6 +98,27 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
         public IActionResult GetVipCustomer([FromODataUri] int key)
         {
             var vipCustomer = Customers.OfType<VipCustomer>().SingleOrDefault(d => d.Id.Equals(key));
+
+            if (vipCustomer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(vipCustomer);
+        }
+
+        // Handles /entityset/cast path template
+        [EnableQuery]
+        public IActionResult GetFromGoldCustomer()
+        {
+            return Ok(Customers.OfType<GoldCustomer>());
+        }
+
+        // Handles /entityset/key/cast and /entityset/cast/key path templates
+        [EnableQuery]
+        public IActionResult GetGoldCustomer([FromODataUri] int key)
+        {
+            var vipCustomer = Customers.OfType<GoldCustomer>().SingleOrDefault(d => d.Id.Equals(key));
 
             if (vipCustomer == null)
             {

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesDataModel.cs
@@ -21,6 +21,11 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
         public string LoyaltyCardNo { get; set; }
     }
 
+    public class GoldCustomer : VipCustomer
+    {
+        public List<Order> BulkOrders { get; set; }
+    }
+
     public class Order
     {
         public int Id { get; set; }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesTests.cs
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
@@ -134,6 +135,38 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
             string expectedContent = "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
                 "\"Orders\":[{\"Id\":2,\"Amount\":230},{\"Id\":3,\"Amount\":150}]";
             Assert.Contains(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Theory]
+        [InlineData("Customers(4)")]
+        [InlineData("Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer")]
+        [InlineData("Customers/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer(4)")]
+        public async Task DerivedTypeNavPropertyLink_FullMetadata(string pathAndQuery)
+        {
+            // Arrange: Key preceeds name of the derived type
+            string requestUri = $"/odata/{pathAndQuery}";
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            string expectedContent = "{\"@odata.context\":\"http://localhost/odata/$metadata#Customers/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer/$entity\"," + 
+                "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer\"," + 
+                "\"@odata.id\":\"http://localhost/odata/Customers(4)\"," + 
+                "\"@odata.editLink\":\"Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer\"," + 
+                "\"Id\":4,\"Name\":\"Customer 4\",\"LoyaltyCardNo\":\"9876543211\"," + 
+                "\"Orders@odata.associationLink\":\"http://localhost/odata/Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer/Orders/$ref\"," + 
+                "\"Orders@odata.navigationLink\":\"http://localhost/odata/Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer/Orders\"," + 
+                "\"BulkOrders@odata.associationLink\":\"http://localhost/odata/Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer/BulkOrders/$ref\"," + 
+                "\"BulkOrders@odata.navigationLink\":\"http://localhost/odata/Customers(4)/Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes.GoldCustomer/BulkOrders\"}";
+            
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
         }
     }
 }


### PR DESCRIPTION
Fixes issue #797 
Type cast segment are no longer added to self links.
Test [DerivedTypeNavPropertyLink_FullMetadata](https://github.com/OData/AspNetCoreOData/pull/798/commits/4bc5326e8716ab116de2efcd27a99eaa9f26978b) shows the expected behavior.
According to http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752341 the cast segment (derived type name) is not to be part of the Canonical URL. odata.id is normally identical to the Canonical URL, but AspNetCoreOData adds the type cast segment to the selfLink and this seems wrong according to spec. 
Another place in the spec has a different conflicting example - http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752341 in this part it is described that the resource URL includes the cast segment. 
To me it seems wrong that the cast segment should be included in the odata.id - meaning I agree with the first link. 