### PR TITLE
Fix invalid partial json generated when serverside paging is applied in multi-level containment scenarios

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/LinkGenerationHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/LinkGenerationHelpers.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.AspNetCore.OData.Edm;
@@ -69,7 +70,16 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 throw Error.ArgumentNull(nameof(resourceContext));
             }
 
-            IList<ODataPathSegment> navigationPathSegments = resourceContext.GenerateBaseODataPathSegments();
+            IList<ODataPathSegment> navigationPathSegments;
+            if (resourceContext.NavigationSource is IEdmContainedEntitySet &&
+                resourceContext.NavigationSource != resourceContext.SerializerContext.Path.NavigationSource())
+            {
+                navigationPathSegments = resourceContext.GenerateContainmentODataPathSegments();
+            }
+            else
+            {
+                navigationPathSegments = resourceContext.GenerateBaseODataPathSegments();
+            }
 
             if (includeCast)
             {
@@ -429,8 +439,7 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 // the case.
                 odataPath.Clear();
 
-                IEdmContainedEntitySet containmnent = navigationSource as IEdmContainedEntitySet;
-                if (containmnent != null)
+                if (navigationSource is IEdmContainedEntitySet)
                 {
                     EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
                     IEdmEntitySet entitySet = new EdmEntitySet(container, navigationSource.Name,
@@ -464,6 +473,108 @@ namespace Microsoft.AspNetCore.OData.Formatter
             GenerateBaseODataPathSegments(feedContext.Request.ODataFeature().Path,
                 feedContext.EntitySetBase,
                 odataPath);
+        }
+
+        private static IList<ODataPathSegment> GenerateContainmentODataPathSegments(this ResourceContext resourceContext)
+        {
+            List<ODataPathSegment> navigationPathSegments = new List<ODataPathSegment>();
+            ResourceContext currentResourceContext = resourceContext;
+
+            // We loop till the base of the $expand expression then use GenerateBaseODataPathSegments to generate the base path segments
+            // For instance, given $expand=Tabs($expand=Items($expand=Notes($expand=Tips))), we loop until we get to Tabs at the base
+            while (currentResourceContext != null && currentResourceContext.NavigationSource != resourceContext.SerializerContext.Path.NavigationSource())
+            {
+                if (currentResourceContext.NavigationSource is IEdmContainedEntitySet containedEntitySet)
+                {
+                    // Type-cast segment for the expanded resource that is passed into the method is added by the caller
+                    if (currentResourceContext != resourceContext && currentResourceContext.StructuredType != containedEntitySet.EntityType())
+                    {
+                        navigationPathSegments.Add(new TypeSegment(currentResourceContext.StructuredType, currentResourceContext.NavigationSource));
+                    }
+
+                    KeySegment keySegment = new KeySegment(
+                        ConventionsHelpers.GetEntityKey(currentResourceContext),
+                        currentResourceContext.StructuredType as IEdmEntityType,
+                        navigationSource: currentResourceContext.NavigationSource);
+                    navigationPathSegments.Add(keySegment);
+
+                    NavigationPropertySegment navPropertySegment = new NavigationPropertySegment(
+                        containedEntitySet.NavigationProperty,
+                        containedEntitySet.ParentNavigationSource);
+                    navigationPathSegments.Add(navPropertySegment);
+                }
+                else if (currentResourceContext.NavigationSource is IEdmEntitySet entitySet)
+                {
+                    // We will get here if there's a non-contained entity set on the $expand expression
+                    if (currentResourceContext.StructuredType != entitySet.EntityType())
+                    {
+                        navigationPathSegments.Add(new TypeSegment(currentResourceContext.StructuredType, currentResourceContext.NavigationSource));
+                    }
+
+                    KeySegment keySegment = new KeySegment(
+                        ConventionsHelpers.GetEntityKey(currentResourceContext),
+                        currentResourceContext.StructuredType as IEdmEntityType,
+                        currentResourceContext.NavigationSource);
+                    navigationPathSegments.Add(keySegment);
+
+                    EntitySetSegment entitySetSegment = new EntitySetSegment(entitySet);
+                    navigationPathSegments.Add(entitySetSegment);
+
+                    // Reverse the list such that the segments are in the right order
+                    navigationPathSegments.Reverse();
+                    return navigationPathSegments;
+                }
+                else if (currentResourceContext.NavigationSource is IEdmSingleton singleton)
+                {
+                    // We will get here if there's a singleton on the $expand expression
+                    if (currentResourceContext.StructuredType != singleton.EntityType())
+                    {
+                        navigationPathSegments.Add(new TypeSegment(currentResourceContext.StructuredType, currentResourceContext.NavigationSource));
+                    }
+
+                    SingletonSegment singletonSegment = new SingletonSegment(singleton);
+                    navigationPathSegments.Add(singletonSegment);
+
+                    // Reverse the list such that the segments are in the right order
+                    navigationPathSegments.Reverse();
+                    return navigationPathSegments;
+                }
+
+                currentResourceContext = currentResourceContext.SerializerContext.ExpandedResource;
+            }
+
+            Debug.Assert(currentResourceContext != null, "currentResourceContext != null");
+            // Once we are at the base of the $expand expression, we call GenerateBaseODataPathSegments to generate the base path segments
+            IList<ODataPathSegment> pathSegments = currentResourceContext.GenerateBaseODataPathSegments();
+
+            Debug.Assert(pathSegments.Count > 0, "pathSegments.Count > 0");
+
+            ODataPathSegment lastNonKeySegment;
+
+            if (pathSegments.Count == 1)
+            {
+                lastNonKeySegment = pathSegments[0];
+                Debug.Assert(lastNonKeySegment is SingletonSegment, "lastNonKeySegment is SingletonSegment");
+            }
+            else
+            {
+                Debug.Assert(pathSegments[pathSegments.Count - 1] is KeySegment, "pathSegments[pathSegments.Count - 1] is KeySegment");
+                // 2nd last segment would be NavigationPathSegment or EntitySetSegment
+                lastNonKeySegment = pathSegments[pathSegments.Count - 2];
+            }
+
+            if (currentResourceContext.StructuredType != lastNonKeySegment.EdmType.AsElementType())
+            {
+                pathSegments.Add(new TypeSegment(currentResourceContext.StructuredType, currentResourceContext.NavigationSource));
+            }
+
+            // Add the segments from the $expand expression in reverse order
+            for (int i = navigationPathSegments.Count - 1; i >= 0; i--)
+            {
+                pathSegments.Add(navigationPathSegments[i]);
+            }
+
+            return pathSegments;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -530,26 +530,12 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         private static Uri GetNestedNextPageLink(ODataSerializerContext writeContext, int pageSize, object obj)
         {
             Contract.Assert(writeContext.ExpandedResource != null);
-            Uri navigationLink;
             IEdmNavigationSource sourceNavigationSource = writeContext.ExpandedResource.NavigationSource;
             NavigationSourceLinkBuilderAnnotation linkBuilder = writeContext.Model.GetNavigationSourceLinkBuilder(sourceNavigationSource);
 
-            // In Contained Navigation, we don't have navigation property binding,
-            // Hence we cannot get the NavigationLink from the NavigationLinkBuilder
-            if (writeContext.NavigationSource.NavigationSourceKind() == EdmNavigationSourceKind.ContainedEntitySet)
-            {
-                // Contained navigation.
-                Uri idlink = linkBuilder.BuildIdLink(writeContext.ExpandedResource);
-
-                var link = idlink.ToString() + "/" + writeContext.NavigationProperty.Name;
-                navigationLink = new Uri(link);
-            }
-            else
-            {
-                // Non-Contained navigation.
-                navigationLink =
-                    linkBuilder.BuildNavigationLink(writeContext.ExpandedResource, writeContext.NavigationProperty);
-            }
+            Uri navigationLink = linkBuilder.BuildNavigationLink(
+                writeContext.ExpandedResource,
+                writeContext.NavigationProperty);
 
             Uri nestedNextLink = GenerateQueryFromExpandedItem(writeContext, navigationLink);
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -155,4 +155,138 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
             return customers;
         }
     }
+
+    public class ContainmentPagingCustomersController : ODataController
+    {
+        [EnableQuery(PageSize = 2)]
+        public ActionResult Get()
+        {
+            return Ok(ContainmentPagingDataSource.Customers);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult GetOrders(int key)
+        {
+            var customer = ContainmentPagingDataSource.Customers.SingleOrDefault(d => d.Id == key);
+
+            if (customer == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(customer.Orders);
+        }
+    }
+
+    public class ContainmentPagingCompanyController : ODataController
+    {
+        private static readonly ContainmentPagingCustomer company = new ContainmentPagingCustomer
+        {
+            Id = 1,
+            Orders = ContainmentPagingDataSource.Orders.Take(ContainmentPagingDataSource.TargetSize).ToList()
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult Get()
+        {
+            return Ok(company);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult GetOrders()
+        {
+            return Ok(company.Orders);
+        }
+    }
+
+    public class NoContainmentPagingCustomersController : ODataController
+    {
+        [EnableQuery(PageSize = 2)]
+        public ActionResult Get()
+        {
+            return Ok(NoContainmentPagingDataSource.Customers);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult GetOrders(int key)
+        {
+            var customer = NoContainmentPagingDataSource.Customers.SingleOrDefault(d => d.Id == key);
+
+            if (customer == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(customer.Orders);
+        }
+    }
+
+    public class ContainmentPagingMenusController : ODataController
+    {
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult Get()
+        {
+            return Ok(ContainmentPagingDataSource.Menus);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult GetFromContainmentPagingExtendedMenu()
+        {
+            return Ok(ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>());
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult GetTabsFromContainmentPagingExtendedMenu(int key)
+        {
+            var menu = ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>().SingleOrDefault(d => d.Id == key);
+
+            if (menu == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(menu.Tabs);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult GetPanelsFromContainmentPagingExtendedMenu(int key)
+        {
+            var menu = ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>().SingleOrDefault(d => d.Id == key);
+
+            if (menu == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(menu.Panels);
+        }
+    }
+
+    public class ContainmentPagingRibbonController : ODataController
+    {
+        private static readonly ContainmentPagingMenu ribbon = new ContainmentPagingExtendedMenu
+        {
+            Id = 1,
+            Tabs = ContainmentPagingDataSource.Tabs.Take(ContainmentPagingDataSource.TargetSize).ToList()
+        };
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult Get()
+        {
+            return Ok(ribbon);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ActionResult GetFromContainmentPagingExtendedMenu()
+        {
+            return Ok(ribbon as ContainmentPagingExtendedMenu);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        [HttpGet("ContainmentPagingRibbon/Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging.ContainmentPagingExtendedMenu/Tabs")]
+        public ActionResult GetTabsFromContainmentPagingExtendedMenu()
+        {
+            return Ok((ribbon as ContainmentPagingExtendedMenu).Tabs);
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.OData.ModelBuilder;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
 {
@@ -45,5 +46,92 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
     {
         public int Id { get; set; }
         public decimal? CreditLimit { get; set; }
+    }
+
+    public class ContainmentPagingCustomer
+    {
+        public int Id { get; set; }
+        [Contained]
+        public List<ContainedPagingOrder> Orders { get; set; }
+    }
+
+    public class ContainedPagingOrder
+    {
+        public int Id { get; set; }
+        [Contained]
+        public List<ContainedPagingOrderItem> Items { get; set; }
+    }
+
+    public class ContainedPagingOrderItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class NoContainmentPagingCustomer
+    {
+        public int Id { get; set; }
+        public List<NoContainmentPagingOrder> Orders { get; set; }
+    }
+
+    public class NoContainmentPagingOrder
+    {
+        public int Id { get; set; }
+        public List<NoContainmentPagingOrderItem> Items { get; set; }
+    }
+
+    public class NoContainmentPagingOrderItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingMenu
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingExtendedMenu : ContainmentPagingMenu
+    {
+        [Contained]
+        public List<ContainedPagingTab> Tabs { get; set; }
+        // Non-contained
+        public List<ContainmentPagingPanel> Panels { get; set; }
+    }
+
+    public class ContainedPagingTab
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainedPagingExtendedTab : ContainedPagingTab
+    {
+        [Contained]
+        public List<ContainedPagingItem> Items { get; set; }
+    }
+
+    public class ContainedPagingItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainedPagingExtendedItem : ContainedPagingItem
+    {
+        [Contained]
+        public List<ContainedPagingNote> Notes { get; set; }
+    }
+
+    public class ContainedPagingNote
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingPanel
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingExtendedPanel : ContainmentPagingPanel
+    {
+        [Contained]
+        public List<ContainedPagingItem> Items { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataSource.cs
@@ -1,0 +1,109 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ServerSidePagingDataSource.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
+{
+    public static class ContainmentPagingDataSource
+    {
+        internal const int TargetSize = 3;
+
+        private static readonly List<ContainedPagingOrderItem> orderItems = new List<ContainedPagingOrderItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingOrderItem
+            {
+                Id = idx
+            }));
+
+        private static readonly List<ContainedPagingOrder> orders = new List<ContainedPagingOrder>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainedPagingOrder
+            {
+                Id = idx,
+                Items = orderItems.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingCustomer> customers = new List<ContainmentPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new ContainmentPagingCustomer
+            {
+                Id = idx,
+                Orders = orders.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainedPagingNote> notes = new List<ContainedPagingNote>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingNote
+            {
+                Id = idx
+            }));
+
+        private static readonly List<ContainedPagingItem> items = new List<ContainedPagingItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingExtendedItem
+            {
+                Id = idx,
+                Notes = notes.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainedPagingTab> tabs = new List<ContainedPagingTab>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainedPagingExtendedTab
+            {
+                Id = idx,
+                Items = items.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingPanel> panels = new List<ContainmentPagingPanel>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainmentPagingExtendedPanel
+            {
+                Id = idx,
+                Items = items.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingMenu> menus = new List<ContainmentPagingMenu>(
+            Enumerable.Range(1, TargetSize).Select(idx => new ContainmentPagingExtendedMenu
+            {
+                Id = idx,
+                Tabs = tabs.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList(),
+                Panels = panels.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        public static List<ContainmentPagingCustomer> Customers => customers;
+
+        public static List<ContainedPagingOrder> Orders => orders;
+
+        public static List<ContainmentPagingMenu> Menus => menus;
+
+        public static List<ContainedPagingTab> Tabs => tabs;
+    }
+
+    public static class NoContainmentPagingDataSource
+    {
+        private const int TargetSize = 3;
+
+        private static readonly List<NoContainmentPagingOrderItem> orderItems = new List<NoContainmentPagingOrderItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new NoContainmentPagingOrderItem
+            {
+                Id = idx
+            }));
+
+        private static readonly List<NoContainmentPagingOrder> orders = new List<NoContainmentPagingOrder>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new NoContainmentPagingOrder
+            {
+                Id = idx,
+                Items = orderItems.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<NoContainmentPagingCustomer> customers = new List<NoContainmentPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new NoContainmentPagingCustomer
+            {
+                Id = idx,
+                Orders = orders.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        public static List<NoContainmentPagingCustomer> Customers => customers;
+
+        public static List<NoContainmentPagingOrder> Orders => orders;
+    }
+}


### PR DESCRIPTION
This pull request ports [this 7.x fix](https://github.com/OData/WebApi/pull/2771) to 8.x