### PR TITLE
tsharp/fix next page issue

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/GetNextPageHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/GetNextPageHelper.cs
@@ -53,10 +53,6 @@ namespace Microsoft.AspNetCore.OData.Extensions
                             {
                                 value = (top - pageSize).ToString(CultureInfo.InvariantCulture);
                             }
-                            else
-                            {
-                                return null;
-                            }
                         }
                         break;
                     case "$skip":


### PR DESCRIPTION
There is an issue with client specified top sizes. When it is explicitly specified and meets the `top > pageSize` condition, a null url will be returned which is invalid. This code seems to have a purpose to right size the top statement.