### PR TITLE
fixes #834, add DefaultQueryConfigurations class

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
@@ -137,10 +137,10 @@ namespace Microsoft.AspNetCore.OData.Edm
         }
 
         public static bool IsTopLimitExceeded(IEdmProperty property, IEdmStructuredType structuredType,
-           IEdmModel edmModel, int top, DefaultQuerySettings defaultQuerySettings, out int maxTop)
+           IEdmModel edmModel, int top, DefaultQueryConfigurations defaultQueryConfs, out int maxTop)
         {
             maxTop = 0;
-            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(property, structuredType, defaultQuerySettings);
+            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(property, structuredType, defaultQueryConfs);
             if (querySettings != null && top > querySettings.MaxTop)
             {
                 maxTop = querySettings.MaxTop.Value;
@@ -339,14 +339,14 @@ namespace Microsoft.AspNetCore.OData.Edm
         }
 
         public static ModelBoundQuerySettings GetModelBoundQuerySettings(this IEdmModel edmModel, IEdmProperty property,
-           IEdmStructuredType structuredType, DefaultQuerySettings defaultQuerySettings = null)
+           IEdmStructuredType structuredType, DefaultQueryConfigurations defaultQueryConfs = null)
         {
             if (edmModel == null)
             {
                 throw Error.ArgumentNull(nameof(edmModel));
             }
 
-            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(structuredType, defaultQuerySettings);
+            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(structuredType, defaultQueryConfs);
             if (property == null)
             {
                 return querySettings;
@@ -354,12 +354,12 @@ namespace Microsoft.AspNetCore.OData.Edm
             else
             {
                 // Settings on property is higher priority than the ones on type.
-                ModelBoundQuerySettings propertyQuerySettings = edmModel.GetModelBoundQuerySettings(property, defaultQuerySettings);
+                ModelBoundQuerySettings propertyQuerySettings = edmModel.GetModelBoundQuerySettings(property, defaultQueryConfs);
                 return GetMergedPropertyQuerySettings(propertyQuerySettings, querySettings);
             }
         }
 
-        private static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(this IEdmModel edmModel, T key, DefaultQuerySettings defaultQuerySettings = null)
+        private static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(this IEdmModel edmModel, T key, DefaultQueryConfigurations defaultQueryConfs = null)
             where T : IEdmElement
         {
             if (key == null)
@@ -372,10 +372,10 @@ namespace Microsoft.AspNetCore.OData.Edm
                 if (querySettings == null)
                 {
                     querySettings = new ModelBoundQuerySettings();
-                    if (defaultQuerySettings != null &&
-                        (!defaultQuerySettings.MaxTop.HasValue || defaultQuerySettings.MaxTop > 0))
+                    if (defaultQueryConfs != null &&
+                        (!defaultQueryConfs.MaxTop.HasValue || defaultQueryConfs.MaxTop > 0))
                     {
-                        querySettings.MaxTop = defaultQuerySettings.MaxTop;
+                        querySettings.MaxTop = defaultQueryConfs.MaxTop;
                     }
                 }
 

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
@@ -137,10 +137,10 @@ namespace Microsoft.AspNetCore.OData.Edm
         }
 
         public static bool IsTopLimitExceeded(IEdmProperty property, IEdmStructuredType structuredType,
-           IEdmModel edmModel, int top, DefaultQueryConfigurations defaultQueryConfs, out int maxTop)
+           IEdmModel edmModel, int top, DefaultQueryConfigurations defaultQueryConfigs, out int maxTop)
         {
             maxTop = 0;
-            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(property, structuredType, defaultQueryConfs);
+            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(property, structuredType, defaultQueryConfigs);
             if (querySettings != null && top > querySettings.MaxTop)
             {
                 maxTop = querySettings.MaxTop.Value;
@@ -339,14 +339,14 @@ namespace Microsoft.AspNetCore.OData.Edm
         }
 
         public static ModelBoundQuerySettings GetModelBoundQuerySettings(this IEdmModel edmModel, IEdmProperty property,
-           IEdmStructuredType structuredType, DefaultQueryConfigurations defaultQueryConfs = null)
+           IEdmStructuredType structuredType, DefaultQueryConfigurations defaultQueryConfigs = null)
         {
             if (edmModel == null)
             {
                 throw Error.ArgumentNull(nameof(edmModel));
             }
 
-            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(structuredType, defaultQueryConfs);
+            ModelBoundQuerySettings querySettings = edmModel.GetModelBoundQuerySettings(structuredType, defaultQueryConfigs);
             if (property == null)
             {
                 return querySettings;
@@ -354,12 +354,12 @@ namespace Microsoft.AspNetCore.OData.Edm
             else
             {
                 // Settings on property is higher priority than the ones on type.
-                ModelBoundQuerySettings propertyQuerySettings = edmModel.GetModelBoundQuerySettings(property, defaultQueryConfs);
+                ModelBoundQuerySettings propertyQuerySettings = edmModel.GetModelBoundQuerySettings(property, defaultQueryConfigs);
                 return GetMergedPropertyQuerySettings(propertyQuerySettings, querySettings);
             }
         }
 
-        private static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(this IEdmModel edmModel, T key, DefaultQueryConfigurations defaultQueryConfs = null)
+        private static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(this IEdmModel edmModel, T key, DefaultQueryConfigurations defaultQueryConfigs = null)
             where T : IEdmElement
         {
             if (key == null)
@@ -372,10 +372,10 @@ namespace Microsoft.AspNetCore.OData.Edm
                 if (querySettings == null)
                 {
                     querySettings = new ModelBoundQuerySettings();
-                    if (defaultQueryConfs != null &&
-                        (!defaultQueryConfs.MaxTop.HasValue || defaultQueryConfs.MaxTop > 0))
+                    if (defaultQueryConfigs != null &&
+                        (!defaultQueryConfigs.MaxTop.HasValue || defaultQueryConfigs.MaxTop > 0))
                     {
-                        querySettings.MaxTop = defaultQueryConfs.MaxTop;
+                        querySettings.MaxTop = defaultQueryConfigs.MaxTop;
                     }
                 }
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5640,7 +5640,18 @@
             The id of the deleted entity (same as the odata.id returned or computed when calling GET on resource), which may be absolute or relative.
             </summary>
         </member>
-   .Value.IEdmDeltaLinkBase">
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaDeletedResourceObject.Reason">
+            <summary>
+            Optional. Either deleted, if the entity was deleted (destroyed), or changed if the entity was removed from membership in the result (i.e., due to a data change).
+            </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaLink">
+            <summary>
+            Represents an instance of an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmChangedObject"/>.
+            Holds the properties necessary to create the ODataDeltaLink.
+            </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaLinkBase">
             <summary>
             Represents an instance of an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmChangedObject"/>.
             Holds the properties necessary to create either ODataDeltaLink or ODataDeltaDeletedLink.
@@ -14844,22 +14855,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5640,18 +5640,7 @@
             The id of the deleted entity (same as the odata.id returned or computed when calling GET on resource), which may be absolute or relative.
             </summary>
         </member>
-        <member name="P:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaDeletedResourceObject.Reason">
-            <summary>
-            Optional. Either deleted, if the entity was deleted (destroyed), or changed if the entity was removed from membership in the result (i.e., due to a data change).
-            </summary>
-        </member>
-        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaLink">
-            <summary>
-            Represents an instance of an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmChangedObject"/>.
-            Holds the properties necessary to create the ODataDeltaLink.
-            </summary>
-        </member>
-        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmDeltaLinkBase">
+   .Value.IEdmDeltaLinkBase">
             <summary>
             Represents an instance of an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmChangedObject"/>.
             Holds the properties necessary to create either ODataDeltaLink or ODataDeltaDeletedLink.
@@ -6275,9 +6264,9 @@
             Gets or sets whether or not the OData system query options should be prefixed with '$'.
             </summary>
         </member>
-        <member name="P:Microsoft.AspNetCore.OData.ODataOptions.QuerySettings">
+        <member name="P:Microsoft.AspNetCore.OData.ODataOptions.QueryConfigurations">
             <summary>
-            Gets the query setting.
+            Gets the query configurations.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataOptions.BuildRouteContainer(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.ODataVersion,System.Action{Microsoft.Extensions.DependencyInjection.IServiceCollection})">
@@ -8011,6 +8000,49 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser.ParseAsync(Microsoft.AspNetCore.Http.HttpRequest)">
             <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations">
+            <summary>
+            This class describes the default settings to use during query composition.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableExpand">
+            <summary>
+            Gets or sets a value indicating whether navigation property can be expanded.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSelect">
+            <summary>
+            Gets or sets a value indicating whether property can be selected.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableCount">
+            <summary>
+            Gets or sets a value indicating whether entity set and property can apply $count.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableOrderBy">
+            <summary>
+            Gets or sets a value indicating whether property can apply $orderby.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableFilter">
+            <summary>
+            Gets or sets a value indicating whether property can apply $filter.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.MaxTop">
+            <summary>
+            Gets or sets the max value of $top that a client can request.
+            </summary>
+            <value>
+            The max value of $top that a client can request, or <c>null</c> if there is no limit.
+            </value>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSkipToken">
+            <summary>
+            Gets or sets a value indicating whether the service will use skiptoken or not.
+            </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute">
             <summary>
@@ -9776,9 +9808,9 @@
             <param name="elementType">The EDM type of the element of the collection being queried.</param>
             <param name="path">The parsed <see cref="T:Microsoft.OData.UriParser.ODataPath"/>.</param>
         </member>
-        <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQuerySettings">
+        <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQueryConfigurations">
             <summary>
-            Gets the given <see cref="P:Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQuerySettings"/>.
+            Gets the given <see cref="P:Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQueryConfigurations"/>.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryContext.Model">
@@ -14812,6 +14844,22 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
+            <param name="segment">The value segment.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
+            <summary>
+            Gets the value segment.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
+            <inheritdoc />
+        </member>
+    </members>
+</doc>
+ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -8014,7 +8014,7 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations">
             <summary>
-            This class describes the default settings to use during query composition.
+            This class describes the default configurations to use during query composition.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableExpand">

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.AspNetCore.OData.Routing.Conventions;
 using Microsoft.Extensions.DependencyInjection;
@@ -195,12 +196,12 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions EnableQueryFeatures(int? maxTopValue = null)
         {
-            QuerySettings.EnableExpand = true;
-            QuerySettings.EnableSelect = true;
-            QuerySettings.EnableFilter = true;
-            QuerySettings.EnableOrderBy = true;
-            QuerySettings.EnableCount = true;
-            QuerySettings.EnableSkipToken = true;
+            QueryConfigurations.EnableExpand = true;
+            QueryConfigurations.EnableSelect = true;
+            QueryConfigurations.EnableFilter = true;
+            QueryConfigurations.EnableOrderBy = true;
+            QueryConfigurations.EnableCount = true;
+            QueryConfigurations.EnableSkipToken = true;
             SetMaxTop(maxTopValue);
             return this;
         }
@@ -211,7 +212,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions Expand()
         {
-            QuerySettings.EnableExpand = true;
+            QueryConfigurations.EnableExpand = true;
             return this;
         }
 
@@ -221,7 +222,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions Select()
         {
-            QuerySettings.EnableSelect = true;
+            QueryConfigurations.EnableSelect = true;
             return this;
         }
 
@@ -231,7 +232,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions Filter()
         {
-            QuerySettings.EnableFilter = true;
+            QueryConfigurations.EnableFilter = true;
             return this;
         }
 
@@ -241,7 +242,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions OrderBy()
         {
-            QuerySettings.EnableOrderBy = true;
+            QueryConfigurations.EnableOrderBy = true;
             return this;
         }
 
@@ -251,7 +252,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions Count()
         {
-            QuerySettings.EnableCount = true;
+            QueryConfigurations.EnableCount = true;
             return this;
         }
 
@@ -261,7 +262,7 @@ namespace Microsoft.AspNetCore.OData
         /// <returns>The current <see cref="ODataOptions"/> instance to enable fluent configuration.</returns>
         public ODataOptions SkipToken()
         {
-            QuerySettings.EnableSkipToken = true;
+            QueryConfigurations.EnableSkipToken = true;
             return this;
         }
 
@@ -277,7 +278,7 @@ namespace Microsoft.AspNetCore.OData
                 throw Error.ArgumentMustBeGreaterThanOrEqualTo(nameof(maxTopValue), maxTopValue, 0);
             }
 
-            QuerySettings.MaxTop = maxTopValue;
+            QueryConfigurations.MaxTop = maxTopValue;
             return this;
         }
 
@@ -287,9 +288,9 @@ namespace Microsoft.AspNetCore.OData
         public bool EnableNoDollarQueryOptions { get; set; } = true;
 
         /// <summary>
-        /// Gets the query setting.
+        /// Gets the query configurations.
         /// </summary>
-        public DefaultQuerySettings QuerySettings { get; } = new DefaultQuerySettings();
+        public DefaultQueryConfigurations QueryConfigurations { get; } = new DefaultQueryConfigurations();
 
         #endregion
 
@@ -310,8 +311,8 @@ namespace Microsoft.AspNetCore.OData
             // Inject the core odata services.
             builder.AddDefaultODataServices(version);
 
-            // Inject the default query setting from this options.
-            builder.Services.AddSingleton(sp => QuerySettings);
+            // Inject the default query configuration from this options.
+            builder.Services.AddSingleton(sp => this.QueryConfigurations);
 
             // Inject the default Web API OData services.
             builder.AddDefaultWebApiServices();

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -668,7 +668,7 @@ Microsoft.AspNetCore.OData.ODataOptions.Filter() -> Microsoft.AspNetCore.OData.O
 Microsoft.AspNetCore.OData.ODataOptions.GetRouteServices(string routePrefix) -> System.IServiceProvider
 Microsoft.AspNetCore.OData.ODataOptions.ODataOptions() -> void
 Microsoft.AspNetCore.OData.ODataOptions.OrderBy() -> Microsoft.AspNetCore.OData.ODataOptions
-Microsoft.AspNetCore.OData.ODataOptions.QuerySettings.get -> Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings
+Microsoft.AspNetCore.OData.ODataOptions.QueryConfigurations.get -> Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations
 Microsoft.AspNetCore.OData.ODataOptions.RouteComponents.get -> System.Collections.Generic.IDictionary<string, (Microsoft.OData.Edm.IEdmModel EdmModel, System.IServiceProvider ServiceProvider)>
 Microsoft.AspNetCore.OData.ODataOptions.RouteOptions.get -> Microsoft.AspNetCore.OData.Routing.ODataRouteOptions
 Microsoft.AspNetCore.OData.ODataOptions.Select() -> Microsoft.AspNetCore.OData.ODataOptions
@@ -812,6 +812,22 @@ Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser
 Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser.CanParse(Microsoft.AspNetCore.Http.HttpRequest request) -> bool
 Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser.DefaultODataQueryRequestParser() -> void
 Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser.ParseAsync(Microsoft.AspNetCore.Http.HttpRequest request) -> System.Threading.Tasks.Task<string>
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.DefaultQueryConfigurations() -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableCount.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableCount.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableExpand.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableExpand.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableFilter.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableFilter.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableOrderBy.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableOrderBy.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSelect.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSelect.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSkipToken.get -> bool
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.EnableSkipToken.set -> void
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.MaxTop.get -> int?
+Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations.MaxTop.set -> void
 Microsoft.AspNetCore.OData.Query.DefaultSkipTokenHandler
 Microsoft.AspNetCore.OData.Query.DefaultSkipTokenHandler.DefaultSkipTokenHandler() -> void
 Microsoft.AspNetCore.OData.Query.EnableQueryAttribute
@@ -935,7 +951,7 @@ Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.CanParse(Microsoft.AspNetCore.Http.HttpRequest request) -> bool
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.ParseAsync(Microsoft.AspNetCore.Http.HttpRequest request) -> System.Threading.Tasks.Task<string>
 Microsoft.AspNetCore.OData.Query.ODataQueryContext
-Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQuerySettings.get -> Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings
+Microsoft.AspNetCore.OData.Query.ODataQueryContext.DefaultQueryConfigurations.get -> Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations
 Microsoft.AspNetCore.OData.Query.ODataQueryContext.ElementClrType.get -> System.Type
 Microsoft.AspNetCore.OData.Query.ODataQueryContext.ElementType.get -> Microsoft.OData.Edm.IEdmType
 Microsoft.AspNetCore.OData.Query.ODataQueryContext.Model.get -> Microsoft.OData.Edm.IEdmModel

--- a/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
@@ -8,7 +8,7 @@
 namespace Microsoft.AspNetCore.OData.Query
 {
     /// <summary>
-    /// This class describes the default settings to use during query composition.
+    /// This class describes the default configurations to use during query composition.
     /// </summary>
     public class DefaultQueryConfigurations
     {

--- a/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
@@ -1,0 +1,67 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DefaultQueryConfigurations.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.AspNetCore.OData.Query
+{
+    /// <summary>
+    /// This class describes the default settings to use during query composition.
+    /// </summary>
+    public class DefaultQueryConfigurations
+    {
+        private int? _maxTop = 0;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether navigation property can be expanded.
+        /// </summary>
+        public bool EnableExpand { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether property can be selected.
+        /// </summary>
+        public bool EnableSelect { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether entity set and property can apply $count.
+        /// </summary>
+        public bool EnableCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether property can apply $orderby.
+        /// </summary>
+        public bool EnableOrderBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether property can apply $filter.
+        /// </summary>
+        public bool EnableFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max value of $top that a client can request.
+        /// </summary>
+        /// <value>
+        /// The max value of $top that a client can request, or <c>null</c> if there is no limit.
+        /// </value>
+        public int? MaxTop
+        {
+            get => _maxTop;
+            set
+            {
+                if (value.HasValue && value < 0)
+                {
+                    throw Error.ArgumentMustBeGreaterThanOrEqualTo("value", value, 0);
+                }
+
+                _maxTop = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the service will use skiptoken or not.
+        /// </summary>
+        public bool EnableSkipToken { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
-using Microsoft.OData.ModelBuilder.Config;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Query
@@ -26,7 +25,7 @@ namespace Microsoft.AspNetCore.OData.Query
     /// </summary>
     public class ODataQueryContext
     {
-        private DefaultQuerySettings _defaultQuerySettings;
+        private DefaultQueryConfigurations _defaultQueryConfigurations;
 
         /// <summary>
         /// Constructs an instance of <see cref="ODataQueryContext"/> with <see cref="IEdmModel" />, element CLR type,
@@ -106,20 +105,20 @@ namespace Microsoft.AspNetCore.OData.Query
         { }
 
         /// <summary>
-        /// Gets the given <see cref="DefaultQuerySettings"/>.
+        /// Gets the given <see cref="DefaultQueryConfigurations"/>.
         /// </summary>
-        public DefaultQuerySettings DefaultQuerySettings
+        public DefaultQueryConfigurations DefaultQueryConfigurations
         {
             get
             {
-                if (_defaultQuerySettings == null)
+                if (_defaultQueryConfigurations == null)
                 {
-                    _defaultQuerySettings = RequestContainer == null
+                    _defaultQueryConfigurations = RequestContainer == null
                         ? GetDefaultQuerySettings()
-                        : RequestContainer.GetRequiredService<DefaultQuerySettings>();
+                        : RequestContainer.GetRequiredService<DefaultQueryConfigurations>();
                 }
 
-                return _defaultQuerySettings;
+                return _defaultQueryConfigurations;
             }
         }
 
@@ -200,20 +199,20 @@ namespace Microsoft.AspNetCore.OData.Query
             }
         }
 
-        private DefaultQuerySettings GetDefaultQuerySettings()
+        private DefaultQueryConfigurations GetDefaultQuerySettings()
         {
             if (Request is null)
             {
-                return new DefaultQuerySettings();
+                return new DefaultQueryConfigurations();
             }
 
             IOptions<ODataOptions> odataOptions = Request.HttpContext?.RequestServices?.GetService<IOptions<ODataOptions>>();
             if (odataOptions is  null || odataOptions.Value is null)
             {
-                return new DefaultQuerySettings();
+                return new DefaultQueryConfigurations();
             }
 
-            return odataOptions.Value.QuerySettings;
+            return odataOptions.Value.QueryConfigurations;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
@@ -64,8 +64,8 @@ namespace Microsoft.AspNetCore.OData.Query
             ExpandedReferenceSelectItem expandedItem = context.CurrentSelectItem as ExpandedReferenceSelectItem;
             IEdmModel model = context.Model;
 
-            DefaultQuerySettings settings = context.QueryContext.DefaultQuerySettings;
-            if (settings.EnableSkipToken)
+            DefaultQueryConfigurations queryConfigs = context.QueryContext.DefaultQueryConfigurations;
+            if (queryConfigs.EnableSkipToken)
             {
                 if (expandedItem != null)
                 {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.OData.Query
             bool levelsEncountered;
             bool isMaxLevel;
             ModelBoundQuerySettings querySettings = Context.Model.GetModelBoundQuerySettings(Context.TargetProperty,
-                Context.TargetStructuredType, Context.DefaultQuerySettings);
+                Context.TargetStructuredType, Context.DefaultQueryConfigurations);
             return ProcessLevels(SelectExpandClause,
                 LevelsMaxLiteralExpansionDepth < 0 ? ODataValidationSettings.DefaultMaxExpansionDepth : LevelsMaxLiteralExpansionDepth,
                 querySettings,

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/CountQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/CountQueryValidator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 string name = countQueryOption.Context.TargetName;
                 if (EdmHelpers.IsNotCountable(property, structuredType,
                     countQueryOption.Context.Model,
-                    countQueryOption.Context.DefaultQuerySettings.EnableCount))
+                    countQueryOption.Context.DefaultQueryConfigurations.EnableCount))
                 {
                     if (property == null)
                     {

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
     {
         private int _currentAnyAllExpressionDepth;
         private int _currentNodeCount;
-        private DefaultQueryConfigurations _defaultQueryConfig;
+        private DefaultQueryConfigurations _defaultQueryConfigs;
         private IEdmProperty _property;
         private IEdmStructuredType _structuredType;
 
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             _property = filterQueryOption.Context.TargetProperty;
             _structuredType = filterQueryOption.Context.TargetStructuredType;
-            _defaultQueryConfig = filterQueryOption.Context.DefaultQueryConfigurations;
+            _defaultQueryConfigs = filterQueryOption.Context.DefaultQueryConfigurations;
 
             Validate(filterQueryOption.FilterClause, settings, filterQueryOption.Context.Model);
         }
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             // Check whether the property is not filterable
             if (EdmHelpers.IsNotFilterable(navigationProperty, _property, _structuredType, _model,
-                _defaultQueryConfig.EnableFilter))
+                _defaultQueryConfigs.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter,
                     navigationProperty.Name));
@@ -352,18 +352,18 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                     SingleNavigationNode singleNavigationNode = propertyAccessNode.Source as SingleNavigationNode;
                     notFilterable = EdmHelpers.IsNotFilterable(property, singleNavigationNode.NavigationProperty,
                         singleNavigationNode.NavigationProperty.ToEntityType(), _model,
-                        _defaultQueryConfig.EnableFilter);
+                        _defaultQueryConfigs.EnableFilter);
                 }
                 else if (propertyAccessNode.Source.Kind == QueryNodeKind.SingleComplexNode)
                 {
                     SingleComplexNode singleComplexNode = propertyAccessNode.Source as SingleComplexNode;
                     notFilterable = EdmHelpers.IsNotFilterable(property, singleComplexNode.Property,
-                        property.DeclaringType, _model, _defaultQueryConfig.EnableFilter);
+                        property.DeclaringType, _model, _defaultQueryConfigs.EnableFilter);
                 }
                 else
                 {
                     notFilterable = EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                        _defaultQueryConfig.EnableFilter);
+                        _defaultQueryConfigs.EnableFilter);
                 }
             }
 
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = singleComplexNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQueryConfig.EnableFilter))
+                _defaultQueryConfigs.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = propertyAccessNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQueryConfig.EnableFilter))
+                _defaultQueryConfigs.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }
@@ -442,7 +442,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = collectionComplexNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQueryConfig.EnableFilter))
+                _defaultQueryConfigs.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
     {
         private int _currentAnyAllExpressionDepth;
         private int _currentNodeCount;
-        private DefaultQuerySettings _defaultQuerySettings;
+        private DefaultQueryConfigurations _defaultQueryConfig;
         private IEdmProperty _property;
         private IEdmStructuredType _structuredType;
 
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             _property = filterQueryOption.Context.TargetProperty;
             _structuredType = filterQueryOption.Context.TargetStructuredType;
-            _defaultQuerySettings = filterQueryOption.Context.DefaultQuerySettings;
+            _defaultQueryConfig = filterQueryOption.Context.DefaultQueryConfigurations;
 
             Validate(filterQueryOption.FilterClause, settings, filterQueryOption.Context.Model);
         }
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             // Check whether the property is not filterable
             if (EdmHelpers.IsNotFilterable(navigationProperty, _property, _structuredType, _model,
-                _defaultQuerySettings.EnableFilter))
+                _defaultQueryConfig.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter,
                     navigationProperty.Name));
@@ -352,18 +352,18 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                     SingleNavigationNode singleNavigationNode = propertyAccessNode.Source as SingleNavigationNode;
                     notFilterable = EdmHelpers.IsNotFilterable(property, singleNavigationNode.NavigationProperty,
                         singleNavigationNode.NavigationProperty.ToEntityType(), _model,
-                        _defaultQuerySettings.EnableFilter);
+                        _defaultQueryConfig.EnableFilter);
                 }
                 else if (propertyAccessNode.Source.Kind == QueryNodeKind.SingleComplexNode)
                 {
                     SingleComplexNode singleComplexNode = propertyAccessNode.Source as SingleComplexNode;
                     notFilterable = EdmHelpers.IsNotFilterable(property, singleComplexNode.Property,
-                        property.DeclaringType, _model, _defaultQuerySettings.EnableFilter);
+                        property.DeclaringType, _model, _defaultQueryConfig.EnableFilter);
                 }
                 else
                 {
                     notFilterable = EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                        _defaultQuerySettings.EnableFilter);
+                        _defaultQueryConfig.EnableFilter);
                 }
             }
 
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = singleComplexNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQuerySettings.EnableFilter))
+                _defaultQueryConfig.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = propertyAccessNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQuerySettings.EnableFilter))
+                _defaultQueryConfig.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }
@@ -442,7 +442,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             // Check whether the property is filterable.
             IEdmProperty property = collectionComplexNode.Property;
             if (EdmHelpers.IsNotFilterable(property, _property, _structuredType, _model,
-                _defaultQuerySettings.EnableFilter))
+                _defaultQueryConfig.EnableFilter))
             {
                 throw new ODataException(Error.Format(SRResources.NotFilterablePropertyUsedInFilter, property.Name));
             }

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 }
             }
 
-            bool enableOrderBy = orderByOption.Context.DefaultQuerySettings.EnableOrderBy;
+            bool enableOrderBy = orderByOption.Context.DefaultQueryConfigurations.EnableOrderBy;
             OrderByModelLimitationsValidator validator = new OrderByModelLimitationsValidator(orderByOption.Context, enableOrderBy);
             bool explicitAllowedProperties = validationSettings.AllowedOrderByProperties.Count > 0;
 

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/SelectExpandQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/SelectExpandQueryValidator.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             }
             else if (!isExpandable)
             {
-                if (!validatorContext.Context.DefaultQuerySettings.EnableExpand ||
+                if (!validatorContext.Context.DefaultQueryConfigurations.EnableExpand ||
                     (expandConfiguration != null && expandConfiguration.ExpandType == SelectExpandType.Disabled))
                 {
                     throw new ODataException(Error.Format(SRResources.NotExpandablePropertyUsedInExpand, property.Name));
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             }
 
             IEdmModel edmModel = validatorContext.Context.Model;
-            bool enableSelect = validatorContext.Context.DefaultQuerySettings.EnableSelect;
+            bool enableSelect = validatorContext.Context.DefaultQueryConfigurations.EnableSelect;
             ODataPathSegment segment = pathSelectItem.SelectedPath.LastSegment;
 
             IEdmProperty property = validatorContext.Property;
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             foreach (var property in structuredType.StructuralProperties())
             {
                 if (EdmHelpers.IsNotSelectable(property, pathProperty, structuredType, edmModel,
-                    validatorContext.Context.DefaultQuerySettings.EnableSelect))
+                    validatorContext.Context.DefaultQueryConfigurations.EnableSelect))
                 {
                     throw new ODataException(Error.Format(SRResources.NotSelectablePropertyUsedInSelect, property.Name));
                 }
@@ -400,7 +400,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 // TODO: OrderByModelLimitationsValidator is used already. but we should use IOrderbyQueryValidator to validate.
                 // Should change it later.
                 OrderByModelLimitationsValidator orderByQueryValidator =
-                   new OrderByModelLimitationsValidator(validatorContext.Context, validatorContext.Context.DefaultQuerySettings.EnableOrderBy);
+                   new OrderByModelLimitationsValidator(validatorContext.Context, validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy);
 
                 orderByQueryValidator.TryValidate(validatorContext.Property, validatorContext.StructuredType, orderByClause, false);
             }
@@ -420,10 +420,10 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 IEdmModel edmModel = validatorContext.Context.Model;
                 IEdmProperty property = validatorContext.Property;
                 IEdmStructuredType structuredType = validatorContext.StructuredType;
-                DefaultQuerySettings settings = validatorContext.Context.DefaultQuerySettings;
+                DefaultQueryConfigurations configs = validatorContext.Context.DefaultQueryConfigurations;
 
                 int maxTop;
-                if (EdmHelpers.IsTopLimitExceeded(property, structuredType, edmModel, (int)topOption.Value, settings, out maxTop))
+                if (EdmHelpers.IsTopLimitExceeded(property, structuredType, edmModel, (int)topOption.Value, configs, out maxTop))
                 {
                     throw new ODataException(Error.Format(SRResources.SkipTopLimitExceeded, maxTop, AllowedQueryOptions.Top, topOption.Value));
                 }
@@ -452,9 +452,9 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 IEdmModel edmModel = validatorContext.Context.Model;
                 IEdmProperty property = validatorContext.Property;
                 IEdmStructuredType structuredType = validatorContext.StructuredType;
-                DefaultQuerySettings settings = validatorContext.Context.DefaultQuerySettings;
+                DefaultQueryConfigurations configs = validatorContext.Context.DefaultQueryConfigurations;
 
-                if (EdmHelpers.IsNotCountable(property, structuredType, edmModel, settings.EnableCount))
+                if (EdmHelpers.IsNotCountable(property, structuredType, edmModel, configs.EnableCount))
                 {
                     throw new ODataException(Error.Format(SRResources.NotCountablePropertyUsedForCount, property.Name));
                 }
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             }
             else
             {
-                if (!validatorContext.Context.DefaultQuerySettings.EnableExpand ||
+                if (!validatorContext.Context.DefaultQueryConfigurations.EnableExpand ||
                     (expandConfiguration != null && expandConfiguration.ExpandType == SelectExpandType.Disabled))
                 {
                     throw new ODataException(Error.Format(SRResources.NotExpandablePropertyUsedInExpand, property.Name));

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/SkipTokenQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/SkipTokenQueryValidator.cs
@@ -34,8 +34,8 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             if (skipToken.Context != null)
             {
-                DefaultQuerySettings defaultSetting = skipToken.Context.DefaultQuerySettings;
-                if (!defaultSetting.EnableSkipToken)
+                DefaultQueryConfigurations defaultConfigs = skipToken.Context.DefaultQueryConfigurations;
+                if (!defaultConfigs.EnableSkipToken)
                 {
                     throw new ODataException(Error.Format(SRResources.NotAllowedQueryOption, AllowedQueryOptions.SkipToken, "AllowedQueryOptions"));
                 }

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/TopQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/TopQueryValidator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 property,
                 structuredType,
                 topQueryOption.Context.Model,
-                topQueryOption.Value, topQueryOption.Context.DefaultQuerySettings,
+                topQueryOption.Value, topQueryOption.Context.DefaultQueryConfigurations,
                 out maxTop))
             {
                 throw new ODataException(Error.Format(SRResources.SkipTopLimitExceeded, maxTop,

--- a/test/Microsoft.AspNetCore.OData.TestCommon/MockServiceProvider.cs
+++ b/test/Microsoft.AspNetCore.OData.TestCommon/MockServiceProvider.cs
@@ -7,9 +7,9 @@
 
 using System;
 using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Query;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
-using Microsoft.OData.ModelBuilder.Config;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.TestCommon
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.OData.TestCommon
 
             odataContainerBuilder.AddDefaultODataServices();
 
-            odataContainerBuilder.AddService(ServiceLifetime.Singleton, sp => new DefaultQuerySettings());
+            odataContainerBuilder.AddService(ServiceLifetime.Singleton, sp => new DefaultQueryConfigurations());
 
             odataContainerBuilder.AddService(ServiceLifetime.Singleton, typeof(ODataUriResolver),
                 sp => new UnqualifiedODataUriResolver { EnableCaseInsensitive = true });

--- a/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/ODataOptionsTests.cs
@@ -284,13 +284,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.Equal(0, options.QuerySettings.MaxTop); // Guard
+            Assert.Equal(0, options.QueryConfigurations.MaxTop); // Guard
 
             // Act
             options.SetMaxTop(2);
 
             // Assert
-            Assert.Equal(2, options.QuerySettings.MaxTop.Value);
+            Assert.Equal(2, options.QueryConfigurations.MaxTop.Value);
         }
 
         [Fact]
@@ -298,13 +298,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableExpand); // Guard
+            Assert.False(options.QueryConfigurations.EnableExpand); // Guard
 
             // Act
             options.Expand();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableExpand);
+            Assert.True(options.QueryConfigurations.EnableExpand);
         }
 
         [Fact]
@@ -312,13 +312,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableSelect); // Guard
+            Assert.False(options.QueryConfigurations.EnableSelect); // Guard
 
             // Act
             options.Select();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableSelect);
+            Assert.True(options.QueryConfigurations.EnableSelect);
         }
 
         [Fact]
@@ -326,13 +326,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableFilter); // Guard
+            Assert.False(options.QueryConfigurations.EnableFilter); // Guard
 
             // Act
             options.Filter();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableFilter);
+            Assert.True(options.QueryConfigurations.EnableFilter);
         }
 
         [Fact]
@@ -340,13 +340,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableOrderBy); // Guard
+            Assert.False(options.QueryConfigurations.EnableOrderBy); // Guard
 
             // Act
             options.OrderBy();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableOrderBy);
+            Assert.True(options.QueryConfigurations.EnableOrderBy);
         }
 
         [Fact]
@@ -354,13 +354,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableCount); // Guard
+            Assert.False(options.QueryConfigurations.EnableCount); // Guard
 
             // Act
             options.Count();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableCount);
+            Assert.True(options.QueryConfigurations.EnableCount);
         }
 
         [Fact]
@@ -368,13 +368,13 @@ namespace Microsoft.AspNetCore.OData.Tests
         {
             // Arrange
             ODataOptions options = new ODataOptions();
-            Assert.False(options.QuerySettings.EnableSkipToken); // Guard
+            Assert.False(options.QueryConfigurations.EnableSkipToken); // Guard
 
             // Act
             options.SkipToken();
 
             // Assert
-            Assert.True(options.QuerySettings.EnableSkipToken);
+            Assert.True(options.QueryConfigurations.EnableSkipToken);
         }
         #endregion
 

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -102,7 +102,7 @@ public class Microsoft.AspNetCore.OData.ODataOptions {
 	bool EnableAttributeRouting  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
 	bool EnableNoDollarQueryOptions  { public get; public set; }
-	Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings QuerySettings  { public get; }
+	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
 	[
 	TupleElementNamesAttribute(),
 	]
@@ -1271,6 +1271,18 @@ public class Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser : I
 	public virtual System.Threading.Tasks.Task`1[[System.String]] ParseAsync (Microsoft.AspNetCore.Http.HttpRequest request)
 }
 
+public class Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations {
+	public DefaultQueryConfigurations ()
+
+	bool EnableCount  { public get; public set; }
+	bool EnableExpand  { public get; public set; }
+	bool EnableFilter  { public get; public set; }
+	bool EnableOrderBy  { public get; public set; }
+	bool EnableSelect  { public get; public set; }
+	bool EnableSkipToken  { public get; public set; }
+	System.Nullable`1[[System.Int32]] MaxTop  { public get; public set; }
+}
+
 public class Microsoft.AspNetCore.OData.Query.DefaultSkipTokenHandler : Microsoft.AspNetCore.OData.Query.SkipTokenHandler {
 	public DefaultSkipTokenHandler ()
 
@@ -1353,7 +1365,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryContext {
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, Microsoft.OData.UriParser.ODataPath path)
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, System.Type elementClrType, Microsoft.OData.UriParser.ODataPath path)
 
-	Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings DefaultQuerySettings  { public get; }
+	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations DefaultQueryConfigurations  { public get; }
 	System.Type ElementClrType  { public get; }
 	Microsoft.OData.Edm.IEdmType ElementType  { public get; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -102,7 +102,7 @@ public class Microsoft.AspNetCore.OData.ODataOptions {
 	bool EnableAttributeRouting  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
 	bool EnableNoDollarQueryOptions  { public get; public set; }
-	Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings QuerySettings  { public get; }
+	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
 	[
 	TupleElementNamesAttribute(),
 	]
@@ -1271,6 +1271,18 @@ public class Microsoft.AspNetCore.OData.Query.DefaultODataQueryRequestParser : I
 	public virtual System.Threading.Tasks.Task`1[[System.String]] ParseAsync (Microsoft.AspNetCore.Http.HttpRequest request)
 }
 
+public class Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations {
+	public DefaultQueryConfigurations ()
+
+	bool EnableCount  { public get; public set; }
+	bool EnableExpand  { public get; public set; }
+	bool EnableFilter  { public get; public set; }
+	bool EnableOrderBy  { public get; public set; }
+	bool EnableSelect  { public get; public set; }
+	bool EnableSkipToken  { public get; public set; }
+	System.Nullable`1[[System.Int32]] MaxTop  { public get; public set; }
+}
+
 public class Microsoft.AspNetCore.OData.Query.DefaultSkipTokenHandler : Microsoft.AspNetCore.OData.Query.SkipTokenHandler {
 	public DefaultSkipTokenHandler ()
 
@@ -1353,7 +1365,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryContext {
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, Microsoft.OData.UriParser.ODataPath path)
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, System.Type elementClrType, Microsoft.OData.UriParser.ODataPath path)
 
-	Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings DefaultQuerySettings  { public get; }
+	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations DefaultQueryConfigurations  { public get; }
 	System.Type ElementClrType  { public get; }
 	Microsoft.OData.Edm.IEdmType ElementType  { public get; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/EnableQueryAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/EnableQueryAttributeTests.cs
@@ -644,9 +644,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
             HttpRequest request = RequestFactory.Create("Get", "http://localhost/?" + query);
 
             var context = new ODataQueryContext(_model, typeof(QCustomer));
-            context.DefaultQuerySettings.EnableFilter = true;
-            context.DefaultQuerySettings.EnableOrderBy = true;
-            context.DefaultQuerySettings.MaxTop = null;
+            context.DefaultQueryConfigurations.EnableFilter = true;
+            context.DefaultQueryConfigurations.EnableOrderBy = true;
+            context.DefaultQueryConfigurations.MaxTop = null;
             var options = new ODataQueryOptions(context, request);
 
             // Act & Assert

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
             IEdmType edmType = entitySet.Type;
             ODataPath path = new ODataPath(new EntitySetSegment(entitySet));
             ODataQueryContext queryContext = new ODataQueryContext(model, edmType, path);
-            queryContext.DefaultQuerySettings.EnableSkipToken = enableSkipToken;
+            queryContext.DefaultQueryConfigurations.EnableSkipToken = enableSkipToken;
 
             var request = RequestFactory.Create(opt => opt.AddRouteComponents(model));
             ResourceContext resource = new ResourceContext();

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/FilterQueryValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/FilterQueryValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
         public FilterQueryValidatorTests()
         {
             _context = ValidationTestHelper.CreateCustomerContext();
-            _context.DefaultQuerySettings.EnableFilter = true;
+            _context.DefaultQueryConfigurations.EnableFilter = true;
 
             _productContext = ValidationTestHelper.CreateDerivedProductsContext();
             _validator = new MyFilterValidator();

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/OrderByQueryValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/OrderByQueryValidatorTest.cs
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             IEdmModel model = GetEdmModel();
             IEdmEntityType edmType = model.SchemaElements.OfType<IEdmEntityType>().Single(t => t.Name == edmTypeName);
             ODataQueryContext context = new ODataQueryContext(model, edmType);
-            context.DefaultQuerySettings.EnableOrderBy = true;
+            context.DefaultQueryConfigurations.EnableOrderBy = true;
             OrderByQueryOption option = new OrderByQueryOption(query, context);
             ODataValidationSettings settings = new ODataValidationSettings();
 
@@ -289,7 +289,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             IEdmEntitySet entitySet = model.FindDeclaredEntitySet("LimitedEntities");
             Assert.NotNull(entitySet);
             ODataQueryContext context = new ODataQueryContext(model, edmType);
-            context.DefaultQuerySettings.EnableOrderBy = true;
+            context.DefaultQueryConfigurations.EnableOrderBy = true;
 
             OrderByQueryOption option = new OrderByQueryOption(
                 "@p,@q desc",

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SelectExpandQueryValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SelectExpandQueryValidatorTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             model.Model.SetAnnotationValue(model.Customer, new ClrTypeAnnotation(typeof(Customer)));
             _queryContext = new ODataQueryContext(model.Model, typeof(Customer), null);
             _queryContext.RequestContainer = new MockServiceProvider();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             CustomersModelWithInheritance model = new CustomersModelWithInheritance();
             model.Model.SetAnnotationValue(model.Customer, new ClrTypeAnnotation(typeof(Customer)));
             ODataQueryContext queryContext = new ODataQueryContext(model.Model, typeof(Customer));
-            queryContext.DefaultQuerySettings.EnableExpand = true;
+            queryContext.DefaultQueryConfigurations.EnableExpand = true;
             queryContext.RequestContainer = new MockServiceProvider();
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, queryContext);
             selectExpandQueryOption.LevelsMaxLiteralExpansionDepth = 1;
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
             IEdmModel model = builder.GetEdmModel();
             var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
-            context.DefaultQuerySettings.EnableExpand = true;
+            context.DefaultQueryConfigurations.EnableExpand = true;
             context.RequestContainer = new MockServiceProvider();
             var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
             selectExpandQueryOption.LevelsMaxLiteralExpansionDepth = 1;
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
             IEdmModel model = builder.GetEdmModel();
             var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
-            context.DefaultQuerySettings.EnableExpand = true;
+            context.DefaultQueryConfigurations.EnableExpand = true;
             context.RequestContainer = new MockServiceProvider();
             var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
 
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
             IEdmModel model = builder.GetEdmModel();
             var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
-            context.DefaultQuerySettings.EnableExpand = true;
+            context.DefaultQueryConfigurations.EnableExpand = true;
             context.RequestContainer = new MockServiceProvider();
             var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
             selectExpandQueryOption.LevelsMaxLiteralExpansionDepth = 4;
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
             IEdmModel model = builder.GetEdmModel();
             var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
-            context.DefaultQuerySettings.EnableExpand = true;
+            context.DefaultQueryConfigurations.EnableExpand = true;
             context.RequestContainer = new MockServiceProvider();
             var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
 
@@ -256,7 +256,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
             IEdmModel model = builder.GetEdmModel();
             var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
-            context.DefaultQuerySettings.EnableExpand = true;
+            context.DefaultQueryConfigurations.EnableExpand = true;
             context.RequestContainer = new MockServiceProvider();
             var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
             selectExpandQueryOption.LevelsMaxLiteralExpansionDepth = levelsMaxLiteralExpansionDepth;
@@ -274,8 +274,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange
             string expand = "Orders($top=4)";
             SelectExpandQueryValidator validator = new SelectExpandQueryValidator();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
-            _queryContext.DefaultQuerySettings.MaxTop = 2;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.MaxTop = 2;
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, _queryContext);
 
             // Act & Assert
@@ -290,8 +290,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange
             string expand = "Orders($count=true)";
             SelectExpandQueryValidator validator = new SelectExpandQueryValidator();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
-            _queryContext.DefaultQuerySettings.EnableCount = false;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.EnableCount = false;
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, _queryContext);
 
             // Act & Assert
@@ -306,8 +306,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange
             string expand = "Orders($orderby=Amount)";
             SelectExpandQueryValidator validator = new SelectExpandQueryValidator();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
-            _queryContext.DefaultQuerySettings.EnableOrderBy = false;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.EnableOrderBy = false;
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, _queryContext);
 
             // Act & Assert
@@ -322,8 +322,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange
             string expand = "Orders($filter=Amount eq 42)";
             SelectExpandQueryValidator validator = new SelectExpandQueryValidator();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
-            _queryContext.DefaultQuerySettings.EnableFilter = false;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.EnableFilter = false;
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, _queryContext);
 
             // Act & Assert
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange
             string expand = "Orders($expand=Customer($expand=Orders($expand=Customer($expand=Orders($expand=Customer)))))";
             SelectExpandQueryValidator validator = new SelectExpandQueryValidator();
-            _queryContext.DefaultQuerySettings.EnableExpand = true;
+            _queryContext.DefaultQueryConfigurations.EnableExpand = true;
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, _queryContext);
 
             // Act & Assert
@@ -356,7 +356,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             CustomersModelWithInheritance model = new CustomersModelWithInheritance();
             model.Model.SetAnnotationValue(model.Customer, new ClrTypeAnnotation(typeof(Customer)));
             ODataQueryContext queryContext = new ODataQueryContext(model.Model, typeof(Customer));
-            queryContext.DefaultQuerySettings.EnableExpand = true;
+            queryContext.DefaultQueryConfigurations.EnableExpand = true;
             queryContext.RequestContainer = new MockServiceProvider();
             SelectExpandQueryOption selectExpandQueryOption = new SelectExpandQueryOption(null, expand, queryContext);
             IEdmStructuredType customerType =

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SelectExpandQueryValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SelectExpandQueryValidatorTest.cs
@@ -490,7 +490,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             // Arrange & Act & Assert
             IServiceProvider services = new ServiceCollection()
                 .AddSingleton<ISelectExpandQueryValidator, SelectExpandQueryValidator>()
-                .AddSingleton<DefaultQuerySettings>().BuildServiceProvider();
+                .AddSingleton<DefaultQueryConfigurations>().BuildServiceProvider();
             context.RequestContainer = services;
             Assert.NotNull(context.GetSelectExpandQueryValidator());
         }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SkipTokenQueryValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/SkipTokenQueryValidatorTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             ODataValidationSettings settings = new ODataValidationSettings();
 
             ODataQueryContext context = new ODataQueryContext(EdmCoreModel.Instance, typeof(int), null);
-            context.DefaultQuerySettings.EnableSkipToken = false;
+            context.DefaultQueryConfigurations.EnableSkipToken = false;
             SkipTokenQueryOption query = new SkipTokenQueryOption("abc", context);
 
             SkipTokenQueryValidator validator = new SkipTokenQueryValidator();

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/ValidationTestHelper.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/ValidationTestHelper.cs
@@ -29,8 +29,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
                 context.RequestContainer = new MockServiceProvider();
             }
 
-            context.DefaultQuerySettings.EnableOrderBy = true;
-            context.DefaultQuerySettings.MaxTop = null;
+            context.DefaultQueryConfigurations.EnableOrderBy = true;
+            context.DefaultQueryConfigurations.MaxTop = null;
             return context;
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
         {
             ODataQueryContext context = new ODataQueryContext(GetDerivedProductsModel(), typeof(Product), null);
             context.RequestContainer = new MockServiceProvider();
-            context.DefaultQuerySettings.EnableFilter = true;
+            context.DefaultQueryConfigurations.EnableFilter = true;
             return context;
         }
 


### PR DESCRIPTION
fixes #834

1. Add DefaultQueryConfigurations class
2. Use it in ODataOptions (a public api changes)
3. change the related test codes.

Benefit:
1) It's a mistake to use DefaultQuerySetting from ModelBuilder ( I think)
2) Now, we can add other configuration, for example $compute, $search.