### PR TITLE
Potential fix for issue #616

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
@@ -135,12 +135,7 @@ namespace Microsoft.AspNetCore.OData.Query
                 bool islast = count == lastIndex;
                 if (obj != null)
                 {
-                    //if (!obj.TryGetPropertyValue(
-                    //        clrPropertyName,
-                    //        out value))
-                    //{
-                        obj.TryGetPropertyValue(edmProperty.Name, out value);
-                    //}
+                    obj.TryGetPropertyValue(edmProperty.Name, out value);
                 }
                 else
                 {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
@@ -133,18 +133,18 @@ namespace Microsoft.AspNetCore.OData.Query
             foreach (IEdmProperty edmProperty in propertiesForSkipToken)
             {
                 bool islast = count == lastIndex;
-                string clrPropertyName = model.GetClrPropertyName(edmProperty);
                 if (obj != null)
                 {
-                    if (!obj.TryGetPropertyValue(
-                            clrPropertyName,
-                            out value))
-                    {
+                    //if (!obj.TryGetPropertyValue(
+                    //        clrPropertyName,
+                    //        out value))
+                    //{
                         obj.TryGetPropertyValue(edmProperty.Name, out value);
-                    }
+                    //}
                 }
                 else
                 {
+                    string clrPropertyName = model.GetClrPropertyName(edmProperty);
                     value = lastMember.GetType().GetProperty(clrPropertyName).GetValue(lastMember);
                 }
 
@@ -426,21 +426,23 @@ namespace Microsoft.AspNetCore.OData.Query
             foreach (string pair in keyValuesPairs)
             {
                 string[] pieces = pair.Split(new char[] { propertyDelimiter }, 2);
-                if (pieces.Length > 1 && !String.IsNullOrWhiteSpace(pieces[0]))
+                string propertyName = pieces[0];
+                if (pieces.Length > 1 && !String.IsNullOrWhiteSpace(propertyName))
                 {
                     object propValue = null;
 
                     IEdmTypeReference propertyType = null;
-                    IEdmProperty property = type.FindProperty(pieces[0]);
+                    IEdmProperty property = type.FindProperty(propertyName);
                     Type propertyClrType = null;
                     if (property != null)
                     {
+                        propertyName = context.Model.GetClrPropertyName(property);
                         propertyType = property.Type;
                         propertyClrType = context.Model.GetClrType(propertyType);
                     }
 
                     propValue = ODataUriUtils.ConvertFromUriLiteral(pieces[1], ODataVersion.V401, context.Model, propertyType);
-                    propertyValuePairs.Add(pieces[0], (propValue, propertyClrType));
+                    propertyValuePairs.Add(propertyName, (propValue, propertyClrType));
                 }
                 else
                 {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs
@@ -136,7 +136,12 @@ namespace Microsoft.AspNetCore.OData.Query
                 string clrPropertyName = model.GetClrPropertyName(edmProperty);
                 if (obj != null)
                 {
-                    obj.TryGetPropertyValue(clrPropertyName, out value);
+                    if (!obj.TryGetPropertyValue(
+                            clrPropertyName,
+                            out value))
+                    {
+                        obj.TryGetPropertyValue(edmProperty.Name, out value);
+                    }
                 }
                 else
                 {

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
@@ -354,17 +354,6 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         {
             ODataConventionModelBuilder builder = new ODataConventionModelBuilder {ModelAliasingEnabled = true};
             var entitySetConfiguration = builder.EntitySet<SkipCustomer>("Customers");
-            //var entityType = entitySetConfiguration.EntityType;
-            //entityType.Property(sc => sc.Id)
-            //    .Name = "SkipCustomerId";
-            //entityType.HasKey(sc => sc.Id);
-            //entityType.Property(sc => sc.Name)
-            //    .Name = "FirstAndLastName";
-            //entityType.Property(sc => sc.Birthday)
-            //    .Name = "DateOfBirth";
-            //entityType.Property(sc => sc.Gender)
-            //    .Name = "MaleOrFemale";
-            //entityType.Property(sc => sc.Gender).
             return builder.GetEdmModel();
         }
         

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
@@ -21,11 +21,15 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Query
 {
+    using System.Runtime.Serialization;
+
     public class DefaultSkipTokenHandlerTests
     {
         private static IEdmModel _model = GetEdmModel();
 
         private static IEdmModel _modelLowerCamelCased = GetEdmModelLowerCamelCased();
+
+        private static IEdmModel _modelAliased = GetEdmModelAliased();
 
         [Fact]
         public void GenerateNextPageLink_ReturnsNull_NullContext()
@@ -60,21 +64,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         [InlineData("http://localhost/Customers?$select=Name", "http://localhost/Customers?$select=Name&$skiptoken=Id-42")]
         public void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink(string baseUri, string expectedUri)
         {
-            // Arrange
-            ODataSerializerContext serializerContext = GetSerializerContext(_model, true);
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            SkipCustomer instance = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
-
-            // Act
-            Uri uri = handler.GenerateNextPageLink(new Uri(baseUri), 10, instance, serializerContext);
-            var actualUri = uri.ToString();
-
-            // Assert
-            Assert.Equal(expectedUri, actualUri);
+            this.GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_Implementation(baseUri,
+                expectedUri, _model);
         }
 
         [Theory]
@@ -83,21 +74,18 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         [InlineData("http://localhost/Customers?$select=name", "http://localhost/Customers?$select=name&$skiptoken=id-42")]
         public void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_WithLowerCamelCase(string baseUri, string expectedUri)
         {
-            // Arrange
-            ODataSerializerContext serializerContext = GetSerializerContext(_modelLowerCamelCased, true);
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            SkipCustomer instance = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
+            this.GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_Implementation(baseUri,
+                expectedUri, _modelLowerCamelCased);
+        }
 
-            // Act
-            Uri uri = handler.GenerateNextPageLink(new Uri(baseUri), 10, instance, serializerContext);
-            var actualUri = uri.ToString();
-
-            // Assert
-            Assert.Equal(expectedUri, actualUri);
+        [Theory]
+        [InlineData("http://localhost/Customers(1)/Orders", "http://localhost/Customers(1)/Orders?$skiptoken=SkipCustomerId-42")]
+        [InlineData("http://localhost/Customers?$expand=Orders", "http://localhost/Customers?$expand=Orders&$skiptoken=SkipCustomerId-42")]
+        [InlineData("http://localhost/Customers?$select=FirstAndLastName", "http://localhost/Customers?$select=FirstAndLastName&$skiptoken=SkipCustomerId-42")]
+        public void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_WithAlias(string baseUri, string expectedUri)
+        {
+            this.GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_Implementation(baseUri,
+                expectedUri, _modelAliased);
         }
 
         [Fact]
@@ -110,231 +98,130 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _model, null);
-
-            // Assert
-            Assert.Equal("Id-42", skipTokenValue);
+            GenerateSkipTokenValue_Returns_SkipTokenValue_Implementation(_model,
+                "Id-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithLowerCamelCase()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
+            GenerateSkipTokenValue_Returns_SkipTokenValue_Implementation(_modelLowerCamelCased,
+                "id-42");
+        }
 
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _modelLowerCamelCased, null);
-
-            // Assert
-            Assert.Equal("id-42", skipTokenValue);
+        [Fact]
+        public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithAlias()
+        {
+            GenerateSkipTokenValue_Returns_SkipTokenValue_Implementation(_modelAliased,
+                "SkipCustomerId-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
-
-            IEdmEntityType entityType = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("Name");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _model, orderByNodes);
-
-            // Assert
-            Assert.Equal("Name-%27ZX%27,Id-42", skipTokenValue);
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_Implementation(
+                _model,
+                "Name",
+                "Name-%27ZX%27,Id-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithLowerCamelCase_WithOrderby()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX"
-            };
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_Implementation(
+                _modelLowerCamelCased,
+                "name",
+                "name-%27ZX%27,id-42");
+        }
 
-            IEdmEntityType entityType = _modelLowerCamelCased.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("name");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _modelLowerCamelCased, orderByNodes);
-
-            // Assert
-            Assert.Equal("name-%27ZX%27,id-42", skipTokenValue);
+        [Fact]
+        public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithAlias_WithOrderby()
+        {
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_Implementation(
+                _modelAliased,
+                "FirstAndLastName",
+                "FirstAndLastName-%27ZX%27,SkipCustomerId-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_IfNullValue()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = null
-            };
-
-            IEdmEntityType entityType = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("Name");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _model, orderByNodes);
-
-            // Assert
-            Assert.Equal("Name-null,Id-42", skipTokenValue);
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_IfNullValue_Implementation(
+                _model,
+                "Name",
+                "Name-null,Id-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithLowerCamelCase_WithOrderby_IfNullValue()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = null
-            };
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_IfNullValue_Implementation(
+                _modelLowerCamelCased,
+                "name",
+                "name-null,id-42");
+        }
 
-            IEdmEntityType entityType = _modelLowerCamelCased.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("name");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _modelLowerCamelCased, orderByNodes);
-
-            // Assert
-            Assert.Equal("name-null,id-42", skipTokenValue);
+        [Fact]
+        public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithAlias_WithOrderby_IfNullValue()
+        {
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_IfNullValue_Implementation(
+                _modelAliased,
+                "FirstAndLastName",
+                "FirstAndLastName-null,SkipCustomerId-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithDateTimeOffset()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Birthday = new DateTime(2021, 01, 20, 3, 4, 5, DateTimeKind.Utc)
-            };
-
-            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8
-            IEdmEntityType entityType = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("Birthday");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _model, orderByNodes, timeZone);
-
-            // Assert
-            Assert.Equal("Birthday-2021-01-19T19%3A04%3A05-08%3A00,Id-42", skipTokenValue);
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithDateTimeOffset_Implementation(
+                _model,
+                "Birthday",
+                "Birthday-2021-01-19T19%3A04%3A05-08%3A00,Id-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithLowerCamelCase_WithDateTimeOffset()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Birthday = new DateTime(2021, 01, 20, 3, 4, 5, DateTimeKind.Utc)
-            };
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithDateTimeOffset_Implementation(
+                _modelLowerCamelCased,
+                "birthday",
+                "birthday-2021-01-19T19%3A04%3A05-08%3A00,id-42");
+        }
 
-            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8
-            IEdmEntityType entityType = _modelLowerCamelCased.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("birthday");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _modelLowerCamelCased, orderByNodes, timeZone);
-
-            // Assert
-            Assert.Equal("birthday-2021-01-19T19%3A04%3A05-08%3A00,id-42", skipTokenValue);
+        [Fact]
+        public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithAlias_WithDateTimeOffset()
+        {
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithDateTimeOffset_Implementation(
+                _modelAliased,
+                "DateOfBirth",
+                "DateOfBirth-2021-01-19T19%3A04%3A05-08%3A00,SkipCustomerId-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_WithEnumValue()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX",
-                Gender = Gender.Male
-            };
-
-            IEdmEntityType entityType = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("Gender");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _model, orderByNodes);
-
-            // Assert
-            Assert.Equal("Gender-Microsoft.AspNetCore.OData.Tests.Query.DefaultSkipTokenHandlerTests%2BGender%27Male%27,Id-42", skipTokenValue);
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_WithEnumValue_Implementation(
+                _model,
+                "Gender",
+                "Gender-Microsoft.AspNetCore.OData.Tests.Query.DefaultSkipTokenHandlerTests%2BGender%27Male%27,Id-42");
         }
 
         [Fact]
         public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithLowerCamelCase_WithOrderby_WithEnumValue()
         {
-            // Arrange
-            SkipCustomer lastMember = new SkipCustomer
-            {
-                Id = 42,
-                Name = "ZX",
-                Gender = Gender.Male
-            };
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_WithEnumValue_Implementation(
+                _modelLowerCamelCased,
+                "gender",
+                "gender-Microsoft.AspNetCore.OData.Tests.Query.DefaultSkipTokenHandlerTests%2BGender%27Male%27,id-42");
+        }
 
-            IEdmEntityType entityType = _modelLowerCamelCased.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "SkipCustomer");
-            IEdmProperty property = entityType.FindProperty("gender");
-            IList<OrderByNode> orderByNodes = new List<OrderByNode>
-            {
-                new OrderByPropertyNode(property, OrderByDirection.Ascending)
-            };
-
-            // Act
-            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(lastMember, _modelLowerCamelCased, orderByNodes);
-
-            // Assert
-            Assert.Equal("gender-Microsoft.AspNetCore.OData.Tests.Query.DefaultSkipTokenHandlerTests%2BGender%27Male%27,id-42", skipTokenValue);
+        [Fact]
+        public void GenerateSkipTokenValue_Returns_SkipTokenValue_WithAlias_WithOrderby_WithEnumValue()
+        {
+            GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_WithEnumValue_Implementation(
+                _modelAliased,
+                "MaleOrFemale",
+                "MaleOrFemale-Microsoft.AspNetCore.OData.Tests.Query.DefaultSkipTokenHandlerTests%2BGender%27Male%27,SkipCustomerId-42");
         }
 
         [Fact]
@@ -389,97 +276,43 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         [Fact]
         public void ApplyToSkipTokenHandler_ThrowsODataException_InvalidSkipTokenValue()
         {
-            // Arrange
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            ODataQuerySettings settings = new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagationOption.False
-            };
-            ODataQueryContext context = new ODataQueryContext(_model, typeof(SkipCustomer));
-
-            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption("abc", context);
-            IQueryable<SkipCustomer> customers = new List<SkipCustomer>().AsQueryable();
-
-            // Act & Assert
-            ExceptionAssert.Throws<ODataException>(
-                () => handler.ApplyTo(customers, skipTokenQuery, new ODataQuerySettings(), null),
-                "Unable to parse the skiptoken value 'abc'. Skiptoken value should always be server generated.");
+            ApplyToSkipTokenHandler_ThrowsODataException_InvalidSkipTokenValue_Implementation(_model);
         }
 
         [Fact]
         public void ApplyToSkipTokenHandler_ThrowsODataException_WithLowerCamelCase_InvalidSkipTokenValue()
         {
-            // Arrange
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            ODataQuerySettings settings = new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagationOption.False
-            };
-            ODataQueryContext context = new ODataQueryContext(_modelLowerCamelCased, typeof(SkipCustomer));
-
-            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption("abc", context);
-            IQueryable<SkipCustomer> customers = new List<SkipCustomer>().AsQueryable();
-
-            // Act & Assert
-            ExceptionAssert.Throws<ODataException>(
-                () => handler.ApplyTo(customers, skipTokenQuery, new ODataQuerySettings(), null),
-                "Unable to parse the skiptoken value 'abc'. Skiptoken value should always be server generated.");
+            ApplyToSkipTokenHandler_ThrowsODataException_InvalidSkipTokenValue_Implementation(_modelLowerCamelCased);
+        }
+        
+        [Fact]
+        public void ApplyToSkipTokenHandler_ThrowsODataException_WithAlias_InvalidSkipTokenValue()
+        {
+            ApplyToSkipTokenHandler_ThrowsODataException_InvalidSkipTokenValue_Implementation(_modelAliased);
         }
 
         [Fact]
         public void ApplyToOfTDefaultSkipTokenHandler_Applies_ToQueryable()
         {
-            // Arrange
-            ODataQuerySettings settings = new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagationOption.False
-            };
-            ODataQueryContext context = new ODataQueryContext(_model, typeof(SkipCustomer));
-
-            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption("Id-2", context);
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            IQueryable<SkipCustomer> customers = new List<SkipCustomer>
-            {
-                new SkipCustomer { Id = 2, Name = "Aaron" },
-                new SkipCustomer { Id = 1, Name = "Andy" },
-                new SkipCustomer { Id = 3, Name = "Alex" }
-            }.AsQueryable();
-
-            // Act
-            SkipCustomer[] results = handler.ApplyTo(customers, skipTokenQuery, settings, null).ToArray();
-
-            // Assert
-            SkipCustomer skipTokenCustomer = Assert.Single(results);
-            Assert.Equal(3, skipTokenCustomer.Id);
-            Assert.Equal("Alex", skipTokenCustomer.Name);
+            ApplyToOfTDefaultSkipTokenHandler_Applies_ToQueryable_Implementation(
+                _model,
+                "Id-2");
         }
 
         [Fact]
         public void ApplyToOfTDefaultSkipTokenHandler_Applies_WithLowerCamelCase_ToQueryable()
         {
-            // Arrange
-            ODataQuerySettings settings = new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagationOption.False
-            };
-            ODataQueryContext context = new ODataQueryContext(_modelLowerCamelCased, typeof(SkipCustomer));
+            ApplyToOfTDefaultSkipTokenHandler_Applies_ToQueryable_Implementation(
+                _modelLowerCamelCased,
+                "id-2");
+        }
 
-            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption("Id-2", context);
-            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
-            IQueryable<SkipCustomer> customers = new List<SkipCustomer>
-            {
-                new SkipCustomer { Id = 2, Name = "Aaron" },
-                new SkipCustomer { Id = 1, Name = "Andy" },
-                new SkipCustomer { Id = 3, Name = "Alex" }
-            }.AsQueryable();
-
-            // Act
-            SkipCustomer[] results = handler.ApplyTo(customers, skipTokenQuery, settings, null).ToArray();
-
-            // Assert
-            SkipCustomer skipTokenCustomer = Assert.Single(results);
-            Assert.Equal(3, skipTokenCustomer.Id);
-            Assert.Equal("Alex", skipTokenCustomer.Name);
+        [Fact]
+        public void ApplyToOfTDefaultSkipTokenHandler_Applies_WithAlias_ToQueryable()
+        {
+            ApplyToOfTDefaultSkipTokenHandler_Applies_ToQueryable_Implementation(
+                _modelAliased,
+                "SkipCustomerId-2");
         }
 
         private ODataSerializerContext GetSerializerContext(IEdmModel model, bool enableSkipToken = false)
@@ -504,27 +337,290 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
 
         private static IEdmModel GetEdmModel()
         {
-            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder {ModelAliasingEnabled = false};
             builder.EntitySet<SkipCustomer>("Customers");
             return builder.GetEdmModel();
         }
 
         private static IEdmModel GetEdmModelLowerCamelCased()
         {
-            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder {ModelAliasingEnabled = false};
             builder.EntitySet<SkipCustomer>("Customers");
             builder.EnableLowerCamelCase();
             return builder.GetEdmModel();
         }
 
+        private static IEdmModel GetEdmModelAliased()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder {ModelAliasingEnabled = true};
+            var entitySetConfiguration = builder.EntitySet<SkipCustomer>("Customers");
+            //var entityType = entitySetConfiguration.EntityType;
+            //entityType.Property(sc => sc.Id)
+            //    .Name = "SkipCustomerId";
+            //entityType.HasKey(sc => sc.Id);
+            //entityType.Property(sc => sc.Name)
+            //    .Name = "FirstAndLastName";
+            //entityType.Property(sc => sc.Birthday)
+            //    .Name = "DateOfBirth";
+            //entityType.Property(sc => sc.Gender)
+            //    .Name = "MaleOrFemale";
+            //entityType.Property(sc => sc.Gender).
+            return builder.GetEdmModel();
+        }
+        
+        private void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_Implementation(
+            string baseUri,
+            string expectedUri,
+            IEdmModel edmModel)
+        {
+            // Arrange
+            ODataSerializerContext serializerContext = this.GetSerializerContext(
+                edmModel,
+                true);
+            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
+            SkipCustomer instance = new SkipCustomer {Id = 42, Name = "ZX"};
+
+            // Act
+            Uri uri = handler.GenerateNextPageLink(
+                new Uri(baseUri),
+                10,
+                instance,
+                serializerContext);
+            var actualUri = uri.ToString();
+
+            // Assert
+            Assert.Equal(
+                expectedUri,
+                actualUri);
+        }
+        
+        private static void GenerateSkipTokenValue_Returns_SkipTokenValue_Implementation(IEdmModel edmModel, string expectedSkipToken)
+        {
+            // Arrange
+            SkipCustomer lastMember = new SkipCustomer {Id = 42, Name = "ZX"};
+
+            // Act
+            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(
+                lastMember,
+                edmModel,
+                null);
+
+            // Assert
+            Assert.Equal(
+                expectedSkipToken,
+                skipTokenValue);
+        }
+
+        private static void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_Implementation(
+            IEdmModel edmModel,
+            string propertyName,
+            string expectedSkipToken)
+        {
+            // Arrange
+            SkipCustomer lastMember = new SkipCustomer {Id = 42, Name = "ZX"};
+
+            IEdmEntityType entityType = edmModel.SchemaElements.OfType<IEdmEntityType>()
+                .First(c => c.Name == "SkipCustomer");
+            IEdmProperty property = entityType.FindProperty(propertyName);
+            IList<OrderByNode> orderByNodes = new List<OrderByNode>
+                {
+                    new OrderByPropertyNode(
+                        property,
+                        OrderByDirection.Ascending)
+                };
+
+            // Act
+            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(
+                lastMember,
+                edmModel,
+                orderByNodes);
+
+            // Assert
+            Assert.Equal(
+                expectedSkipToken,
+                skipTokenValue);
+        }
+
+        private static void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_IfNullValue_Implementation(
+            IEdmModel edmModel,
+            string propertyName,
+            string expectedSkipToken)
+        {
+            // Arrange
+            SkipCustomer lastMember = new SkipCustomer {Id = 42, Name = null};
+
+            IEdmEntityType entityType = edmModel.SchemaElements.OfType<IEdmEntityType>()
+                .First(c => c.Name == "SkipCustomer");
+            IEdmProperty property = entityType.FindProperty(propertyName);
+            IList<OrderByNode> orderByNodes = new List<OrderByNode>
+                {
+                    new OrderByPropertyNode(
+                        property,
+                        OrderByDirection.Ascending)
+                };
+
+            // Act
+            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(
+                lastMember,
+                edmModel,
+                orderByNodes);
+
+            // Assert
+            Assert.Equal(
+                expectedSkipToken,
+                skipTokenValue);
+        }
+
+        private static void GenerateSkipTokenValue_Returns_SkipTokenValue_WithDateTimeOffset_Implementation(
+            IEdmModel edmModel,
+            string propertyName,
+            string expectedSkipToken)
+        {
+            // Arrange
+            SkipCustomer lastMember = new SkipCustomer
+                {
+                    Id = 42,
+                    Birthday = new DateTime(
+                        2021,
+                        01,
+                        20,
+                        3,
+                        4,
+                        5,
+                        DateTimeKind.Utc)
+                };
+
+            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8
+            IEdmEntityType entityType = edmModel.SchemaElements.OfType<IEdmEntityType>()
+                .First(c => c.Name == "SkipCustomer");
+            IEdmProperty property = entityType.FindProperty(propertyName);
+            IList<OrderByNode> orderByNodes = new List<OrderByNode>
+                {
+                    new OrderByPropertyNode(
+                        property,
+                        OrderByDirection.Ascending)
+                };
+
+            // Act
+            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(
+                lastMember,
+                edmModel,
+                orderByNodes,
+                timeZone);
+
+            // Assert
+            Assert.Equal(
+                expectedSkipToken,
+                skipTokenValue);
+        }
+        
+        private static void GenerateSkipTokenValue_Returns_SkipTokenValue_WithOrderby_WithEnumValue_Implementation(
+            IEdmModel edmModel,
+            string propertyName,
+            string expectedSkipToken)
+        {
+            // Arrange
+            SkipCustomer lastMember = new SkipCustomer {Id = 42, Name = "ZX", Gender = Gender.Male};
+
+            IEdmEntityType entityType = edmModel.SchemaElements.OfType<IEdmEntityType>()
+                .First(c => c.Name == "SkipCustomer");
+            IEdmProperty property = entityType.FindProperty(propertyName);
+            IList<OrderByNode> orderByNodes = new List<OrderByNode>
+                {
+                    new OrderByPropertyNode(
+                        property,
+                        OrderByDirection.Ascending)
+                };
+
+            // Act
+            string skipTokenValue = DefaultSkipTokenHandler.GenerateSkipTokenValue(
+                lastMember,
+                edmModel,
+                orderByNodes);
+
+            // Assert
+            Assert.Equal(
+                expectedSkipToken,
+                skipTokenValue);
+        }
+
+        private static void ApplyToSkipTokenHandler_ThrowsODataException_InvalidSkipTokenValue_Implementation(
+            IEdmModel edmModel)
+        {
+            // Arrange
+            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
+            ODataQuerySettings settings = new ODataQuerySettings {HandleNullPropagation = HandleNullPropagationOption.False};
+            ODataQueryContext context = new ODataQueryContext(
+                edmModel,
+                typeof(SkipCustomer));
+
+            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption(
+                "abc",
+                context);
+            IQueryable<SkipCustomer> customers = new List<SkipCustomer>().AsQueryable();
+
+            // Act & Assert
+            ExceptionAssert.Throws<ODataException>(
+                () => handler.ApplyTo(
+                    customers,
+                    skipTokenQuery,
+                    new ODataQuerySettings(),
+                    null),
+                "Unable to parse the skiptoken value 'abc'. Skiptoken value should always be server generated.");
+        }
+        
+        private static void ApplyToOfTDefaultSkipTokenHandler_Applies_ToQueryable_Implementation(
+            IEdmModel edmModel,
+            string skipTokenQueryOptionRawValue)
+        {
+            // Arrange
+            ODataQuerySettings settings = new ODataQuerySettings {HandleNullPropagation = HandleNullPropagationOption.False};
+            ODataQueryContext context = new ODataQueryContext(
+                edmModel,
+                typeof(SkipCustomer));
+
+            SkipTokenQueryOption skipTokenQuery = new SkipTokenQueryOption(
+                skipTokenQueryOptionRawValue,
+                context);
+            DefaultSkipTokenHandler handler = new DefaultSkipTokenHandler();
+            IQueryable<SkipCustomer> customers = new List<SkipCustomer>
+                {
+                    new SkipCustomer {Id = 2, Name = "Aaron"},
+                    new SkipCustomer {Id = 1, Name = "Andy"},
+                    new SkipCustomer {Id = 3, Name = "Alex"}
+                }.AsQueryable();
+
+            // Act
+            SkipCustomer[] results = handler.ApplyTo(
+                    customers,
+                    skipTokenQuery,
+                    settings,
+                    null)
+                .ToArray();
+
+            // Assert
+            SkipCustomer skipTokenCustomer = Assert.Single(results);
+            Assert.Equal(
+                3,
+                skipTokenCustomer.Id);
+            Assert.Equal(
+                "Alex",
+                skipTokenCustomer.Name);
+        }
+
+        [DataContract]
         public class SkipCustomer
         {
+            [DataMember(Name = "SkipCustomerId")]
             public int Id { get; set; }
 
+            [DataMember(Name = "FirstAndLastName")]
             public string Name { get; set; }
 
+            [DataMember(Name = "DateOfBirth")]
             public DateTime Birthday { get; set; }
 
+            [DataMember(Name = "MaleOrFemale")]
             public Gender Gender { get; set; }
         }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/DefaultSkipTokenHandlerTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         [Theory]
         [InlineData("http://localhost/Customers(1)/Orders", "http://localhost/Customers(1)/Orders?$skiptoken=Id-42")]
         [InlineData("http://localhost/Customers?$expand=Orders", "http://localhost/Customers?$expand=Orders&$skiptoken=Id-42")]
+        [InlineData("http://localhost/Customers?$select=Name", "http://localhost/Customers?$select=Name&$skiptoken=Id-42")]
         public void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink(string baseUri, string expectedUri)
         {
             // Arrange
@@ -78,7 +79,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
 
         [Theory]
         [InlineData("http://localhost/Customers(1)/Orders", "http://localhost/Customers(1)/Orders?$skiptoken=id-42")]
-        [InlineData("http://localhost/Customers?$expand=Orders", "http://localhost/Customers?$expand=Orders&$skiptoken=id-42")]
+        [InlineData("http://localhost/Customers?$expand=orders", "http://localhost/Customers?$expand=orders&$skiptoken=id-42")]
+        [InlineData("http://localhost/Customers?$select=name", "http://localhost/Customers?$select=name&$skiptoken=id-42")]
         public void GetNextPageLinkDefaultSkipTokenHandler_Returns_CorrectSkipTokenLink_WithLowerCamelCase(string baseUri, string expectedUri)
         {
             // Arrange


### PR DESCRIPTION
Based on issue #616 which I also encountered, I would like to propose this fix.

As I am not completely aware of side-effects that using only `edmProperty.Name` could have, I relied on a safe way to rollback to the EDM property name instead of the CLR one if the latter is not found.

https://github.com/OData/AspNetCoreOData/blob/10a246671b6312fd234151c47cc91787da5cb171/src/Microsoft.AspNetCore.OData/Query/Query/DefaultSkipTokenHandler.cs#LL136C1-L145C18

I tested this change with my current project, but I suspect that some unit tests might have to be "doubled" with a `builder.EnableLowerCamelCase()` scenario to check for regressions on property retrieval when using a lowercased convention.

edit: Also tested along with the `[DataContract]` and `[DataMember]` attributes which create aliases for properties.
