### PR TITLE
#907: Enable read the untyped collection

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -775,6 +775,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             {
                 ODataResourceWrapper resourceWrapper = CreateResourceWrapper(elementType, refLinkWrapper, readContext);
                 resourceSetWrapper.Resources.Add(resourceWrapper);
+                resourceSetWrapper.Items.Add(resourceWrapper); // in the next major release, we should only use 'Items'.
             }
 
             return resourceSetWrapper;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataPrimitiveWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataPrimitiveWrapper.cs
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataPrimitiveWrapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData;
+
+namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
+{
+    /// <summary>
+    /// Encapsulates <see cref="ODataPrimitiveValue"/> in an Untyped (declared or undeclared) collection.
+    /// </summary>
+    public class ODataPrimitiveWrapper : ODataItemWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ODataPrimitiveWrapper"/>.
+        /// </summary>
+        /// <param name="value">The wrapped primitive value.</param>
+        public ODataPrimitiveWrapper(ODataPrimitiveValue value)
+        {
+            Value = value ?? throw Error.ArgumentNull(nameof(value));
+        }
+
+        /// <summary>
+        /// Gets the wrapped <see cref="ODataPrimitiveValue"/>.
+        /// </summary>
+        public ODataPrimitiveValue Value { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
@@ -238,6 +238,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
                 if (parentResourceSet != null)
                 {
                     parentResourceSet.Resources.Add(resourceWrapper);
+                    parentResourceSet.Items.Add(resourceWrapper);// in the next major release, we should only use 'Items'.
                 }
                 else if (parentDeleteResourceSet != null)
                 {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
             if (itemsStack.Count > 0)
             {
                 ODataItemWrapper peekedWrapper = itemsStack.Peek();
-                if (peekWrapper is ODataNestedResourceInfoWrapper parentNestedResourceInfo)
+                if (peekedWrapper is ODataNestedResourceInfoWrapper parentNestedResourceInfo)
                 {
                     Contract.Assert(parentNestedResourceInfo.NestedResourceInfo.IsCollection == true, "Only collection nested properties can contain resource set as their child.");
                     Contract.Assert(parentNestedResourceInfo.NestedItems.Count == 0, "Each nested property can contain only one resource set as its direct child.");
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
                 }
                 else
                 {
-                    ODataResourceSetWrapper parentResourceSet = (ODataResourceSetWrapper)peekWrapper;
+                    ODataResourceSetWrapper parentResourceSet = (ODataResourceSetWrapper)peekedWrapper;
                     parentResourceSet.Items.Add(resourceSetWrapper);
                 }
             }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataReaderExtensions.cs
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
             ODataResourceSetWrapper resourceSetWrapper = new ODataResourceSetWrapper(resourceSet);
             if (itemsStack.Count > 0)
             {
-                ODataItemWrapper peekWrapper = itemsStack.Peek();
+                ODataItemWrapper peekedWrapper = itemsStack.Peek();
                 if (peekWrapper is ODataNestedResourceInfoWrapper parentNestedResourceInfo)
                 {
                     Contract.Assert(parentNestedResourceInfo.NestedResourceInfo.IsCollection == true, "Only collection nested properties can contain resource set as their child.");

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataResourceSetWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataResourceSetWrapper.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
         public ODataResourceSetWrapper(ODataResourceSet resourceSet)
         {
             Resources = new List<ODataResourceWrapper>();
+            Items = new List<ODataItemWrapper>();
             ResourceSet = resourceSet;
         }
 
@@ -35,5 +36,13 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
         /// Resource set only contains resources.
         /// </summary>
         public IList<ODataResourceWrapper> Resources { get; }
+
+        /// <summary>
+        /// Gets the nested items of this ResourceSet.
+        /// Since we have 'Resources' to contain ODataResource items in the collection (we have to keep it avoid breaking changes).
+        /// This list is used to hold other items, for example a primitive or a collection, etc.
+        /// In the next major release, we should combine 'Resources' and 'Items' together.
+        /// </summary>
+        public IList<ODataItemWrapper> Items { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataResourceSetWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Wrapper/ODataResourceSetWrapper.cs
@@ -40,7 +40,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Wrapper
         /// <summary>
         /// Gets the nested items of this ResourceSet.
         /// Since we have 'Resources' to contain ODataResource items in the collection (we have to keep it avoid breaking changes).
-        /// This list is used to hold other items, for example a primitive or a collection, etc.
+        /// This list is used to hold other items also, for example a primitive or a collection, etc.
+        /// I assume the order of items does matter, so 'Items' contains all 'Resources' item to keep the same order.
         /// In the next major release, we should combine 'Resources' and 'Items' together.
         /// </summary>
         public IList<ODataItemWrapper> Items { get; }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5989,7 +5989,8 @@
             <summary>
             Gets the nested items of this ResourceSet.
             Since we have 'Resources' to contain ODataResource items in the collection (we have to keep it avoid breaking changes).
-            This list is used to hold other items, for example a primitive or a collection, etc.
+            This list is used to hold other items also, for example a primitive or a collection, etc.
+            I assume the order of items does matter, so 'Items' contains all 'Resources' item to keep the same order.
             In the next major release, we should combine 'Resources' and 'Items' together.
             </summary>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5884,6 +5884,22 @@
             Gets the nested items that are part of this nested resource info.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper">
+            <summary>
+            Encapsulates <see cref="T:Microsoft.OData.ODataPrimitiveValue"/> in an Untyped (declared or undeclared) collection.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper.#ctor(Microsoft.OData.ODataPrimitiveValue)">
+            <summary>
+            Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper"/>.
+            </summary>
+            <param name="value">The wrapped primitive value.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper.Value">
+            <summary>
+            Gets the wrapped <see cref="T:Microsoft.OData.ODataPrimitiveValue"/>.
+            </summary>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataReaderExtensions">
             <summary>
             Extension methods for <see cref="T:Microsoft.OData.ODataReader"/>.
@@ -5967,6 +5983,14 @@
             <summary>
             Gets the nested resources of this ResourceSet.
             Resource set only contains resources.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper.Items">
+            <summary>
+            Gets the nested items of this ResourceSet.
+            Since we have 'Resources' to contain ODataResource items in the collection (we have to keep it avoid breaking changes).
+            This list is used to hold other items, for example a primitive or a collection, etc.
+            In the next major release, we should combine 'Resources' and 'Items' together.
             </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper">

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -626,10 +626,14 @@ Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedResourceInfoWrapper
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedResourceInfoWrapper.NestedItems.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper>
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedResourceInfoWrapper.NestedResourceInfo.get -> Microsoft.OData.ODataNestedResourceInfo
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedResourceInfoWrapper.ODataNestedResourceInfoWrapper(Microsoft.OData.ODataNestedResourceInfo nestedInfo) -> void
+Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper
+Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper.ODataPrimitiveWrapper(Microsoft.OData.ODataPrimitiveValue value) -> void
+Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper.Value.get -> Microsoft.OData.ODataPrimitiveValue
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataReaderExtensions
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetBaseWrapper
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetBaseWrapper.ODataResourceSetBaseWrapper() -> void
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper
+Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper.Items.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper>
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper.ODataResourceSetWrapper(Microsoft.OData.ODataResourceSet resourceSet) -> void
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper.Resources.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper>
 Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper.ResourceSet.get -> Microsoft.OData.ODataResourceSet

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataPrimitiveWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataPrimitiveWrapperTests.cs
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataPrimitiveWrapperTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData.Formatter.Wrapper;
+using Microsoft.AspNetCore.OData.Tests.Commons;
+using Microsoft.OData;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
+{
+    public class ODataPrimitiveWrapperTests
+    {
+        [Fact]
+        public void Ctor_ThrowsArgumentNull_PrimitiveValue()
+        {
+            // Arrange & Act & Assert
+            ExceptionAssert.ThrowsArgumentNull(() => new ODataPrimitiveWrapper(null), "value");
+        }
+
+        [Fact]
+        public void Ctor_Sets_CorrectProperties()
+        {
+            // Arrange & Act & Assert
+            ODataPrimitiveValue oDataPrimitiveValue = new ODataPrimitiveValue(42);
+
+            // Act
+            ODataPrimitiveWrapper wrapper = new ODataPrimitiveWrapper(oDataPrimitiveValue);
+
+            // Assert
+            Assert.Same(oDataPrimitiveValue, wrapper.Value);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
@@ -249,8 +249,30 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                             });
                     });
 
-                Assert.Equal(2, nestedResourceSetWrapper.Items.Count);
+                Assert.Equal(4, nestedResourceSetWrapper.Items.Count);
                 Assert.Collection(nestedResourceSetWrapper.Items,
+                    p =>
+                    {
+                        Assert.Null(p); // since it's a 'null' value in collection,
+                                        // ODL reads it as ResourceStart, ResourceEnd with null item.
+                    },
+                    p =>
+                    {
+                        ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(p);
+                        Assert.Empty(resourceWrapper.NestedResourceInfos);
+                        Assert.NotNull(resourceWrapper.Resource);
+                        Assert.Collection(resourceWrapper.Resource.Properties,
+                            p =>
+                            {
+                                Assert.Equal("Key1", p.Name);
+                                Assert.Equal("Value1", p.Value);
+                            },
+                            p =>
+                            {
+                                Assert.Equal("Key2", p.Name);
+                                Assert.True((bool)p.Value);
+                            });
+                    },
                     p =>
                     {
                         ODataPrimitiveWrapper primitiveWrapper = Assert.IsType<ODataPrimitiveWrapper>(p);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
@@ -1,0 +1,450 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataReaderExtensionsTests.Untyped.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Formatter.Wrapper;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
+{
+    /// <summary>
+    /// Here contains reading test cases for 'Edm.Untyped' (Declared or undeclared)
+    /// </summary>
+    public partial class ODataReaderExtensionsTests
+    {
+        private static readonly EdmModel UntypedModel = BuildUntypedModel();
+
+        private static EdmModel BuildUntypedModel()
+        {
+            EdmModel model = new EdmModel();
+
+            // Open Complex Type (Info)
+            EdmComplexType info = new EdmComplexType("NS", "Info", null, false, isOpen: true);
+            model.AddElement(info);
+
+            // Open Entity Type (Person)
+            /*
+             <EntityType Name="Person" IsOpen="True" >
+                <Property Name="ID" Type="Edm.Int32" />
+                <Property Name="Name" Type="Edm.String" />
+                <Property Name="Data" Type="Edm.Untyped" />
+                <Property Name="Infos" Type="Collection(NS.Info)" />
+             </EntityType>
+             */
+            EdmEntityType person = new EdmEntityType("NS", "Person", null, false, isOpen: true);
+            model.AddElement(person);
+            person.AddKeys(person.AddStructuralProperty("ID", EdmCoreModel.Instance.GetInt32(false)));
+            person.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(true));
+            person.AddStructuralProperty("Data", EdmCoreModel.Instance.GetUntyped(true));
+            person.AddStructuralProperty("Infos", new EdmCollectionTypeReference
+                (new EdmCollectionType(new EdmComplexTypeReference(info, false))));
+
+            EdmEntityContainer defaultContainer = new EdmEntityContainer("NS", "Container");
+            model.AddElement(defaultContainer);
+            EdmEntitySet people = defaultContainer.AddEntitySet("People", person);
+            return model;
+        }
+
+        public static TheoryDataSet<string, object> PrimitiveValueCases
+        {
+            get
+            {
+                var data = new TheoryDataSet<string, object>
+                {
+                    { "42", (decimal)42 }, // why it's decimal? see https://github.com/OData/odata.net/issues/2657
+                    { "9.19", (decimal)9.19 },
+                    { "3.1415926535897931", 3.1415926535897931m },
+                    { "true", true },
+                    { "false", false },
+                    { "\"false\"", "false" },
+                    { "\"a simple string\"", "a simple string" },
+
+                     // looks like a Guid string, but it's string
+                    { "\"969D9BB3-1A1D-40C7-8716-4E29CFE02E81\"", "969D9BB3-1A1D-40C7-8716-4E29CFE02E81" },
+                    { "\"Red\"", "Red" }, // looks like a Enum string, but it's string
+                    { "null", null }
+                };
+
+                return data;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PrimitiveValueCases))]
+        public async Task ReadOpenResource_WithUntypedPrimitiveValue_WorksAsExpected(string value, object expect)
+        {
+            // Arrange
+            string payload =
+            "{" +
+                "\"ID\": 17," +
+                $"\"Data\": {value}," +
+                $"\"Dynamic\": {value}" +
+            "}";
+
+            IEdmEntitySet people = UntypedModel.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(people, people.EntityType());
+            ODataItemWrapper item = await ReadUntypedPayloadAsync(payload, UntypedModel, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
+            Assert.Empty(resourceWrapper.NestedResourceInfos);
+
+            Assert.Collection(resourceWrapper.Resource.Properties,
+                p =>
+                {
+                    // Declared property with 'Edm.Int32'
+                    Assert.Equal("ID", p.Name);
+                    Assert.Equal(17, p.Value);
+                },
+                p =>
+                {
+                    // Declared property with 'Edm.Untyped'
+                    Assert.Equal("Data", p.Name);
+                    Assert.Equal(expect, p.Value);
+                },
+                p =>
+                {
+                    // Un-declared (dynamic) property
+                    Assert.Equal("Dynamic", p.Name);
+                    Assert.Equal(expect, p.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadOpenResource_WithUntypedResourceValue_WorksAsExpected()
+        {
+            // Arrange
+            string resourceValue = "{\"Key1\": \"Value1\", \"Key2\": true}";
+            string payload =
+            "{" +
+                "\"ID\": 17," +
+                $"\"Data\": {resourceValue}," +
+                $"\"Dynamic\": {resourceValue}" +
+            "}";
+
+            IEdmEntitySet people = UntypedModel.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(people, people.EntityType());
+            ODataItemWrapper item = await ReadUntypedPayloadAsync(payload, UntypedModel, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
+
+            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties);
+            // Declared property with 'Edm.Int32'
+            Assert.Equal("ID", property.Name);
+            Assert.Equal(17, property.Value);
+
+            Assert.Equal(2, resourceWrapper.NestedResourceInfos.Count);
+
+            Action<ODataNestedResourceInfoWrapper, string> verifyAction = (p, n) =>
+            {
+                Assert.Equal(n, p.NestedResourceInfo.Name);
+                ODataResourceWrapper nestedResourceWrapper = Assert.IsType<ODataResourceWrapper>(Assert.Single(p.NestedItems));
+                Assert.Empty(nestedResourceWrapper.NestedResourceInfos);
+                Assert.Collection(nestedResourceWrapper.Resource.Properties,
+                    p =>
+                    {
+                        Assert.Equal("Key1", p.Name);
+                        Assert.Equal("Value1", p.Value);
+                    },
+                    p =>
+                    {
+                        Assert.Equal("Key2", p.Name);
+                        Assert.True((bool)p.Value);
+                    });
+            };
+
+            Assert.Collection(resourceWrapper.NestedResourceInfos,
+                p =>
+                {
+                    // Declared property with 'Edm.Untyped'
+                    verifyAction(p, "Data");
+                },
+                p =>
+                {
+                    // Un-declared (dynamic) property
+                    verifyAction(p, "Dynamic");
+                });
+        }
+
+        [Fact]
+        public async Task ReadOpenResource_WithUntypedCollectionValue_WorksAsExpected()
+        {
+            // Arrange
+            string collectionValue = "[" +
+                "null," +
+                "{\"Key1\": \"Value1\", \"Key2\": true}," +
+                "\"A string item\"," +
+                "42" +
+            "]";
+
+            string payload =
+            "{" +
+                "\"ID\": 17," +
+                $"\"Data\": {collectionValue}," +
+                $"\"Dynamic\": {collectionValue}" +
+            "}";
+
+            IEdmEntitySet people = UntypedModel.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(people, people.EntityType());
+            ODataItemWrapper item = await ReadUntypedPayloadAsync(payload, UntypedModel, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
+
+            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties);
+            // Declared property with 'Edm.Int32'
+            Assert.Equal("ID", property.Name);
+            Assert.Equal(17, property.Value);
+
+            Assert.Equal(2, resourceWrapper.NestedResourceInfos.Count);
+
+            Action<ODataNestedResourceInfoWrapper, string> verifyAction = (p, n) =>
+            {
+                Assert.Equal(n, p.NestedResourceInfo.Name);
+                ODataResourceSetWrapper nestedResourceSetWrapper = Assert.IsType<ODataResourceSetWrapper>(Assert.Single(p.NestedItems));
+                Assert.Equal(2, nestedResourceSetWrapper.Resources.Count);
+
+                Assert.Collection(nestedResourceSetWrapper.Resources,
+                    p =>
+                    {
+                        Assert.Null(p); // since it's a 'null' value in collection,
+                                        // ODL reads it as ResourceStart, ResourceEnd with null item.
+                    },
+                    p =>
+                    {
+                        Assert.Empty(p.NestedResourceInfos);
+                        Assert.NotNull(p.Resource);
+                        Assert.Collection(p.Resource.Properties,
+                            p =>
+                            {
+                                Assert.Equal("Key1", p.Name);
+                                Assert.Equal("Value1", p.Value);
+                            },
+                            p =>
+                            {
+                                Assert.Equal("Key2", p.Name);
+                                Assert.True((bool)p.Value);
+                            });
+                    });
+
+                Assert.Equal(2, nestedResourceSetWrapper.Items.Count);
+                Assert.Collection(nestedResourceSetWrapper.Items,
+                    p =>
+                    {
+                        ODataPrimitiveWrapper primitiveWrapper = Assert.IsType<ODataPrimitiveWrapper>(p);
+                        Assert.NotNull(primitiveWrapper.Value);
+                        Assert.Equal("A string item", primitiveWrapper.Value.Value);
+                    },
+                    p =>
+                    {
+                        ODataPrimitiveWrapper primitiveWrapper = Assert.IsType<ODataPrimitiveWrapper>(p);
+                        Assert.NotNull(primitiveWrapper.Value);
+                        Assert.Equal(42, primitiveWrapper.Value.Value);
+                    });
+            };
+
+            Assert.Collection(resourceWrapper.NestedResourceInfos,
+                p =>
+                {
+                    // Declared property with 'Edm.Untyped'
+                    verifyAction(p, "Data");
+                },
+                p =>
+                {
+                    // Un-declared (dynamic) property
+                    verifyAction(p, "Dynamic");
+                });
+        }
+
+        [Fact]
+        public async Task ReadOpenResource_WithUntypedCollectionValue_OnNestedResourceInfo_WorksAsExpected()
+        {
+            // Arrange
+            string collectionValue = "[" +
+                "{}," +
+                "{\"Key1\": \"Value1\"}," +
+                "{\"Key2\": {}}," +
+                "{\"Key3\": {\"@odata.type\":\"NS.Info\"}}," +
+                "{\"Key4\": []}" +
+            "]";
+
+            string payload =
+            "{" +
+                $"\"Infos\": {collectionValue}" +
+            "}";
+
+            IEdmEntitySet people = UntypedModel.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(people, people.EntityType());
+            ODataItemWrapper item = await ReadUntypedPayloadAsync(payload, UntypedModel, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
+
+            Assert.Empty(resourceWrapper.Resource.Properties);
+
+            ODataNestedResourceInfoWrapper nestedResourceInfoWrapper = Assert.Single(resourceWrapper.NestedResourceInfos);
+            Assert.Equal("Infos", nestedResourceInfoWrapper.NestedResourceInfo.Name);
+
+            ODataResourceSetWrapper nestedResourceSetWrapper = Assert.IsType<ODataResourceSetWrapper>
+                (Assert.Single(nestedResourceInfoWrapper.NestedItems));
+
+            Assert.Collection(nestedResourceSetWrapper.Resources,
+                p =>
+                {
+                    Assert.Equal("NS.Info", p.Resource.TypeName);
+
+                    Assert.Empty(p.Resource.Properties);
+                    Assert.Empty(p.NestedResourceInfos);
+                },
+                p =>
+                {
+                    Assert.Equal("NS.Info", p.Resource.TypeName);
+
+                    Assert.Empty(p.NestedResourceInfos);
+                    ODataProperty property = Assert.Single(p.Resource.Properties);
+                    Assert.Equal("Key1", property.Name);
+                    Assert.Equal("Value1", property.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("NS.Info", p.Resource.TypeName);
+                    Assert.Empty(p.Resource.Properties);
+
+                    ODataNestedResourceInfoWrapper nestedInfoWrapper = Assert.Single(p.NestedResourceInfos);
+                    Assert.Equal("Key2", nestedInfoWrapper.NestedResourceInfo.Name);
+
+                    ODataResourceWrapper nestedResourceWrapper = Assert.IsType<ODataResourceWrapper>(Assert.Single(nestedInfoWrapper.NestedItems));
+                    Assert.Equal("Edm.Untyped", nestedResourceWrapper.Resource.TypeName);
+                    Assert.Empty(nestedResourceWrapper.Resource.Properties);
+                    Assert.Empty(nestedResourceWrapper.NestedResourceInfos);
+                },
+                p =>
+                {
+                    Assert.Equal("NS.Info", p.Resource.TypeName);
+                    Assert.Empty(p.Resource.Properties);
+
+                    ODataNestedResourceInfoWrapper nestedInfoWrapper = Assert.Single(p.NestedResourceInfos);
+                    Assert.Equal("Key3", nestedInfoWrapper.NestedResourceInfo.Name);
+
+                    ODataResourceWrapper nestedResourceWrapper = Assert.IsType<ODataResourceWrapper>(Assert.Single(nestedInfoWrapper.NestedItems));
+                    Assert.Equal("NS.Info", nestedResourceWrapper.Resource.TypeName);
+                    Assert.Empty(nestedResourceWrapper.Resource.Properties);
+                    Assert.Empty(nestedResourceWrapper.NestedResourceInfos);
+                },
+                p =>
+                {
+                    Assert.Equal("NS.Info", p.Resource.TypeName);
+                    Assert.Empty(p.Resource.Properties);
+
+                    ODataNestedResourceInfoWrapper nestedInfoWrapper = Assert.Single(p.NestedResourceInfos);
+                    Assert.Equal("Key4", nestedInfoWrapper.NestedResourceInfo.Name);
+
+                    ODataResourceSetWrapper nestedResourceSetWrapper = Assert.IsType<ODataResourceSetWrapper>(Assert.Single(nestedInfoWrapper.NestedItems));
+                    Assert.Empty(nestedResourceSetWrapper.Resources);
+                });
+        }
+
+        [Fact]
+        public async Task ReadOpenResource_WithDeepUntypedCollectionValue_WorksAsExpected()
+        {
+            // Arrange
+            const int Depth = 10;
+            string collectionValue = "[42]";
+            for (int i = 0; i < Depth; i++)
+            {
+                collectionValue = $"[42, {collectionValue}]";
+            }
+            // [42, [42, [42, [42, [42, [42, [42, [42, [42, [42, [42]]]]]]]]]]]
+
+            string payload =
+            "{" +
+                $"\"Data\": {collectionValue}," +
+                $"\"Dynamic\": {collectionValue}" +
+            "}";
+
+            IEdmEntitySet people = UntypedModel.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(people, people.EntityType());
+            ODataItemWrapper item = await ReadUntypedPayloadAsync(payload, UntypedModel, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
+
+            Assert.Empty(resourceWrapper.Resource.Properties);
+            Assert.Equal(2, resourceWrapper.NestedResourceInfos.Count);
+
+            Action<ODataNestedResourceInfoWrapper, string> verifyAction = (p, n) =>
+            {
+                Assert.Equal(n, p.NestedResourceInfo.Name);
+                ODataResourceSetWrapper nestedResourceSetWrapper = Assert.IsType<ODataResourceSetWrapper>(Assert.Single(p.NestedItems));
+
+                for (int i = 0; i <= Depth; ++i) // Why '<= Depth'? Because we have extra single primitive (42) in the deepest level.
+                {
+                    Assert.Empty(nestedResourceSetWrapper.Resources);
+                    ODataPrimitiveWrapper primitiveWrapper;
+                    if (i == Depth)
+                    {
+                        primitiveWrapper = Assert.IsType<ODataPrimitiveWrapper>(Assert.Single(nestedResourceSetWrapper.Items));
+                    }
+                    else
+                    {
+                        Assert.Equal(2, nestedResourceSetWrapper.Items.Count);
+                        primitiveWrapper = Assert.IsType<ODataPrimitiveWrapper>(nestedResourceSetWrapper.Items.First());
+                        nestedResourceSetWrapper = Assert.IsType<ODataResourceSetWrapper>(nestedResourceSetWrapper.Items.Last());
+                    }
+
+                    Assert.NotNull(primitiveWrapper.Value);
+                    Assert.Equal(42, primitiveWrapper.Value.Value); // in the collection, ODL reads 42 as integer. It's different with 42 in untyped single value property
+                }
+            };
+
+            Assert.Collection(resourceWrapper.NestedResourceInfos,
+                p =>
+                {
+                    // Declared property with 'Edm.Untyped'
+                    verifyAction(p, "Data");
+                },
+                p =>
+                {
+                    // Un-declared (dynamic) property
+                    verifyAction(p, "Dynamic");
+                });
+        }
+
+        private async Task<ODataItemWrapper> ReadUntypedPayloadAsync(string payload,
+            IEdmModel edmModel, Func<ODataMessageReader, Task<ODataReader>> createReader,
+            bool readUntypedAsString = false)
+        {
+            return await ReadPayloadAsync(payload, edmModel, createReader, ODataVersion.V4, readUntypedAsString);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
 {
-    public class ODataReaderExtensionsTests
+    public partial class ODataReaderExtensionsTests
     {
         private static readonly EdmModel Model;
 
@@ -574,7 +574,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
         }
 
         private async Task<ODataItemWrapper> ReadPayloadAsync(string payload,
-            IEdmModel edmModel, Func<ODataMessageReader, Task<ODataReader>> createReader, ODataVersion version = ODataVersion.V4)
+            IEdmModel edmModel, Func<ODataMessageReader, Task<ODataReader>> createReader, ODataVersion version = ODataVersion.V4,
+            bool readUntypedAsString = false)
         {
             var message = new InMemoryMessage()
             {
@@ -586,6 +587,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             {
                 BaseUri = new Uri("http://localhost/$metadata"),
                 EnableMessageStreamDisposal = true,
+                ReadUntypedAsString = readUntypedAsString,
                 Version = version,
             };
 

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -2594,6 +2594,12 @@ public class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataEntityReferenceLi
 	Microsoft.OData.ODataEntityReferenceLink EntityReferenceLink  { public get; }
 }
 
+public class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper {
+	public ODataPrimitiveWrapper (Microsoft.OData.ODataPrimitiveValue value)
+
+	Microsoft.OData.ODataPrimitiveValue Value  { public get; }
+}
+
 public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataDeltaDeletedLinkWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataDeltaLinkBaseWrapper {
 	public ODataDeltaDeletedLinkWrapper (Microsoft.OData.ODataDeltaDeletedLink deltaDeletedLink)
 
@@ -2623,6 +2629,7 @@ public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedReso
 public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetBaseWrapper {
 	public ODataResourceSetWrapper (Microsoft.OData.ODataResourceSet resourceSet)
 
+	System.Collections.Generic.IList`1[[Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper]] Items  { public get; }
 	System.Collections.Generic.IList`1[[Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper]] Resources  { public get; }
 	Microsoft.OData.ODataResourceSet ResourceSet  { public get; }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2594,6 +2594,12 @@ public class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataEntityReferenceLi
 	Microsoft.OData.ODataEntityReferenceLink EntityReferenceLink  { public get; }
 }
 
+public class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataPrimitiveWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper {
+	public ODataPrimitiveWrapper (Microsoft.OData.ODataPrimitiveValue value)
+
+	Microsoft.OData.ODataPrimitiveValue Value  { public get; }
+}
+
 public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataDeltaDeletedLinkWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataDeltaLinkBaseWrapper {
 	public ODataDeltaDeletedLinkWrapper (Microsoft.OData.ODataDeltaDeletedLink deltaDeletedLink)
 
@@ -2623,6 +2629,7 @@ public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataNestedReso
 public sealed class Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetWrapper : Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceSetBaseWrapper {
 	public ODataResourceSetWrapper (Microsoft.OData.ODataResourceSet resourceSet)
 
+	System.Collections.Generic.IList`1[[Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataItemWrapper]] Items  { public get; }
 	System.Collections.Generic.IList`1[[Microsoft.AspNetCore.OData.Formatter.Wrapper.ODataResourceWrapper]] Resources  { public get; }
 	Microsoft.OData.ODataResourceSet ResourceSet  { public get; }
 }


### PR DESCRIPTION
fixes #907.

also part of fixes #885. (No breaking changes)

Enable read the untyped collection.

For example:
```json

{
 "awsTag":[
            null,
            {
                "X1": "Red",
                "Data": {
                    "D1": 42
                }
            },
            "finance",
            "hr",
            "legal",
            43
        ]
}
```

where, awsTag could be a dynamic property, it contains primitive value item, resource value item.

ODL reads it and returns:
1) ODataReaderState.Primitive  for primitive value in collection
2) ODataReaderState.ResourceStart  for resource value in collection.
3) It also can contain collection value item again in the collection.


This PR is to handle the above scenario.