### PR TITLE
Fix wrong links generated for derived type with navigation property when odata.metadata=full

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/NavigationSourceLinkBuilderAnnotation.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/NavigationSourceLinkBuilderAnnotation.cs
@@ -60,12 +60,10 @@ namespace Microsoft.AspNetCore.OData.Edm
             }
 
             // Add navigation link builders for all navigation properties in derived types.
-            bool derivedTypesDefineNavigationProperty = false;
             foreach (IEdmEntityType derivedEntityType in derivedTypes)
             {
                 foreach (IEdmNavigationProperty navigationProperty in derivedEntityType.DeclaredNavigationProperties())
                 {
-                    derivedTypesDefineNavigationProperty = true;
                     Func<ResourceContext, IEdmNavigationProperty, Uri> navigationLinkFactory =
                     (resourceContext, navProperty) => resourceContext.GenerateNavigationPropertyLink(navProperty, includeCast: true);
                     AddNavigationPropertyLinkBuilder(navigationProperty, new NavigationLinkBuilder(navigationLinkFactory, followsConventions: true));
@@ -73,7 +71,7 @@ namespace Microsoft.AspNetCore.OData.Edm
             }
 
             Func<ResourceContext, Uri> selfLinkFactory =
-                (resourceContext) => resourceContext.GenerateSelfLink(includeCast: derivedTypesDefineNavigationProperty);
+                (resourceContext) => resourceContext.GenerateSelfLink(includeCast: false);
             IdLinkBuilder = new SelfLinkBuilder<Uri>(selfLinkFactory, followsConventions: true);
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesControllers.cs
@@ -47,6 +47,16 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
                     {
                         new Order { Id = 4, Amount = 170M }
                     }
+                },
+                new EnterpriseCustomer
+                {
+                    Id = 4,
+                    Name = "Customer 4",
+                    Orders = new List<Order>
+                    {
+                        new Order { Id = 5, Amount = 190M}
+                    },
+                    RelationshipManager = new Employee { Id = 1, Name = "Employee 1" }
                 }
             };
         }
@@ -90,6 +100,19 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
             }
 
             return Ok(vipCustomer);
+        }
+
+        [EnableQuery]
+        public IActionResult GetEnterpriseCustomer([FromRoute] int key)
+        {
+            var enterpriseCustomer = Customers.OfType<EnterpriseCustomer>().SingleOrDefault(d => d.Id.Equals(key));
+
+            if (enterpriseCustomer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(enterpriseCustomer);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DerivedTypes/DerivedTypesDataModel.cs
@@ -26,4 +26,15 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DerivedTypes
         public int Id { get; set; }
         public decimal Amount { get; set; }
     }
+
+    public class EnterpriseCustomer : Customer
+    {
+        public Employee RelationshipManager { get; set; }
+    }
+
+    public class Employee
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
 }


### PR DESCRIPTION
*This pull request fixes https://github.com/OData/AspNetCoreOData/issues/797.*

### Description

Fix wrong links generated for derived type with navigation property when `odata.metadata=full`. When `odata.metadata=full` is specified, the type-cast segment is wrongly appended to the resource id.

When that happens, since ODL also appends the type-cast segment, you end up with the response payload looking as follows:
```json
{
    "@odata.context": "http://localhost:5219/odata/$metadata#Customers/ODataAlternateKeySample.Models.GoldCustomer/$entity",
    "@odata.type": "#ODataAlternateKeySample.Models.GoldCustomer",
    "@odata.id": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer",
    "@odata.editLink": "Customers(1)/ODataAlternateKeySample.Models.GoldCustomer/ODataAlternateKeySample.Models.GoldCustomer",
    "Id": 1,
    "Name": "Tom",
    "CountryOrRegion": null,
    "Passport": null,
    "SSN": "SSN-1-101",
    "Titles@odata.type": "#Collection(String)",
    "Titles": [ "abc", null, "efg" ],
    "Contact@odata.associationLink": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer/ODataAlternateKeySample.Models.GoldCustomer/Contact/$ref",
    "Contact@odata.navigationLink": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer/ODataAlternateKeySample.Models.GoldCustomer/Contact"
}
```
This pull request fixes the generation of `@odata.id`, `@odata.editLink`, `@odata.associationLink` and `@odata.nagivationLink` properties such that the response payload looks as follows:
```json
{
    "@odata.context": "http://localhost:5219/odata/$metadata#Customers/ODataAlternateKeySample.Models.GoldCustomer/$entity",
    "@odata.type": "#ODataAlternateKeySample.Models.GoldCustomer",
    "@odata.id": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer",
    "@odata.editLink": "Customers(1)/ODataAlternateKeySample.Models.GoldCustomer",
    "Id": 1,
    "Name": "Tom",
    "CountryOrRegion": null,
    "Passport": null,
    "SSN": "SSN-1-101",
    "Titles@odata.type": "#Collection(String)",
    "Titles": [ "abc", null, "efg" ],
    "Contact@odata.associationLink": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer/Contact/$ref",
    "Contact@odata.navigationLink": "http://localhost:5219/odata/Customers(1)/ODataAlternateKeySample.Models.GoldCustomer/Contact"
}
```