### PR TITLE
fixes #921, Enable $compute in non-odata path using ODataQueryOptions<T> directly

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Container/JsonPropertyNameMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/JsonPropertyNameMapper.cs
@@ -28,7 +28,14 @@ namespace Microsoft.AspNetCore.OData.Query.Container
 
         public string MapProperty(string propertyName)
         {
-            IEdmProperty property = _type.Properties().Single(s => s.Name == propertyName);
+            IEdmProperty property = _type.Properties().FirstOrDefault(s => s.Name == propertyName);
+            if (property == null)
+            {
+                // If we can't find a property on the Edm type, it could be a dynamic property.
+                // We should simply return the property name.
+                return propertyName;
+            }
+
             PropertyInfo info = GetPropertyInfo(property);
 
             JsonIgnoreAttribute jsonIgnore = GetJsonIgnore(info);

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -364,6 +364,17 @@ namespace Microsoft.AspNetCore.OData.Query
                 this.Context.ElementClrType = Apply.ResultClrType;
             }
 
+            // We need this code to let 'ODataQueryOptionParser' to parse the 'ComputeClause'
+            // By parsing the compute clause, we give the parser opportunity to gather the 'computed' properties
+            // which could be required in $filter, $order and $select, etc.
+            // Without this code, it will be failed when customer only uses 'ODataQueryOptions<T>' as the parameter in action.
+            // It should work if customer uses [EnableQuery], this is because [EnableQuery] calls validators
+            // and the validators parse the 'ComputeClause' already.
+            if (IsAvailableODataQueryOption(Compute, querySettings, AllowedQueryOptions.Compute))
+            {
+                _ = Compute.ComputeClause;
+            }
+
             // TODO: need pass the result from $compute to the remaining query options
             // Construct the actual query and apply them in the following order: filter, orderby, skip, top
             if (IsAvailableODataQueryOption(Filter, querySettings, AllowedQueryOptions.Filter))

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ActionResults/ActionResultController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ActionResults/ActionResultController.cs
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -34,6 +35,26 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ActionResults
                     },
                 },
             });
+        }
+
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        [HttpGet("/api/weather")]
+        public IActionResult Get(ODataQueryOptions<Weather> options)
+        {
+            var data = Enumerable.Range(1, 10).Select(index => new Weather
+            {
+                Id = index,
+                TemperatureC = 22 + index,
+                Summary = Summaries[index - 1]
+            })
+            .ToArray()
+            .AsQueryable();
+
+            return Ok(options.ApplyTo(data));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ActionResults/ActionResultODataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ActionResults/ActionResultODataModel.cs
@@ -20,4 +20,15 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ActionResults
     {
         public string Id { get; set; }
     }
+
+    public class Weather
+    {
+        public int Id { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
 }


### PR DESCRIPTION
fixes #921

1) Fix the error when using $compute in non-odata scenario:
```C#
  Microsoft.OData.ODataException: Could not find a property named '{{propertyName}}' on type '{{entityType}}'.
```

2) Fix the problem in `JsonPropertyNameMapper.MapProperty(...)` if we have $compute in the query option.

3) Add test cases to cover it.