### PR TITLE
ResultHelpers.GetEntityType can now resolve the IEdmTypeReference fro…

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.AspNetCore.OData.Formatter.Value;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
@@ -171,7 +172,15 @@ namespace Microsoft.AspNetCore.OData.Results
         private static IEdmEntityTypeReference GetEntityType(IEdmModel model, object entity)
         {
             Type entityType = entity.GetType();
-            IEdmTypeReference edmType = model.GetEdmTypeReference(entityType);
+            IEdmTypeReference edmType;
+            if (entity is IEdmObject edmObject)
+            {
+                edmType = edmObject.GetEdmType();
+            }
+            else
+            {
+                edmType = model.GetEdmTypeReference(entityType);
+            }
             if (edmType == null)
             {
                 throw Error.InvalidOperation(SRResources.ResourceTypeNotInModel, entityType.FullName);

--- a/test/Microsoft.AspNetCore.OData.Tests/Results/ResultHelpersTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Results/ResultHelpersTest.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Formatter.Value;
 using Microsoft.AspNetCore.OData.Results;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.AspNetCore.OData.Tests.Extensions;
@@ -42,6 +44,22 @@ namespace Microsoft.AspNetCore.OData.Tests.Results
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => ResultHelpers.GenerateODataLink(request, _entity, isEntityId: true),
                 "The Id link builder for the entity set 'Customers' returned null. An Id link is required for the OData-EntityId header.");
+        }
+
+        [Fact]
+        public void GenerateODataLink_CanResolveIEdmObject()
+        {
+            // Arrange
+            var model = new CustomersModelWithInheritance();
+            var path = new ODataPath(new EntitySetSegment(model.Customers));
+            var request = RequestFactory.Create(model.Model, path: path);
+            request.ODataFeature().BaseAddress = "http://localhost";
+            var edmEntity = new EdmEntityObject(model.Customer);
+            edmEntity.TrySetPropertyValue("ID", 1);
+
+            // Act & Assert
+            Assert.Equal("http://localhost/Customers(1)",
+                ResultHelpers.GenerateODataLink(request, edmEntity, isEntityId: true).AbsoluteUri);
         }
 
         [Fact]


### PR DESCRIPTION
`ResultHelpers.GetEntityType` can now resolve the `IEdmTypeReference` from an `IEdmObject`. This is a fix for #893