### PR TITLE
Fix skiptoken paging issue when combined with $orderby involving nullable property

### DIFF
--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -67,4 +67,52 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
             return Ok(hiredInPeriod);
         }
     }
+
+    public class SkipTokenPagingS1CustomersController : ODataController
+    {
+        private static readonly List<SkipTokenPagingCustomer> customers = new List<SkipTokenPagingCustomer>
+        {
+            new SkipTokenPagingCustomer { Id = 1, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 2, CreditLimit = 2 },
+            new SkipTokenPagingCustomer { Id = 3, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 4, CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 5, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 6, CreditLimit = 35 },
+            new SkipTokenPagingCustomer { Id = 7, CreditLimit = 5 },
+            new SkipTokenPagingCustomer { Id = 8, CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 9, CreditLimit = 25 },
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult<IEnumerable<SkipTokenPagingCustomer>> Get()
+        {
+            return customers;
+        }
+    }
+
+    public class SkipTokenPagingS2CustomersController : ODataController
+    {
+        private readonly List<SkipTokenPagingCustomer> customers = new List<SkipTokenPagingCustomer>
+        {
+            new SkipTokenPagingCustomer { Id = 1, Grade = "A", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 2, Grade = "B", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 3, Grade = "A", CreditLimit = 10 },
+            new SkipTokenPagingCustomer { Id = 4, Grade = "C", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 5, Grade = "A", CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 6, Grade = "C", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 7, Grade = "B", CreditLimit = 5 },
+            new SkipTokenPagingCustomer { Id = 8, Grade = "C", CreditLimit = 25 },
+            new SkipTokenPagingCustomer { Id = 9, Grade = "B", CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 10, Grade = "D", CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 11, Grade = "F", CreditLimit = 35 },
+            new SkipTokenPagingCustomer { Id = 12, Grade = "F", CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 13, Grade = "F", CreditLimit = 55 }
+        };
+
+        [EnableQuery(PageSize = 4)]
+        public ActionResult<IEnumerable<SkipTokenPagingCustomer>> Get()
+        {
+            return customers;
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -32,4 +32,11 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
         public int Id { get; set; }
         public DateTime HireDate { get; set; }
     }
+
+    public class SkipTokenPagingCustomer
+    {
+        public int Id { get; set; }
+        public string Grade { get; set; }
+        public decimal? CreditLimit { get; set; }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
@@ -6,13 +6,17 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
@@ -28,8 +32,10 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
         protected static void UpdateConfigureServices(IServiceCollection services)
         {
             IEdmModel edmModel = GetEdmModel();
-            services.ConfigureControllers(typeof(ServerSidePagingCustomersController), typeof(ServerSidePagingEmployeesController));
-            services.AddControllers().AddOData(opt => opt.Expand().AddRouteComponents("{a}", edmModel));
+            services.ConfigureControllers(
+                typeof(ServerSidePagingCustomersController),
+                typeof(ServerSidePagingEmployeesController));
+            services.AddControllers().AddOData(opt => opt.Expand().OrderBy().AddRouteComponents("{a}", edmModel));
         }
 
         protected static IEdmModel GetEdmModel()
@@ -113,6 +119,313 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
                 "/prefix/ServerSidePagingEmployees/GetEmployeesHiredInPeriod(fromDate=@fromDate,toDate=@toDate)" +
                 "?%40fromDate=2023-01-07T00%3A00%3A00%2B00%3A00&%40toDate=2023-05-07T00%3A00%3A00%2B00%3A00&$skip=3",
                 content);
+        }
+    }
+
+    public class SkipTokenPagingTests : WebApiTestBase<SkipTokenPagingTests>
+    {
+        public SkipTokenPagingTests(WebApiTestFixture<SkipTokenPagingTests> fixture)
+            : base(fixture)
+        {
+        }
+
+        // following the Fixture convention.
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            IEdmModel model = GetEdmModel();
+            services.ConfigureControllers(
+                typeof(SkipTokenPagingS1CustomersController),
+                typeof(SkipTokenPagingS2CustomersController));
+            services.AddControllers().AddOData(opt => opt.Expand().OrderBy().SkipToken().AddRouteComponents("{a}", model));
+        }
+
+        protected static IEdmModel GetEdmModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<SkipTokenPagingCustomer>("SkipTokenPagingS1Customers");
+            builder.EntitySet<SkipTokenPagingCustomer>("SkipTokenPagingS2Customers");
+
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullableProperty()
+        {
+            HttpClient client = CreateClient();
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, decimal?, int, decimal?>>
+            {
+                Tuple.Create<int, decimal?, int, decimal?> (1, null, 3, null),
+                Tuple.Create<int, decimal?, int, decimal?> (5, null, 2, 2),
+                Tuple.Create<int, decimal?, int, decimal?> (7, 5, 9, 25),
+                Tuple.Create<int, decimal?, int, decimal?>(4, 30, 6, 35)
+            };
+
+            string requestUri = "/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt0 = testData.Item1;
+                decimal? creditLimitAt0 = testData.Item2;
+                int idAt1 = testData.Item3;
+                decimal? creditLimitAt1 = testData.Item4;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt1 != null ? creditLimitAt1.ToString() : "null", ",Id-", idAt1);
+
+                // Act
+                response = await client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt0, (pageResult[0] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt0, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt1, (pageResult[1] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(8, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal(50, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullablePropertyDescending()
+        {
+            HttpClient client = CreateClient();
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, decimal?>>
+            {
+                Tuple.Create<int, decimal ?> (6, 35),
+                Tuple.Create<int, decimal?> (9, 25),
+                Tuple.Create<int, decimal?> (2, 2),
+                Tuple.Create<int, decimal?>(3, null)
+            };
+
+            string requestUri = "/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit desc";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt1 = testData.Item1;
+                decimal? creditLimitAt1 = testData.Item2;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt1 != null ? creditLimitAt1.ToString() : "null", ",Id-", idAt1);
+
+                // Act
+                response = await client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt1, (pageResult[1] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit%20desc&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(5, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Null((pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNonNullablePropertyThenByNullableProperty()
+        {
+            HttpClient client = CreateClient();
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, string, decimal?>>
+            {
+                Tuple.Create<int, string, decimal?> (2, "B", null),
+                Tuple.Create<int, string, decimal?> (6, "C", null),
+                Tuple.Create<int, string, decimal?> (11, "F", 35),
+            };
+
+            string requestUri = "/prefix/SkipTokenPagingS2Customers?$orderby=Grade,CreditLimit";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt3 = testData.Item1;
+                string gradeAt3 = testData.Item2;
+                decimal? creditLimitAt3 = testData.Item3;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=Grade-%27", gradeAt3, "%27,CreditLimit-", creditLimitAt3 != null ? creditLimitAt3.ToString() : "null", ",Id-", idAt3);
+
+                // Act
+                response = await client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(4, pageResult.Count);
+                Assert.Equal(idAt3, (pageResult[3] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(gradeAt3, (pageResult[3] as JObject)["Grade"].ToObject<string>());
+                Assert.Equal(creditLimitAt3, (pageResult[3] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS2Customers?$orderby=Grade%2CCreditLimit&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(13, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal("F", (pageResult[0] as JObject)["Grade"].ToObject<string>());
+            Assert.Equal(55, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullablePropertyThenByNonNullableProperty()
+        {
+            HttpClient client = CreateClient();
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, string, decimal?>>
+            {
+                Tuple.Create<int, string, decimal?> (6, "C", null),
+                Tuple.Create<int, string, decimal?> (5, "A", 30),
+                Tuple.Create<int, string, decimal?> (10, "D", 50),
+            };
+
+            string requestUri = "/prefix/SkipTokenPagingS2Customers?$orderby=CreditLimit,Grade";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt3 = testData.Item1;
+                string gradeAt3 = testData.Item2;
+                decimal? creditLimitAt3 = testData.Item3;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt3 != null ? creditLimitAt3.ToString() : "null", ",Grade-%27", gradeAt3, "%27", ",Id-", idAt3);
+
+                // Act
+                response = await client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(4, pageResult.Count);
+                Assert.Equal(idAt3, (pageResult[3] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(gradeAt3, (pageResult[3] as JObject)["Grade"].ToObject<string>());
+                Assert.Equal(creditLimitAt3, (pageResult[3] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS2Customers?$orderby=CreditLimit%2CGrade&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(13, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal("F", (pageResult[0] as JObject)["Grade"].ToObject<string>());
+            Assert.Equal(55, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

*This pull request fixes https://github.com/OData/WebApi/issues/1943, fixes https://github.com/OData/WebApi/issues/2041, and fixes https://github.com/OData/WebApi/issues/2561*

## Description
Consider a simple scenario involving a data sample comprising of `Id` key field and a non-unique nullable field `CreditLimit`:
| Id | CreditLimit |
| -- | ------------ |
| 1 | null |
| 2 | 2 |
| 3 | null |
| 4 | 30 |
| 5 | null |
| 6 | 35 |
| 7 | 5 |
| 8 | 50 |
| 9 | 25 |

From the controller action, we could configure a page size of 2:
```csharp
[EnableQuery(PageSize = 2)]
public ActionResult<IEnumerable<S1Customer>> Get()
{
    return new List<S1Customer>
    {
        new S1Customer { Id = 1, CreditLimit = null },
        new S1Customer { Id = 2, CreditLimit = 2 },
        new S1Customer { Id = 3, CreditLimit = null },
        new S1Customer { Id = 4, CreditLimit = 30 },
        new S1Customer { Id = 5, CreditLimit = null },
        new S1Customer { Id = 6, CreditLimit = 35 },
        new S1Customer { Id = 7, CreditLimit = 5 },
        new S1Customer { Id = 8, CreditLimit = 50 },
        new S1Customer { Id = 9, CreditLimit = 25 },
    };
}
```

When the data sample is ordered by `CreditLimit` field (`$orderby=CreditLimit`), and then internally by `Id` (for uniqueness and predictability - stable ordering), the ordered data sample would look at follows:
| CreditLimit | Id |
| ------------ | -- |
| null | 1 |
| null | 3 |
| null | 5 |
| 2 | 2 |
| 5 | 7 |
| 25 | 9 |
| 30 | 4 |
| 35 | 6 |
| 50 | 8 |

If we query for the `S1Customers` entity set and order by `CreditLimit`, we get the following response:
```http
GET: http://localhost:5000/odata/S1Customers?$orderby=CreditLimit
```
#### Response:
```json
{
    "@odata.context": "http://localhost:5000/odata/$metadata#S1Customers",
    "value": [
        {
            "Id": 1,
            "CreditLimit": null
        },
        {
            "Id": 3,
            "CreditLimit": null
        }
    ],
    "@odata.nextLink": "http://localhost:5000/odata/S1Customers?$orderby=CreditLimit&$skiptoken=CreditLimit-null,Id-3"
}
```

While the response is correct (including the next-link), if we attempt to use the returned next link to fetch the next batch of records, the following error message is returned:
```
The query specified in the URI is not valid. The binary operator GreaterThan is not defined for the types 'System.Nullable`1[System.Decimal]' and 'Microsoft.OData.ODataNullValue'.
```
What is happening here is that we’re mishandling the null value and attempting to apply a greater-than operator between the nullable `CreditLimit` field and the `ODataNullValue`.

This pull request fixes this issue by ensuring that a valid `Where` expression is composed as follows:
- for skiptoken value **`CreditLimit-null,Id-3`** in ascending order scenario - `$orderby=CreditLimit`, we compose the `Where` expression as: **`(CreditLimit ne null OR (CreditLimit eq null AND Id gt 3))`**
- for skiptoken value **`CreditLimit-2,Id-2`** in ascending order scenario - `$orderby=CreditLimit`, we compose the `Where` expression as: **`(CreditLimit gt 2 OR (CreditLimit eq 2 AND Id gt 2))`**
- for skiptoken value **`CreditLimit-null,Id-3`** in descending order scenario - `$orderby=CreditLimit desc`, we compose the `Where` expression as: **`(CreditLimit eq null AND Id gt 3)`**
- for skiptoken value **`CreditLimit-35,Id-6`** in descending order scenario - `$orderby=CreditLimit desc`, we compose the `Where` expression as: **`(CreditLimit lt 35 OR (CreditLimit eq 35 AND Id gt 6))`**


Consider also a more advanced scenario involving a data sample comprising of `Id` key field, a non-nullable field `Grade`, and a non-unique nullable field `CreditLimit`:
| Id | Grade | CreditLimit |
| -- | ----- | ------------ |
| 1 | A | null |
| 2 | B | null |
| 3 | A | 10 |
| 4 | C | null |
| 5 | A | 30 |
| 6 | C | null |
| 7 | B | 5 |
| 8 | C | 25 |
| 9 | B | 50 |
| 10 | D | 50 |
| 11 | F | 35 |
| 12 | F | 30 |
| 13 | F | 55 |

From the controller action, we would configure a page size of 4 as follows:
```csharp
[EnableQuery(PageSize = 4)]
public ActionResult<IEnumerable<S2Customer>> Get()
{
    return new List<S2Customer>
    {
        new S2Customer { Id = 1, Grade = "A", CreditLimit = null },
        new S2Customer { Id = 2, Grade = "B", CreditLimit = null },
        new S2Customer { Id = 3, Grade = "A", CreditLimit = 10 },
        new S2Customer { Id = 4, Grade = "C", CreditLimit = null },
        new S2Customer { Id = 5, Grade = "A", CreditLimit = 30 },
        new S2Customer { Id = 6, Grade = "C", CreditLimit = null },
        new S2Customer { Id = 7, Grade = "B", CreditLimit = 5 },
        new S2Customer { Id = 8, Grade = "C", CreditLimit = 25 },
        new S2Customer { Id = 9, Grade = "B", CreditLimit = 50 },
        new S2Customer { Id = 10, Grade = "D", CreditLimit = 50 },
        new S2Customer { Id = 11, Grade = "F", CreditLimit = 35 },
        new S2Customer { Id = 12, Grade = "F", CreditLimit = 30 }
    };
}
```

When the data sample is ordered by `Grade` and then by `CreditLimit` field ($orderby=Grade,CreditLimit), and then internally by `Id` (for uniqueness and predictability - stable ordering), the ordered data sample would look at follows:
| Grade | CreditLimit | Id |
| ----- | ----------- | -- |
| A | null | 1 |
| A | 10 | 3 |
| A | 30 | 5 |
| B | null | 2 |
| B | 5 | 7 |
| B | 50 | 9 |
| C | null | 4 |
| C | null | 6 |
| C | 25 | 8 |
| D | 50 | 10 |
| F | 30 | 12 |
| F | 35 | 11 |
| F | 55 | 13 |

If we query for the `S2Customers` entity set and orderby `Grade` and then by `CreditLimit`, we get the following response:
```http
GET: http://localhost:5000/odata/S2Customers?$orderby=Grade,CreditLimit
```
#### Response
```json
{
    "@odata.context": "http://localhost:5000/odata/$metadata#S2Customers",
    "value": [
        {
            "Id": 1,
            "Grade": "A",
            "CreditLimit": null
        },
        {
            "Id": 3,
            "Grade": "A",
            "CreditLimit": 10.00
        },
        {
            "Id": 5,
            "Grade": "A",
            "CreditLimit": 30.00
        },
        {
            "Id": 2,
            "Grade": "B",
            "CreditLimit": null
        }
    ],
    "@odata.nextLink": "http://localhost:5000/odata/S2Customers?$orderby=Grade%2CCreditLimit&$skiptoken=Grade-%27B%27,CreditLimit-null,Id-2"
}
```

Again, the response is correct (including the next-link), but if we attempt to use the returned next link to fetch the next batch of records, the following error message is returned:
```
The query specified in the URI is not valid. The binary operator GreaterThan is not defined for the types 'System.Nullable`1[System.Decimal]' and 'Microsoft.OData.ODataNullValue'.
```

Again, this is due to mishandling of the null value.

In this pull request we ensure that a valid `Where` expression is composed as follows:
- for skiptoken value of **`Grade-B,CreditLimit-null,Id-2`** in ascending order scenario - `$orderby=Grade,CreditLimit`, we compose the `Where` expression as: **`Grade gt B OR (Grade eq B AND (CreditLimit ne null OR (CreditLimit eq null AND Id gt 2)))`**
- for skiptoken value of **`Grade-F,CreditLimit-30,Id-12`** in ascending order scenario - `$orderby=Grade,CreditLimit`, we compose the `Where` expression as: **`Grade gt F OR (Grade eq F AND (CreditLimit gt 30 OR (CreditLimit eq 30 AND Id gt 12)))`**
- for skiptoken value of **`CreditLimit-null,Grade-C,Id-6`** in ascending order scenario - `$orderby=CreditLimit,Grade`, we compose the `Where` expression as: **`CreditLimit ne null OR (CreditLimit eq null AND (Grade gt C OR (Grade eq C AND Id gt 6)))`**
- for skiptoken value of **`CreditLimit-30,Grade-A,Id-5`** in ascending order scenario - `$orderby=CreditLimit,Grade`, we compose the `Where` expression as: **`CreditLimit gt 30 OR (CreditLimit eq 30 AND (Grade gt A OR (Grade eq A AND Id gt 5)))`**