### PR TITLE
AutoExpand does not expand beyond non-default MaxExpansionDepth

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -163,6 +164,8 @@ namespace Microsoft.AspNetCore.OData.Query
         internal IEdmStructuredType TargetStructuredType { get; set; }
 
         internal string TargetName { get; set; }
+
+        internal ODataValidationSettings ValidationSettings { get; set; }
 
         private static IEdmNavigationSource GetNavigationSource(IEdmModel model, IEdmType elementType, ODataPath odataPath)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -629,6 +629,8 @@ namespace Microsoft.AspNetCore.OData.Query
                 throw Error.ArgumentNull(nameof(validationSettings));
             }
 
+            this.Context.ValidationSettings = validationSettings;
+
             if (Validator != null)
             {
                 Validator.Validate(this, validationSettings);
@@ -834,6 +836,10 @@ namespace Microsoft.AspNetCore.OData.Query
                 if (originalSelectExpand != null && originalSelectExpand.LevelsMaxLiteralExpansionDepth > 0)
                 {
                     SelectExpand.LevelsMaxLiteralExpansionDepth = originalSelectExpand.LevelsMaxLiteralExpansionDepth;
+                }
+                else if (Context.ValidationSettings != null && Context.ValidationSettings.MaxExpansionDepth > 0)
+                {
+                    SelectExpand.LevelsMaxLiteralExpansionDepth = Context.ValidationSettings.MaxExpansionDepth;
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandController.cs
@@ -5,9 +5,11 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
@@ -72,6 +74,84 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
             }
 
             return Ok(n);
+        }
+    }
+
+    public class EnableQueryMenusController : ODataController
+    {
+        private static readonly List<Menu> menus = new List<Menu>
+        {
+            new Menu
+            {
+                Id = 1,
+                Tabs = new List<Tab>
+                {
+                    new Tab
+                    {
+                        Id = 1,
+                        Items = new List<Item>
+                        {
+                            new Item
+                            {
+                                Id = 1,
+                                Notes = new List<Note>
+                                {
+                                    new Note { Id = 1 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        [EnableQuery(MaxExpansionDepth = 4)]
+        public ActionResult Get()
+        {
+            return Ok(menus);
+        }
+    }
+
+    public class QueryOptionsOfTMenusController : ODataController
+    {
+        private static readonly List<Menu> menus = new List<Menu>
+        {
+            new Menu
+            {
+                Id = 1,
+                Tabs = new List<Tab>
+                {
+                    new Tab
+                    {
+                        Id = 1,
+                        Items = new List<Item>
+                        {
+                            new Item
+                            {
+                                Id = 1,
+                                Notes = new List<Note>
+                                {
+                                    new Note { Id = 1 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        public ActionResult Get(ODataQueryOptions<Menu> queryOptions)
+        {
+            var validationSettings = new ODataValidationSettings
+            {
+                MaxExpansionDepth = 4
+            };
+
+            queryOptions.Validate(validationSettings);
+
+            var result = queryOptions.ApplyTo(menus.AsQueryable());
+            
+            return Ok(result);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandDataModel.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.OData.ModelBuilder;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
@@ -127,5 +128,31 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
         public int Id { get; set; }
 
         public string Description { get; set; }
+    }
+
+    public class Menu
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Tab> Tabs { get; set; }
+    }
+
+    public class Tab
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Item> Items { get; set; }
+    }
+
+    public class Item
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Note> Notes { get; set; }
+    }
+
+    public class Note
+    {
+        public int Id { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandEdmModel.cs
@@ -25,6 +25,11 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
             builder.EntityType<DerivedOrder2>();
             builder.EntitySet<OrderDetail>("OrderDetails");
             builder.EntitySet<People>("People");
+            builder.EntitySet<Menu>("EnableQueryMenus");
+            builder.EntitySet<Menu>("QueryOptionsOfTMenus");
+            builder.EntitySet<Tab>("Tabs");
+            builder.EntitySet<Item>("Items");
+            builder.EntitySet<Note>("Notes");
             IEdmModel model = builder.GetEdmModel();
             return model;
         }


### PR DESCRIPTION
Fixes https://github.com/OData/WebApi/issues/2748

We set the default `MaxExpansionDepth` when the `Validate` method of the `ODataQueryOptions` object is called. The problem currently is that when the `MaxExpansionDepth` is overridden, for instance by assigning the value from the `EnableQuery` attribute (`[EnableQuery(MaxExpansionDepth = 4)]`), we call the `Validate` method before the `AutoExpand` navigation properties have been added to the `SelectExpandQueryOption` object. For that reason, the specified `MaxExpansionDepth` ends up not being respected for the auto-expanded navigation properties.

This pull request fixes that by calling `ODataQueryOptions.AddAutoSelectExpandProperties` prior to validating the `SelectExpand` query option.