### PR TITLE
Make UpdateODataResult inherit from ObjectResult

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
@@ -20,13 +20,14 @@ namespace Microsoft.AspNetCore.OData.Results
     /// </summary>
     /// <typeparam name="T">The entity type.</typeparam>
     /// <remarks>This action result handles content negotiation and the HTTP prefer header.</remarks>
-    public class UpdatedODataResult<T> : ActionResult
+    public class UpdatedODataResult<T> : ObjectResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdatedODataResult{T}"/> class.
         /// </summary>
         /// <param name="entity">The updated entity.</param>
         public UpdatedODataResult(T entity)
+            : base(entity)
         {
             Entity = entity ?? throw new ArgumentNullException(nameof(entity));
         }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandController.cs
@@ -51,6 +51,19 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
         {
             return Created(customer);
         }
+
+        [EnableQuery]
+        public IActionResult Put(int key, [FromBody] Customer customer)
+        {
+            var existingCustomer = AutoExpandDataSource.Customers.FirstOrDefault(d => d.Id == key);
+
+            if (existingCustomer == null)
+            {
+                return BadRequest();
+            }
+
+            return Updated(existingCustomer);
+        }
     }
 
     public class PeopleController : ODataController

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/AutoExpand/AutoExpandTests.cs
@@ -453,5 +453,40 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand
                 Assert.Contains(expectedOrder, json);
             }
         }
+
+        [Fact]
+        public async Task PutCustomer_AutoExpandNavigationProperties()
+        {
+            //Arrange
+            var requestUri = "autoexpand/Customers(2)";
+            var content = "{\"Id\":2}";
+            var client = CreateClient();
+            var stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+
+            var expectedOrder = "\"Order\":{\"Id\":2,\"Choice\":{\"Id\":2,\"Amount\":2000.0}}";
+            var expectedFriend = "\"Friend\":{" +
+                "\"Id\":1," +
+                "\"HomeAddress\":{" +
+                "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.AutoExpand.UsAddress\"," +
+                "\"Street\":\"UsStreet 1\"," +
+                "\"City\":\"UsCity 1\"," +
+                "\"CountryOrRegion\":{\"Id\":101,\"Name\":\"C and R 101\"}," +
+                "\"ZipCode\":{\"Id\":2001,\"Code\":\"Code 1\"}}," +
+                "\"Order\":{\"Id\":1}," +
+                "\"Friend\":null}}";
+
+            //Act & Assert
+            using (var request = new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = stringContent })
+            {
+                request.Headers.Add("Prefer", "return=representation");
+                using (var response = await client.SendAsync(request))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    var json = response.Content.ReadAsStringAsync().Result;
+                    Assert.Contains(expectedFriend, json);
+                    Assert.Contains(expectedOrder, json);
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -1726,7 +1726,7 @@ public class Microsoft.AspNetCore.OData.Results.UnprocessableEntityODataResult :
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 
-public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft.AspNetCore.Mvc.ActionResult, IActionResult {
+public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft.AspNetCore.Mvc.ObjectResult, IActionResult, IStatusCodeActionResult {
 	public UpdatedODataResult`1 (T entity)
 
 	T Entity  { public virtual get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -1726,7 +1726,7 @@ public class Microsoft.AspNetCore.OData.Results.UnprocessableEntityODataResult :
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 
-public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft.AspNetCore.Mvc.ActionResult, IActionResult {
+public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft.AspNetCore.Mvc.ObjectResult, IActionResult, IStatusCodeActionResult {
 	public UpdatedODataResult`1 (T entity)
 
 	T Entity  { public virtual get; }


### PR DESCRIPTION
This pull request fixes #972 and fixes #434.

Make `UpdateODataResult` inherit from `ObjectResult`.