### PR TITLE
Make output set of $apply transformations available for subsequent transformations or other query operators

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Validator/ODataQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/ODataQueryValidator.cs
@@ -39,12 +39,9 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 options.Compute.Validate(validationSettings);
             }
 
-            if (options.Apply != null)
+            if (options.Apply?.ApplyClause != null)
             {
-                if (options.Apply.ApplyClause != null)
-                {
-                    ValidateQueryOptionAllowed(AllowedQueryOptions.Apply, validationSettings.AllowedQueryOptions);
-                } 
+                ValidateQueryOptionAllowed(AllowedQueryOptions.Apply, validationSettings.AllowedQueryOptions);
             }
 
             if (options.Skip != null)

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/ODataQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/ODataQueryValidator.cs
@@ -41,7 +41,10 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
 
             if (options.Apply != null)
             {
-                ValidateQueryOptionAllowed(AllowedQueryOptions.Apply, validationSettings.AllowedQueryOptions);
+                if (options.Apply.ApplyClause != null)
+                {
+                    ValidateQueryOptionAllowed(AllowedQueryOptions.Apply, validationSettings.AllowedQueryOptions);
+                } 
             }
 
             if (options.Skip != null)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationController.cs
@@ -102,4 +102,49 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.EntitySetAggregation
             return employees.AsQueryable();
         }
     }
+
+    public class OrdersController : ODataController
+    {
+        private readonly EntitySetAggregationContext _context;
+
+        public OrdersController(EntitySetAggregationContext context)
+        {
+            context.Database.EnsureCreated();
+            _context = context;
+
+            if (!_context.Orders.Any())
+            {
+                Generate();
+            }
+        }
+
+        [EnableQuery]
+        public IQueryable<Order> Get()
+        {
+            return _context.Orders;
+        }
+
+        [EnableQuery]
+        public SingleResult<Order> Get(int key)
+        {
+            return SingleResult.Create(_context.Orders.Where(c => c.Id == key));
+        }
+
+        public void Generate()
+        {
+            for (int i = 1; i <= 3; i++)
+            {
+                var order = new Order
+                {
+                    Name = "Order" + 2 * i,
+                    Price = i * 25,
+                    SaleInfo = new SaleInfo { Quantity = i, UnitPrice = 25 }
+                };
+
+                _context.Orders.Add(order);
+            }
+
+            _context.SaveChanges();
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationDataModel.cs
@@ -22,6 +22,8 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.EntitySetAggregation
 
         public DbSet<Customer> Customers { get; set; }
 
+        public DbSet<Order> Orders { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Customer>().OwnsOne(c => c.Address).WithOwner();


### PR DESCRIPTION
This PR fixes https://github.com/OData/AspNetCoreOData/issues/945, #984 

This fix makes this work: 
```url
http://localhost:5000/odata/Orders?$apply=groupby((Customer/Name), aggregate($count as OrderCount, TotalAmount with sum as Total))&$orderby=Total desc
```

Like you can use the output of $apply transformations, `Total`,  in this case to perform subsequent transformations, `$orderby` in this case. 

This is how the `ApplyClause` property looks like: 

```c#
        public ApplyClause ApplyClause
        {
            get
            {
                if (_applyClause == null)
                {
                    _applyClause = _queryOptionParser.ParseApply();
                }

                return _applyClause;
            }
        }
```

So what happens when this is called: `if (options.Apply?.ApplyClause != null)`.  if `ApplyClause` is null,which will be null at this point, then the `ParseApply` gets called which parses the apply clause and binds the dynamic properties introduced in the `$apply` transformation. This makes these properties recognizable in subsequent transformations.

Before this change, the parsing of the apply clause was not happening before the `$orderby` gets called. 