### PR TITLE
fixes #931: Undeclared enum type value for untype value serialized as empty resource

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1414,8 +1414,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                     {
                         Name = structuralProperty.Name,
 
-                        // TBD: Shall we write the un-declared enum value as full-name string?
+                        // Shall we write the un-declared enum value as full-name string?
                         // So, "Data":"Apple"  => should be ""Data":"Namespace.EnumTypeName.Apple" ?
+                        // We keep it simple to write it as string (enum member name), not the full-name string.
                         Value = propertyValue.ToString()
                     };
                 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedDataSource.cs
@@ -98,6 +98,20 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Untyped
                         }
                     },
 
+                    // not in model enum
+                    new InModelPerson
+                    {
+                        Id = 22, // special Id number
+                        Name = "Yin",
+                        Data = NotInModelEnum.Apple,
+                        Infos = new object[] { InModelColor.Blue, InModelColor.Green, NotInModelEnum.Apple },
+                        Containers = new Dictionary<string, object>
+                        {
+                            { "EnumDynamic1", InModelColor.Blue },
+                            { "EnumDynamic2", NotInModelEnum.Apple },
+                        }
+                    },
+
                     // In model complex
                     new InModelPerson
                     {

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedTests.cs
@@ -325,6 +325,34 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Untyped
         }
 
         [Fact]
+        public async Task QuerySinglePeople_WithDeclaredOrUndeclaredEnum_OnUntypedAndDynamicProperty()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync("odata/people/22");
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":22," +
+                "\"Name\":\"Yin\"," +
+                "\"EnumDynamic1@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelColor\"," +
+                "\"EnumDynamic1\":\"Blue\"," +
+                "\"EnumDynamic2\":\"Apple\"," +
+                "\"Data@odata.type\":\"#String\"," +
+                "\"Data\":\"Apple\"," +
+                "\"Infos\":[\"Blue\",\"Green\",\"Apple\"]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
         public async Task QuerySinglePeople_WithCollectionInCollection_OnDeclaredUntypedProperty()
         {
             // Arrange


### PR DESCRIPTION
fixes #931

If we have
```C#
public enum UserType {...}
```
But this enum is not defined in OData model.

Suppose we use this C# enum to assign a value for a untyped property or dynamic property, the result is empty resource.

Person p = new Person
{
    Data = UserType.Admin  // System.Object Data {get;set;}
}
We get:

"Data": {},

This PR is to fix this issue.

To Be discussed: Shall we write the full-name of enum member as string into OData payload? @mikepizzo 