### PR TITLE
fix: correctly find the target of a containment navigation property

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelExtensions.cs
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.OData.Edm
 
             if (navigationProperty.ContainsTarget)
             {
-                return navigationSource;
+                return navigationSource.FindNavigationTarget(navigationProperty);
             }
 
             IEnumerable<IEdmNavigationPropertyBinding> bindings =


### PR DESCRIPTION
This fixes an issue where the NavigationPropertySegment would have the wrong NavigationSource, resulting in an arcane error in certain scenarios because the associated entity type was wrong. The modified method is effectively a copy from [odata.net EdmExtensionMethods](https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Core/EdmExtensionMethods.cs#L32), and it isn't clear why this line deviated.