### PR TITLE
Server-side paging should not apply to collections of non-entity types

### DIFF
--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -289,4 +289,32 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
             return Ok((ribbon as ContainmentPagingExtendedMenu).Tabs);
         }
     }
+
+    public class CollectionPagingCustomersController : ODataController
+    {
+        private const int TargetSize = 3;
+        private static readonly List<CollectionPagingCustomer> customers = new List<CollectionPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new CollectionPagingCustomer
+            {
+                Id = idx,
+                Tags = new List<string> { "Tier 1", "Gen-Z", "HNW" },
+                Categories = new List<CollectionPagingCategory>
+                {
+                    CollectionPagingCategory.Retailer,
+                    CollectionPagingCategory.Wholesaler,
+                    CollectionPagingCategory.Distributor
+                },
+                Locations = new List<CollectionPagingLocation>(
+                    Enumerable.Range(1, TargetSize).Select(dx => new CollectionPagingLocation
+                    {
+                        Street = $"Street {idx}{dx}"
+                    }))
+            }));
+
+        [EnableQuery(PageSize = 2)]
+        public ActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -134,4 +134,24 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
         [Contained]
         public List<ContainedPagingItem> Items { get; set; }
     }
+
+    public enum CollectionPagingCategory
+    {
+        Retailer,
+        Wholesaler,
+        Distributor
+    }
+
+    public class CollectionPagingLocation
+    {
+        public string Street { get; set; }
+    }
+
+    public class CollectionPagingCustomer
+    {
+        public int Id { get; set; }
+        public List<string> Tags { get; set; }
+        public List<CollectionPagingCategory> Categories { get; set; }
+        public List<CollectionPagingLocation> Locations { get; set; }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
@@ -43,8 +43,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
                 typeof(ContainmentPagingCompanyController),
                 typeof(NoContainmentPagingCustomersController),
                 typeof(ContainmentPagingMenusController),
-                typeof(ContainmentPagingRibbonController));
-            services.AddControllers().AddOData(opt => opt.Expand().OrderBy().AddRouteComponents("{a}", edmModel));
+                typeof(ContainmentPagingRibbonController),
+                typeof(CollectionPagingCustomersController));
+            services.AddControllers().AddOData(opt => opt.Expand().OrderBy().Select().SetMaxTop(null).AddRouteComponents("{a}", edmModel));
         }
 
         protected static IEdmModel GetEdmModel()
@@ -60,6 +61,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
             builder.EntitySet<ContainmentPagingMenu>("ContainmentPagingMenus");
             builder.EntitySet<ContainmentPagingPanel>("ContainmentPagingPanels");
             builder.Singleton<ContainmentPagingMenu>("ContainmentPagingRibbon");
+            builder.EntitySet<CollectionPagingCustomer>("CollectionPagingCustomers");
 
             var getEmployeesHiredInPeriodFunction = builder.EntitySet<ServerSidePagingEmployee>(
                 "ServerSidePagingEmployees").EntityType.Collection.Function("GetEmployeesHiredInPeriod");
@@ -437,6 +439,84 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging
             Assert.Contains($"/prefix/ContainmentPagingPanels/2/{extendedPanelTypeName}/Items/5/{extendedItemTypeName}/Notes?$skip=2", content);
             Assert.Contains($"/prefix/ContainmentPagingPanels/2/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
             Assert.Contains($"{menu1ResourcePath}/Panels?$expand={extendedPanelTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("?$select=Tags,Categories,Locations")]
+        public async Task VerifyServerSidePagingNotAppliedToNonEntityCollections(string url)
+        {
+            // Arrange
+            var requestUri = $"/prefix/CollectionPagingCustomers{url}";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var client = CreateClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            var pageResult = content.GetValue("value") as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Equal(2, pageResult.Count);
+
+            foreach (JObject item in pageResult)
+            {
+                var tags = item.GetValue("Tags") as JArray;
+                Assert.NotNull(tags);
+                Assert.Equal(3, tags.Count);
+
+                var categories = item.GetValue("Categories") as JArray;
+                Assert.NotNull(categories);
+                Assert.Equal(3, categories.Count);
+
+                var locations = item.GetValue("Locations") as JArray;
+                Assert.NotNull(locations);
+                Assert.Equal(3, locations.Count);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyClientSidePagingAppliedToNonEntityCollections()
+        {
+            // Arrange
+            var requestUri = "/prefix/CollectionPagingCustomers?$select=Tags($skip=1;$top=1),Categories($skip=1;$top=1),Locations($skip=1;$top=1)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var client = CreateClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            var pageResult = content.GetValue("value") as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Equal(2, pageResult.Count);
+
+            JObject page;
+            string tag;
+            CollectionPagingCategory? category;
+            CollectionPagingLocation location;
+
+            page = pageResult[0] as JObject;
+            tag = Assert.Single(page.GetValue("Tags")).ToObject<string>();
+            category = Assert.Single(page.GetValue("Categories")).ToObject<CollectionPagingCategory?>();
+            location = Assert.Single(page.GetValue("Locations")).ToObject<CollectionPagingLocation>();
+
+            Assert.Equal("Gen-Z", tag);
+            Assert.Equal(CollectionPagingCategory.Wholesaler, category);
+            Assert.NotNull(location);
+            Assert.Equal("Street 12", location.Street);
+
+            page = pageResult[1] as JObject;
+            tag = Assert.Single(page.GetValue("Tags")).ToObject<string>();
+            category = Assert.Single(page.GetValue("Categories")).ToObject<CollectionPagingCategory?>();
+            location = Assert.Single(page.GetValue("Locations")).ToObject<CollectionPagingLocation>();
+
+            Assert.Equal("Gen-Z", tag);
+            Assert.Equal(CollectionPagingCategory.Wholesaler, category);
+            Assert.NotNull(location);
+            Assert.Equal("Street 22", location.Street);
         }
     }
 


### PR DESCRIPTION
This pull request ports the following 7.x fix to 8.x: https://github.com/OData/WebApi/pull/2785