### PR TITLE
Support writing nested entities without a navigation source.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1179,22 +1179,25 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             IEdmNavigationSource navigationSource = writeContext.NavigationSource;
             ODataNestedResourceInfo navigationLink = null;
 
-            if (navigationSource != null && navigationProperty.Type != null)
+            if (navigationProperty.Type != null)
             {
                 IEdmTypeReference propertyType = navigationProperty.Type;
-                IEdmModel model = writeContext.Model;
-                NavigationSourceLinkBuilderAnnotation linkBuilder = EdmModelLinkBuilderExtensions.GetNavigationSourceLinkBuilder(model, navigationSource);
-                Uri navigationUrl = linkBuilder.BuildNavigationLink(resourceContext, navigationProperty, writeContext.MetadataLevel);
-
                 navigationLink = new ODataNestedResourceInfo
                 {
                     IsCollection = propertyType.IsCollection(),
                     Name = navigationProperty.Name,
                 };
 
-                if (navigationUrl != null)
+                if (navigationSource != null)
                 {
-                    navigationLink.Url = navigationUrl;
+                    IEdmModel model = writeContext.Model;
+                    NavigationSourceLinkBuilderAnnotation linkBuilder = EdmModelLinkBuilderExtensions.GetNavigationSourceLinkBuilder(model, navigationSource);
+                    Uri navigationUrl = linkBuilder.BuildNavigationLink(resourceContext, navigationProperty, writeContext.MetadataLevel);
+
+                    if (navigationUrl != null)
+                    {
+                        navigationLink.Url = navigationUrl;
+                    }
                 }
             }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -7,7 +7,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Abstracts;
@@ -20,6 +23,7 @@ using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.AspNetCore.OData.Tests.Edm;
 using Microsoft.AspNetCore.OData.Tests.Extensions;
 using Microsoft.AspNetCore.OData.Tests.Models;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OData;
@@ -2250,6 +2254,71 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
         }
 
         [Fact]
+        public async Task WriteObjectInlineAsync_Writes_Nested_Entities_Without_NavigationSource()
+        {
+            // Arrange
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            builder.Namespace = "Default";
+            builder.EntityType<Product>();
+            builder.ComplexType<Result>();
+            var model = builder.GetEdmModel();
+
+            var result = new Result
+            {
+                Title = "myResult",
+                Products = new Product[]
+                {
+                    new Product
+                    {
+                        ProductID = 1
+                    },
+                    new Product
+                    {
+                        ProductID = 2
+                    }
+                }
+            };
+
+            var resultType = model.FindType("Default.Result") as IEdmComplexType;
+            var resultTypeReference = new EdmComplexTypeReference(resultType as IEdmComplexType, false);
+            var titleProperty = resultTypeReference.FindProperty("Title") as IEdmStructuralProperty;
+            var productsProperty = resultTypeReference.FindNavigationProperty("Products");
+            var selectExpand = new SelectExpandClause(new SelectItem[]
+                {
+                    new PathSelectItem(new ODataSelectPath(new PropertySegment(titleProperty))),
+                    new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(productsProperty, null)),null,null)
+                },
+             false);
+
+            var writeContext = new ODataSerializerContext() 
+            { 
+                Model = model,
+                SelectExpandClause = selectExpand
+            };
+            var stream = new MemoryStream();
+            IODataResponseMessage responseMessage = new ODataMessageWrapper(stream);
+            ODataUri uri = new ODataUri { ServiceRoot = new Uri("http://myService", UriKind.Absolute) };
+            ODataMessageWriterSettings settings = new ODataMessageWriterSettings
+            {
+                ODataUri = uri                
+            };
+            ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, settings);
+            ODataWriter writer = await messageWriter.CreateODataResourceWriterAsync(null, resultType as IEdmComplexType);
+
+            ODataResourceSerializer serializer = new ODataResourceSerializer(_serializerProvider);
+
+            // Act
+            await serializer.WriteObjectInlineAsync(result, resultTypeReference, writer, writeContext);
+
+            // Assert
+            stream.Position = 0;
+            StreamReader reader = new StreamReader(stream);
+            string response = reader.ReadToEnd();
+            Assert.Contains(@"""ProductID"":1", response);
+            Assert.Contains(@"""ProductID"":2", response);
+        }
+
+        [Fact]
         public void CreateSelectExpandNode_Caches_SelectExpandNode()
         {
             // Arrange
@@ -2485,6 +2554,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             public string Name { get; set; }
             public string Shipment { get; set; }
             public Customer Customer { get; set; }
+        }
+
+        private class Result
+        {
+            public string Title { get; set; }
+            public IList<Product> Products { get; set; }
         }
 
         private class SpecialOrder


### PR DESCRIPTION
There are cases where we don't have a URL when writing a collection of nested entities. This may be, for example, because there was no navigation property binding for the collection, because the collection was returned as the child of a complex type returned by a function, or because the entities were "transient".

In any case, lack of a URL should not prevent us from writing the nested data, if available.

Currently, we conflate writing the content with writing the url and, if we can't determine a navigation source, we skip writing the nested content entirely (although there are other cases where, even though we have a navigation source, we can't determine the url, so we already have cases where we write nested content without the url but only if we have a navigation source.)

This PR allows writing the content in any case, and optionally adds the URL if the necessary information is available.