### PR TITLE
Fixes #766, Support in memory filtering after ODataQueryOptions.ApplyTo

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -9618,6 +9618,48 @@
             <param name="request">A http request containing the query options.</param>
             <returns>A string representing the query options part of an OData URL.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.ODataCastOptions">
+            <summary>
+            The cast options.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.ODataCastOptions.MapProvider">
+            <summary>
+            Gets/sets the map provider.
+            </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.IQueryableODataExtension">
+            <summary>
+            Provides a set of static methods for querying data structures that implement <see cref="T:System.Linq.IQueryable"/>
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.IQueryableODataExtension.OCast``1(System.Object,Microsoft.AspNetCore.OData.Query.ODataCastOptions)">
+            <summary>
+            Converts the source to the specified type.
+            </summary>
+            <typeparam name="TResult">The type to convert the source to.</typeparam>
+            <param name="source">The source.</param>
+            <param name="options">The cast options.</param>
+            <returns>The converted object if it's OData object. Otherwise, return same source or the default.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.IQueryableODataExtension.OCast``1(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.ODataCastOptions)">
+            <summary>
+            Converts the elements of an <see cref="T:System.Linq.IQueryable"/> to the specified type.
+            </summary>
+            <typeparam name="TResult">The type to convert the elements of source to.</typeparam>
+            <param name="source">The <see cref="T:System.Linq.IQueryable"/> that contains the elements to be converted.</param>
+            <param name="options">The cast options.</param>
+            <returns>Contains each element of the source sequence converted to the specified type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.IQueryableODataExtension.CreateInstance(Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper,System.Type,Microsoft.AspNetCore.OData.Query.ODataCastOptions)">
+            <summary>
+            Create the object based on <see cref="T:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper"/>
+            </summary>
+            <param name="wrapper">The select expand wrapper.</param>
+            <param name="resultType">The created type.</param>
+            <param name="options">The options.</param>
+            <returns>The created object.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ModelBoundQuerySettingsExtensions">
             <summary>
             This class describes the model bound settings to use during query composition.
@@ -12240,6 +12282,11 @@
             Indicates whether the underlying instance can be used to obtain property values.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper.InstanceValue">
+            <summary>
+            Gets the instance value.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper.GetEdmType">
             <inheritdoc />
         </member>
@@ -12275,6 +12322,11 @@
         <member name="P:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper`1.Instance">
             <summary>
             Gets or sets the instance of the element being selected and expanded.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper`1.InstanceValue">
+            <summary>
+            Gets the instance value.
             </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Results.BadRequestODataResult">

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -934,6 +934,11 @@ Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtensions
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.CanParse(Microsoft.AspNetCore.Http.HttpRequest request) -> bool
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.ParseAsync(Microsoft.AspNetCore.Http.HttpRequest request) -> System.Threading.Tasks.Task<string>
+Microsoft.AspNetCore.OData.Query.IQueryableODataExtension
+Microsoft.AspNetCore.OData.Query.ODataCastOptions
+Microsoft.AspNetCore.OData.Query.ODataCastOptions.MapProvider.get -> System.Func<Microsoft.OData.Edm.IEdmModel, Microsoft.OData.Edm.IEdmStructuredType, Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper>
+Microsoft.AspNetCore.OData.Query.ODataCastOptions.MapProvider.set -> void
+Microsoft.AspNetCore.OData.Query.ODataCastOptions.ODataCastOptions() -> void
 Microsoft.AspNetCore.OData.Query.ODataQueryContext
 Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQuerySettings.get -> Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings
 Microsoft.AspNetCore.OData.Query.ODataQueryContext.ElementClrType.get -> System.Type
@@ -1709,6 +1714,8 @@ static Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.ApplyNullPropaga
 static Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.GetDynamicPropertyContainer(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openNode, Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext context) -> System.Reflection.PropertyInfo
 static Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtensions.GetETag(this Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTagHeaderValue) -> Microsoft.AspNetCore.OData.Query.ETag
 static Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtensions.GetETag<TEntity>(this Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTagHeaderValue) -> Microsoft.AspNetCore.OData.Query.ETag<TEntity>
+static Microsoft.AspNetCore.OData.Query.IQueryableODataExtension.OCast<TResult>(this object source, Microsoft.AspNetCore.OData.Query.ODataCastOptions options = null) -> TResult
+static Microsoft.AspNetCore.OData.Query.IQueryableODataExtension.OCast<TResult>(this System.Linq.IQueryable source, Microsoft.AspNetCore.OData.Query.ODataCastOptions options = null) -> System.Collections.Generic.IEnumerable<TResult>
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.IsSystemQueryOption(string queryOptionName) -> bool
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.IsSystemQueryOption(string queryOptionName, bool isDollarSignOptional) -> bool
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.LimitResults<T>(System.Linq.IQueryable<T> queryable, int limit, bool parameterize, out bool resultsLimited) -> System.Linq.IQueryable<T>

--- a/src/Microsoft.AspNetCore.OData/Query/IQueryableODataExtension.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/IQueryableODataExtension.cs
@@ -1,0 +1,218 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IQueryableODataExtension.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Formatter.Deserialization;
+using Microsoft.AspNetCore.OData.Query.Container;
+using Microsoft.AspNetCore.OData.Query.Wrapper;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Query
+{
+    /// <summary>
+    /// The cast options.
+    /// </summary>
+    public class ODataCastOptions
+    {
+        /// <summary>
+        /// Gets/sets the map provider.
+        /// </summary>
+        public Func<IEdmModel, IEdmStructuredType, IPropertyMapper> MapProvider { get; set; }
+    }
+
+    /// <summary>
+    /// Provides a set of static methods for querying data structures that implement <see cref="IQueryable"/>
+    /// </summary>
+    public static class IQueryableODataExtension
+    {
+        /// <summary>
+        /// Converts the source to the specified type.
+        /// </summary>
+        /// <typeparam name="TResult">The type to convert the source to.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="options">The cast options.</param>
+        /// <returns>The converted object if it's OData object. Otherwise, return same source or the default.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
+        public static TResult OCast<TResult>(this object source, ODataCastOptions options = null)
+        {
+            if (source is null)
+            {
+                return default;
+            }
+
+            Type sourceType = source.GetType();
+            if (source is SelectExpandWrapper wrapper)
+            {
+                return (TResult)CreateInstance(wrapper, sourceType, options);
+            }
+
+            if (typeof(TResult) == sourceType)
+            {
+                return (TResult)source;
+            }
+
+            if (typeof(TResult).IsAssignableFrom(sourceType))
+            {
+                return (TResult)Convert.ChangeType(source, typeof(TResult), CultureInfo.InvariantCulture);
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Converts the elements of an <see cref="IQueryable"/> to the specified type.
+        /// </summary>
+        /// <typeparam name="TResult">The type to convert the elements of source to.</typeparam>
+        /// <param name="source">The <see cref="IQueryable"/> that contains the elements to be converted.</param>
+        /// <param name="options">The cast options.</param>
+        /// <returns>Contains each element of the source sequence converted to the specified type.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
+        public static IEnumerable<TResult> OCast<TResult>(this IQueryable source, ODataCastOptions options = null)
+        {
+            if (source is null)
+            {
+                throw Error.ArgumentNull(nameof(source));
+            }
+
+            foreach (var item in source)
+            {
+                yield return OCast<TResult>(item, options);
+            }
+        }
+
+        /// <summary>
+        /// Create the object based on <see cref="SelectExpandWrapper"/>
+        /// </summary>
+        /// <param name="wrapper">The select expand wrapper.</param>
+        /// <param name="resultType">The created type.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>The created object.</returns>
+        private static object CreateInstance(SelectExpandWrapper wrapper, Type resultType, ODataCastOptions options)
+        {
+            object instance;
+            Type instanceType = resultType;
+            IEdmModel model = wrapper.Model;
+            if (wrapper.UseInstanceForProperties)
+            {
+                instance = wrapper.InstanceValue;
+                instanceType = instance.GetType();
+            }
+            else
+            {
+                if (wrapper.InstanceType != null && wrapper.InstanceType != resultType.FullName)
+                {
+                    // inheritance
+                    IEdmTypeReference typeReference = wrapper.GetEdmType();
+                    instanceType = model.GetClrType(typeReference); // inheritance type
+                }
+
+                instance = Activator.CreateInstance(instanceType);
+            }
+
+            IDictionary<string, object> properties;
+            if (options != null && options.MapProvider != null)
+            {
+                properties = wrapper.ToDictionary(options.MapProvider);
+            }
+            else
+            {
+                properties = wrapper.ToDictionary();
+            }
+
+            foreach (var property in properties)
+            {
+                string propertyName = property.Key;
+                object propertyValue = property.Value;
+                if (propertyValue == null)
+                {
+                    // If it's null, we don't need to do anything.
+                    continue;
+                }
+
+                PropertyInfo propertyInfo = GetPropertyInfo(instanceType, propertyName);
+                if (propertyInfo == null)
+                {
+                    throw new ODataException(Error.Format(SRResources.PropertyNotFound, instanceType.FullName, propertyName));
+                }
+
+                bool isCollection = TypeHelper.IsCollection(propertyInfo.PropertyType, out Type elementType);
+
+                if (isCollection)
+                {
+                    IList<object> collection = new List<object>();
+                    IEnumerable collectionPropertyValue = propertyValue as IEnumerable;
+                    foreach (var item in collectionPropertyValue)
+                    {
+                        object itemValue = CreateValue(item, elementType, options);
+                        collection.Add(itemValue);
+                    }
+
+                    IEdmTypeReference typeRef = model.GetEdmTypeReference(propertyInfo.PropertyType);
+                    IEdmCollectionTypeReference collectionTypeRef = typeRef.AsCollection();
+
+                    DeserializationHelpers.SetCollectionProperty(instance, propertyName, collectionTypeRef, collection, true, null);
+                }
+                else
+                {
+                    object itemValue = CreateValue(propertyValue, elementType, options);
+                    propertyInfo.SetValue(instance, itemValue);
+                }
+            }
+
+            return instance;
+        }
+
+        private static object CreateValue(object value, Type elementType, ODataCastOptions options)
+        {
+            Type valueType = value.GetType();
+
+            if (typeof(ISelectExpandWrapper).IsAssignableFrom(valueType))
+            {
+                SelectExpandWrapper subWrapper = value as SelectExpandWrapper;
+                return CreateInstance(subWrapper, elementType, options);
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        private static PropertyInfo GetPropertyInfo(Type type, string propertyName)
+        {
+            PropertyInfo propertyInfo = null;
+            var properties = type.GetProperties().Where(p => p.Name == propertyName).ToArray();
+            if (properties.Length <= 0)
+            {
+                propertyInfo = null;
+            }
+            else if (properties.Length == 1)
+            {
+                propertyInfo = properties[0];
+            }
+            else
+            {
+                // resolve 'new' modifier
+                propertyInfo = properties.FirstOrDefault(p => p.DeclaringType == type);
+                if (propertyInfo == null)
+                {
+                    throw new ODataException(Error.Format(SRResources.AmbiguousPropertyNameFound, propertyName));
+                }
+            }
+
+            return propertyInfo;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
@@ -48,6 +48,11 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
         /// </summary>
         public bool UseInstanceForProperties { get; set; }
 
+        /// <summary>
+        /// Gets the instance value.
+        /// </summary>
+        public abstract object InstanceValue { get; }
+
         /// <inheritdoc />
         public IEdmTypeReference GetEdmType()
         {

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
@@ -36,6 +36,11 @@ property selection combination possible. */
             set { UntypedInstance = value; }
         }
 
+        /// <summary>
+        /// Gets the instance value.
+        /// </summary>
+        public override object InstanceValue => Instance;
+
         protected override Type GetElementType()
         {
             return UntypedInstance == null ? typeof(TElement) : UntypedInstance.GetType();

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -1226,6 +1226,21 @@ public sealed class Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtens
 	public static ETag`1 GetETag (Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTagHeaderValue)
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Query.IQueryableODataExtension {
+	[
+	ExtensionAttribute(),
+	]
+	public static IEnumerable`1 OCast (System.Linq.IQueryable source, params Microsoft.AspNetCore.OData.Query.ODataCastOptions options)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TResult OCast (object source, params Microsoft.AspNetCore.OData.Query.ODataCastOptions options)
+}
+
 public class Microsoft.AspNetCore.OData.Query.ApplyQueryOption {
 	public ApplyQueryOption (string rawValue, Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.OData.UriParser.ODataQueryOptionParser queryOptionParser)
 
@@ -1347,6 +1362,12 @@ public class Microsoft.AspNetCore.OData.Query.FilterQueryOption {
 
 	public System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
 	public void Validate (Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings)
+}
+
+public class Microsoft.AspNetCore.OData.Query.ODataCastOptions {
+	public ODataCastOptions ()
+
+	System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]] MapProvider  { public get; public set; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.ODataQueryContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -1226,6 +1226,21 @@ public sealed class Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtens
 	public static ETag`1 GetETag (Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTagHeaderValue)
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Query.IQueryableODataExtension {
+	[
+	ExtensionAttribute(),
+	]
+	public static IEnumerable`1 OCast (System.Linq.IQueryable source, params Microsoft.AspNetCore.OData.Query.ODataCastOptions options)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TResult OCast (object source, params Microsoft.AspNetCore.OData.Query.ODataCastOptions options)
+}
+
 public class Microsoft.AspNetCore.OData.Query.ApplyQueryOption {
 	public ApplyQueryOption (string rawValue, Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.OData.UriParser.ODataQueryOptionParser queryOptionParser)
 
@@ -1347,6 +1362,12 @@ public class Microsoft.AspNetCore.OData.Query.FilterQueryOption {
 
 	public System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
 	public void Validate (Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings)
+}
+
+public class Microsoft.AspNetCore.OData.Query.ODataCastOptions {
+	public ODataCastOptions ()
+
+	System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]] MapProvider  { public get; public set; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.ODataQueryContext {

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/IQueryableODataExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/IQueryableODataExtensionTests.cs
@@ -1,0 +1,236 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IQueryableODataExtensionTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.AspNetCore.OData.Tests.Query.Expressions;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Query
+{
+    public class IQueryableODataExtensionTests
+    {
+        private readonly ODataQuerySettings _settings;
+        private readonly IEdmModel _model;
+
+        public IQueryableODataExtensionTests()
+        {
+            _model = SelectExpandBinderTest.GetEdmModel();
+            _settings = new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False };
+        }
+
+        [Fact]
+        public void OCast_Works_ForSingleObject()
+        {
+            // Arrange & Act & Assert
+            object source = null;
+            Assert.Null(source.OCast<object>());
+
+            // Arrange & Act & Assert
+            QueryCustomer customer = new QueryCustomer
+            {
+                Name = "A"
+            };
+
+            Assert.Null(customer.OCast<string>());
+
+            var expectCustomer = customer.OCast<QueryCustomer>();
+            Assert.Same(customer, expectCustomer);
+        }
+
+        [Fact]
+        public void OCast_Works_ForSingleSelectAndExpand()
+        {
+            // Arrange
+            ODataQueryContext context = new ODataQueryContext(_model, typeof(QueryCustomer)) { RequestContainer = new MockServiceProvider() };
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: "Name", expand: null, context: context);
+            QueryCustomer customer = new QueryCustomer
+            {
+                Name = "A",
+                Age = 42
+            };
+
+            SelectExpandBinder binder = new SelectExpandBinder();
+            QueryBinderContext queryBinderContext = new QueryBinderContext(_model, _settings, typeof(QueryCustomer))
+            {
+                NavigationSource = context.NavigationSource
+            };
+
+            object result = binder.ApplyBind(customer, selectExpand.SelectExpandClause, queryBinderContext);
+
+            // Act
+            QueryCustomer expectedCustomer = result.OCast<QueryCustomer>();
+
+            // Assert
+            Assert.Equal("A", expectedCustomer.Name);
+            Assert.Equal(0, expectedCustomer.Age);
+        }
+
+        [Theory]
+        [InlineData("Name", false)]
+        [InlineData("Name,Age", true)]
+        public void OCast_Works_ForQuerableSelectAndExpand(string select, bool withAge)
+        {
+            // Arrange
+            ODataQueryContext context = new ODataQueryContext(_model, typeof(QueryCustomer)) { RequestContainer = new MockServiceProvider() };
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select, expand: null, context: context);
+            IQueryable customers = new[] {
+                new QueryCustomer
+                {
+                    Name = "A",
+                    Age = 42
+                },
+                new QueryCustomer
+                {
+                    Name = "B",
+                    Age = 38
+                }
+            }.AsQueryable();
+
+            SelectExpandBinder binder = new SelectExpandBinder();
+            QueryBinderContext queryBinderContext = new QueryBinderContext(_model, _settings, typeof(QueryCustomer))
+            {
+                NavigationSource = context.NavigationSource
+            };
+
+            IQueryable queryable = binder.ApplyBind(customers, selectExpand.SelectExpandClause, queryBinderContext);
+
+            // Act
+            IEnumerable<QueryCustomer> expectedCustomers = queryable.OCast<QueryCustomer>();
+
+            // Assert
+            Assert.Collection(expectedCustomers,
+                e =>
+                {
+                    Assert.Equal("A", e.Name);
+
+                    if (withAge)
+                        Assert.Equal(42, e.Age);
+                    else
+                        Assert.Equal(0, e.Age);
+                },
+                e =>
+                {
+                    Assert.Equal("B", e.Name);
+
+                    if (withAge)
+                        Assert.Equal(38, e.Age);
+                    else
+                        Assert.Equal(0, e.Age);
+                });
+        }
+
+        [Fact]
+        public void OCast_Works_ForInheritancePropertiesQuerableSelectAndExpand()
+        {
+            // Arrange
+            ODataQueryContext context = new ODataQueryContext(_model, typeof(QueryVipCustomer)) { RequestContainer = new MockServiceProvider() };
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: "Taxes($top=2)", expand: null, context: context);
+            IQueryable customers = new[] {
+                new QueryVipCustomer
+                {
+                    Name = "A",
+                    Age = 42,
+                    Taxes = new List<int> { 1, 2, 3, 4, 5}
+                },
+                new QueryVipCustomer
+                {
+                    Name = "B",
+                    Age = 38,
+                    Taxes = new List<int> { 6, 7, 8, 9, 10}
+                }
+            }.AsQueryable();
+
+            SelectExpandBinder binder = new SelectExpandBinder();
+            QueryBinderContext queryBinderContext = new QueryBinderContext(_model, _settings, typeof(QueryCustomer))
+            {
+                NavigationSource = context.NavigationSource
+            };
+
+            IQueryable queryable = binder.ApplyBind(customers, selectExpand.SelectExpandClause, queryBinderContext);
+
+            // Act
+            IEnumerable<QueryCustomer> expectedCustomers = queryable.OCast<QueryCustomer>();
+
+            // Assert
+            Assert.Collection(expectedCustomers,
+                e =>
+                {
+                    QueryVipCustomer vipCustomer = Assert.IsType<QueryVipCustomer>(e);
+                    Assert.Null(vipCustomer.Name);
+                    Assert.NotNull(vipCustomer.Taxes);
+                    Assert.Equal(new int[] { 1, 2 }, vipCustomer.Taxes);
+                },
+                e =>
+                {
+                    QueryVipCustomer vipCustomer = Assert.IsType<QueryVipCustomer>(e);
+                    Assert.Null(vipCustomer.Name);
+                    Assert.NotNull(vipCustomer.Taxes);
+                    Assert.Equal(new int[] { 6, 7 }, vipCustomer.Taxes);
+                });
+        }
+
+        [Fact]
+        public void OCast_Works_ForCollectionSelectAndExpand()
+        {
+            QueryCustomer customer = new QueryCustomer
+            {
+                Name = "A",
+                Orders = new List<QueryOrder>()
+            };
+            QueryOrder order = new QueryOrder { Customer = customer };
+            customer.Orders.Add(order);
+
+            QueryCustomer vipCustomer = new QueryVipCustomer
+            {
+                Name = "B",
+                Orders = new List<QueryOrder>()
+            };
+            order = new QueryOrder { Customer = vipCustomer };
+            vipCustomer.Orders.Add(order);
+
+            var queryableOf = new[] { customer, vipCustomer }.AsQueryable();
+
+            // Arrange
+            ODataQueryContext context = new ODataQueryContext(_model, typeof(QueryCustomer)) { RequestContainer = new MockServiceProvider() };
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption("Orders", "Orders,Orders($expand=Customer)", context);
+
+            // Act
+            SelectExpandBinder binder = new SelectExpandBinder();
+            QueryBinderContext queryBinderContext = new QueryBinderContext(_model, _settings, typeof(QueryCustomer))
+            {
+                NavigationSource = context.NavigationSource
+            };
+
+            IQueryable queryable = binder.ApplyBind(queryableOf, selectExpand.SelectExpandClause, queryBinderContext);
+            IEnumerable<QueryCustomer> expectedCustomers = queryable.OCast<QueryCustomer>();
+
+            // Assert
+            Assert.Collection(expectedCustomers,
+                e =>
+                {
+                    QueryCustomer c = Assert.IsType<QueryCustomer>(e);
+                    Assert.NotNull(c.Orders);
+                    QueryOrder order = Assert.Single(c.Orders);
+                    Assert.NotNull(order.Customer);
+                    Assert.Equal("A", order.Customer.Name);
+                },
+                e =>
+                {
+                    QueryVipCustomer c = Assert.IsType<QueryVipCustomer>(e);
+                    Assert.NotNull(c.Orders);
+                    QueryOrder order = Assert.Single(c.Orders);
+                    Assert.NotNull(order.Customer);
+                    Assert.Equal("B", order.Customer.Name);
+                });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #766.

If we have $select and $expand in the request query, the result is collection of ISelectExpandWrapper.

It's not easy for customers to do further. So Add 'Cast' Extension methods on IQueryable and Object.

Basic usage in the controller/action:
```C#
IQueryable query = options.ApplyTo(....);
IEnumerable<Customer> results = query.OCast<Customer>(query); // the new extension methods on IQueryable.

foreach (var a in results)
{
    // a is a partial object of Customer if we have $select and $expand.
}

```

Thanks.