### PR TITLE
Fix issue #796: Request path segments gets double unescaped

### DIFF
--- a/sample/ODataAlternateKeySample/Models/AlternateKeyRepositoryInMemory.cs
+++ b/sample/ODataAlternateKeySample/Models/AlternateKeyRepositoryInMemory.cs
@@ -17,11 +17,11 @@ namespace ODataAlternateKeySample.Models
         {
             // Customers
             var names = new[] { "Tom", "Jerry", "Mike", "Ben", "Sam", "Peter" };
-            _customers = Enumerable.Range(1, 5).Select(e => new Customer
+            _customers = Enumerable.Range(1, 5).Select((e, i) => new Customer
             {
                 Id = e,
                 Name = names[e - 1],
-                SSN = "SSN-" + e + "-" + (100 + e),
+                SSN = i % 2 == 0 ? "SSN-" + e + "-" + (100 + e) : "SSN-%25-" + e + "-" + (100 + e),
                 Titles = new string[] { "abc", null, "efg" }
             }).ToList();
 

--- a/src/Microsoft.AspNetCore.OData/Common/StringExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/StringExtensions.cs
@@ -12,6 +12,22 @@ namespace Microsoft.AspNetCore.OData.Common
     internal static class StringExtensions
     {
         /// <summary>
+        /// Unescape Uri string for %2F
+        /// See details at: https://github.com/dotnet/aspnetcore/issues/14170#issuecomment-533342396
+        /// </summary>
+        /// <param name="uriString">The Uri string.</param>
+        /// <returns>Unescaped back slash Uri string.</returns>
+        public static string UnescapeBackSlashUriString(this string uriString)
+        {
+            if (uriString == null)
+            {
+                return null;
+            }
+
+            return uriString.Replace("%2f", "%2F").Replace("%2F", "/");
+        }
+
+        /// <summary>
         /// Normalize the http method.
         /// </summary>
         /// <param name="method">The http method.</param>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1094,20 +1094,6 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.DateOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a DateOnly; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
-            <summary>
-            Determine if a type is a <see cref="T:System.TimeOnly"/>.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <returns>True if the type is a TimeOnly; false otherwise.</returns>
-        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -14629,6 +14615,22 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
+            <param name="segment">The value segment.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
+            <summary>
+            Gets the value segment.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
+            <inheritdoc />
+        </member>
+    </members>
+</doc>
+ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1047,6 +1047,14 @@
             <returns>a fast getter.</returns>
             <remarks>This method is more memory efficient than a dynamically compiled lambda, and about the same speed.</remarks>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.StringExtensions.UnescapeBackSlashUriString(System.String)">
+            <summary>
+            Unescape Uri string for %2F
+            See details at: https://github.com/dotnet/aspnetcore/issues/14170#issuecomment-533342396
+            </summary>
+            <param name="uriString">The Uri string.</param>
+            <returns>Unescaped back slash Uri string.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.StringExtensions.NormalizeHttpMethod(System.String)">
             <summary>
             Normalize the http method.
@@ -1093,6 +1101,20 @@
             </summary>
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
@@ -14615,22 +14637,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
@@ -173,8 +173,10 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                     IEdmTypeReference edmType = keyProperty.Type;
                     string strValue = rawValue as string;
 
-                    // rawValue from Request route values, it's unescaped.
                     string newStrValue = context.GetParameterAliasOrSelf(strValue);
+
+                    // rawValue from Request route values, it's unescaped except the back-slash.
+                    newStrValue = newStrValue.UnescapeBackSlashUriString();
                     if (newStrValue != strValue)
                     {
                         updateValues[templateName] = newStrValue;

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
@@ -172,8 +172,9 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
 
                     IEdmTypeReference edmType = keyProperty.Type;
                     string strValue = rawValue as string;
+
+                    // rawValue from Request route values, it's unescaped.
                     string newStrValue = context.GetParameterAliasOrSelf(strValue);
-                    newStrValue = Uri.UnescapeDataString(newStrValue);
                     if (newStrValue != strValue)
                     {
                         updateValues[templateName] = newStrValue;

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/ODataTemplateTranslateContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/ODataTemplateTranslateContext.cs
@@ -95,15 +95,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
         /// <returns>The parameter alias name.</returns>
         public string GetParameterAliasOrSelf(string alias)
         {
-            var set = new HashSet<string>();
-            string value = GetParameterAliasOrSelf(alias, set);
-            if (set.Count > 1)
-            {
-                // Since it returns from query, should unescape the string.
-                return Uri.UnescapeDataString(value);
-            }
-
-            return value;
+            return GetParameterAliasOrSelf(alias, new HashSet<string>());
         }
 
         private string GetParameterAliasOrSelf(string alias, ISet<string> visited)

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/ODataTemplateTranslateContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/ODataTemplateTranslateContext.cs
@@ -95,7 +95,15 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
         /// <returns>The parameter alias name.</returns>
         public string GetParameterAliasOrSelf(string alias)
         {
-            return GetParameterAliasOrSelf(alias, new HashSet<string>());
+            var set = new HashSet<string>();
+            string value = GetParameterAliasOrSelf(alias, set);
+            if (set.Count > 1)
+            {
+                // Since it returns from query, should unescape the string.
+                return Uri.UnescapeDataString(value);
+            }
+
+            return value;
         }
 
         private string GetParameterAliasOrSelf(string alias, ISet<string> visited)

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/KeySegmentTemplateTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/KeySegmentTemplateTests.cs
@@ -497,7 +497,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Template
             EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
             EdmEntitySet customers = container.AddEntitySet("Customers", customerType);
             model.AddElement(container);
-            RouteValueDictionary routeValueDictionary = new RouteValueDictionary(new { First = "'Zhang'", Last = "'Gan%2Fnng%23%20T'" });
+            RouteValueDictionary routeValueDictionary = new RouteValueDictionary(new { First = "'Zhang'", Last = "'Gan%2Fnng# T'" });
             IDictionary<string, string> keys = new Dictionary<string, string>
             {
                 { "FirstName", "{first}" },


### PR DESCRIPTION
See details at:  issue #796

When we retrieve the value from Request route values, it's unescaped. We don't need to unescape it again.

But for the Query option, we retrieve it from query string, it's not unescaped. we should unescape it.