### PR TITLE
fixes #954, enable to read the untyped value with odata.type annotated

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -99,8 +99,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             {
                 if (!_isNoClrType.HasValue)
                 {
-                    _isNoClrType = TypeHelper.IsTypeAssignableFrom(typeof(IEdmObject), ResourceType) ||
-                        typeof(ODataUntypedActionParameters) == ResourceType;
+                    _isNoClrType = (TypeHelper.IsTypeAssignableFrom(typeof(IEdmObject), ResourceType) &&
+                        (typeof(EdmUntypedObject) != ResourceType && typeof(EdmUntypedCollection) != ResourceType))
+                        || typeof(ODataUntypedActionParameters) == ResourceType;
                 }
 
                 return _isNoClrType.Value;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -90,6 +90,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             }
         }
 
+        // TODO: need refactor this part.
+        // We can't only use the resource type to identify there's no Clr Type or not.
+        // We should use the model type mapping to identify there's no Clr Type or not.
         internal bool IsNoClrType
         {
             get

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                 if (deserializer == null)
                 {
                     throw new SerializationException(
-                        Error.Format(SRResources.TypeCannotBeDeserialized, actualEntityType.FullName()));
+                        Error.Format(SRResources.TypeCannotBeDeserialized, actualStructuredType.FullName()));
                 }
 
                 object resource = deserializer.ReadInline(resourceWrapper, actualStructuredType, readContext);
@@ -611,8 +611,16 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 
             if (edmType.IsUntyped())
             {
-                nestedReadContext.ResourceType = typeof(EdmUntypedObject);
-                return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
+                if (resourceWrapper.Resource.TypeName == null || resourceWrapper.Resource.TypeName == "Edm.Untyped")
+                {
+                    nestedReadContext.ResourceType = typeof(EdmUntypedObject);
+                    return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
+                }
+                else
+                {
+                    // We should use the given type name to read
+                    edmType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
+                }
             }
 
             IEdmStructuredTypeReference structuredType = edmType.AsStructured();

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -611,15 +611,13 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 
             if (edmType.IsUntyped())
             {
-                if (resourceWrapper.Resource.TypeName == null || resourceWrapper.Resource.TypeName == "Edm.Untyped")
+                // We should use the given type name to replace the EdmType.
+                // If it's real untyped, use untyped object to read.
+                edmType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
+                if (edmType.IsUntyped())
                 {
                     nestedReadContext.ResourceType = typeof(EdmUntypedObject);
                     return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
-                }
-                else
-                {
-                    // We should use the given type name to read
-                    edmType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -202,7 +202,49 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
                     Error.Format(SRResources.TypeCannotBeDeserialized, elementType.FullName()));
             }
 
-            return deserializer.ReadInline(resourceWrapper, elementType, readContext);
+            ODataDeserializerContext nestedReadContext = readContext.CloneWithoutType();
+            if (elementType == null || elementType.IsUntyped())
+            {
+                if (resourceWrapper.Resource.TypeName == null || resourceWrapper.Resource.TypeName == "Edm.Untyped")
+                {
+                    nestedReadContext.ResourceType = typeof(EdmUntypedObject);
+                }
+                else
+                {
+                    // We should use the given type name to read
+                    elementType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
+                }
+            }
+
+            if (nestedReadContext.ResourceType == null)
+            {
+                Type clrType = readContext.Model.GetClrType(elementType);
+                if (clrType == null)
+                {
+                    if (readContext.IsNoClrType)
+                    {
+                        if (elementType.IsEntity())
+                        {
+                            nestedReadContext.ResourceType = typeof(EdmEntityObject);
+                        }
+                        else
+                        {
+                            nestedReadContext.ResourceType = typeof(EdmComplexObject);
+                        }
+                    }
+                    else
+                    {
+                        throw new ODataException(
+                            Error.Format(SRResources.MappingDoesNotContainResourceType, elementType.FullName()));
+                    }
+                }
+                else
+                {
+                    nestedReadContext.ResourceType = clrType;
+                }
+            }
+
+            return deserializer.ReadInline(resourceWrapper, elementType, nestedReadContext);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -215,28 +215,26 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
 
             if (nestedReadContext.ResourceType == null)
             {
-                Type clrType = readContext.Model.GetClrType(elementType);
-                if (clrType == null)
+                if (readContext.IsNoClrType)
                 {
-                    if (readContext.IsNoClrType)
+                    if (elementType.IsEntity())
                     {
-                        if (elementType.IsEntity())
-                        {
-                            nestedReadContext.ResourceType = typeof(EdmEntityObject);
-                        }
-                        else
-                        {
-                            nestedReadContext.ResourceType = typeof(EdmComplexObject);
-                        }
+                        nestedReadContext.ResourceType = typeof(EdmEntityObject);
                     }
                     else
                     {
-                        throw new ODataException(
-                            Error.Format(SRResources.MappingDoesNotContainResourceType, elementType.FullName()));
+                        nestedReadContext.ResourceType = typeof(EdmComplexObject);
                     }
                 }
                 else
                 {
+                    Type clrType = readContext.Model.GetClrType(elementType);
+                    if (clrType == null)
+                    {
+                        throw new ODataException(
+                            Error.Format(SRResources.MappingDoesNotContainResourceType, elementType.FullName()));
+                    }
+
                     nestedReadContext.ResourceType = clrType;
                 }
             }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -205,14 +205,11 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             ODataDeserializerContext nestedReadContext = readContext.CloneWithoutType();
             if (elementType == null || elementType.IsUntyped())
             {
-                if (resourceWrapper.Resource.TypeName == null || resourceWrapper.Resource.TypeName == "Edm.Untyped")
+                // We should use the given type name to read
+                elementType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
+                if (elementType.IsUntyped())
                 {
                     nestedReadContext.ResourceType = typeof(EdmUntypedObject);
-                }
-                else
-                {
-                    // We should use the given type name to read
-                    elementType = readContext.Model.ResolveResourceType(resourceWrapper.Resource);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2282,7 +2282,15 @@
             </summary>
             <param name="model">The Edm model.</param>
             <param name="resourceSet">The given resource set.</param>
-            <returns></returns>
+            <returns>The resolved type.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.ResolveResourceType(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.ODataResourceBase)">
+            <summary>
+            Resolve the type reference from the type name of <see cref="T:Microsoft.OData.ODataResourceBase"/>
+            </summary>
+            <param name="model">The Edm model.</param>
+            <param name="resource">The given resource.</param>
+            <returns>The resolved type.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Edm.EdmModelExtensions.GetAllProperties(Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType)">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1177,19 +1177,6 @@
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.GetImplementedIEnumerableType(System.Type)">
             <summary>
             Returns type of T if the type implements IEnumerable of T, otherwise, return null.
-            e otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsCollection(System.Type,System.Type@)">
-            <summary>
-            Determine if a type is a collection.
-            </summary>
-            <param name="clrType">The type to test.</param>
-            <param name="elementType">out: the element type of the collection.</param>
-            <returns>True if the type is an enumeration; false otherwise.</returns>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.GetImplementedIEnumerableType(System.Type)">
-            <summary>
-            Returns type of T if the type implements IEnumerable of T, otherwise, return null.
             </summary>
             <param name="type"></param>
             <returns></returns>
@@ -1488,6 +1475,18 @@
             <param name="dynamicDictionaryPropertyInfo">The property info that is used as dictionary of dynamic
             properties. <c>null</c> means this entity type is not open.</param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource`1.#ctor(System.Type,System.Collections.Generic.IEnumerable{System.String},System.Reflection.PropertyInfo,System.Boolean)">
+            <summary>
+            Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource`1"/>.
+            </summary>
+            <param name="structuralType">The derived entity type which the changes would be tracked.
+            <paramref name="structuralType"/> should be assignable to instances of <typeparamref name="T"/>.</param>
+            <param name="updatableProperties">The set of properties that can be updated or reset. Unknown property
+            names, including those of dynamic properties, are ignored.</param>
+            <param name="dynamicDictionaryPropertyInfo">The property info that is used as dictionary of dynamic
+            <param name="isComplexType">If structuralType is a complex type.</param>
+            properties. <c>null</c> means this entity type is not open.</param>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.Deltas.DeltaDeletedResource`1.Id">
             <inheritdoc />
         </member>
@@ -1649,8 +1648,41 @@
             <param name="updatableProperties">The set of properties that can be updated or reset. Unknown property
             names, including those of dynamic properties, are ignored.</param>
             <param name="dynamicDictionaryPropertyInfo">The property info that is used as dictionary of dynamic
-            properties. <c>null</c> means nger
+            properties. <c>null</c> means this entity type is not open.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.#ctor(System.Type,System.Collections.Generic.IEnumerable{System.String},System.Reflection.PropertyInfo,System.Boolean)">
+            <summary>
+            Initializes a new instance of <see cref="T:Microsoft.AspNetCore.OData.Deltas.Delta`1"/>.
+            </summary>
+            <param name="structuralType">The derived entity type or complex type for which the changes would be tracked.
+            <paramref name="structuralType"/> should be assignable to instances of <typeparamref name="T"/>.
+            </param>
+            <param name="updatableProperties">The set of properties that can be updated or reset. Unknown property
+            names, including those of dynamic properties, are ignored.</param>
+            <param name="dynamicDictionaryPropertyInfo">The property info that is used as dictionary of dynamic
+            properties. <c>null</c> means this entity type is not open.</param>
+            <param name="isComplexType">If structuralType is a complex type.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.Kind">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.StructuredType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.ExpectedClrType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.UpdatableProperties">
+            <summary>
+            The list of property names that can be updated.
+            </summary>
+            <remarks>When the list is modified, any modified properties that were removed from the list are no longer
             considered to be changed.</remarks>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Deltas.Delta`1.IsComplexType">
+            <summary>
+            If the StructuralType is a Complex type.
+            </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.Clear">
             <inheritdoc/>
@@ -1718,23 +1750,11 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.Patch(`0)">
             <summary>
-            Overwrites the <paramref name="origina="original"/> entity recursively.
-            </summary>
-            <param name="original">The entity to be updated.</param>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.CopyUnchangedValues(`0)">
-            <summary>
-            Copies the unchanged property values from the underlying entity (accessible via <see cref="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.GetInstance" />)
-            to the <paramref name="original"/> entity.
-            </summary>
-            <param name="original">The entity to be updated.</param>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.Patch(`0)">
-            <summary>
             Overwrites the <paramref name="original"/> entity with the changes tracked by this Delta.
             <remarks>The semantics of this operation are equivalent to a HTTP PATCH operation, hence the name.</remarks>
             </summary>
             <param name="original">The entity to be updated.</param>
+            <returns>The updated entity.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.Put(`0)">
             <summary>
@@ -6043,6 +6063,19 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.TypedEdmStructuredObject.TryGetPropertyValue(System.String,System.Object@)">
             <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.PropertyGetterCacheEqualityComparer">
+            <summary>
+            A custom equality comparer for the property getter cache. 
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.PropertyGetterCacheEqualityComparer.GetHashCode(System.ValueTuple{System.String,System.Type})">
+            <summary>
+            This method overrides the default GetHashCode() implementation
+            for a tuple of (string, Type) to provide a more effective hash code.
+            </summary>
+            <param name="obj">The tuple object to calculate a hash code for</param>
+            <returns>The calculated hash code. </returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.TypedEdmUntypedObject">
             <summary>
@@ -12383,7 +12416,7 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateBinaryOperatorNode(Microsoft.OData.UriParser.BinaryOperatorNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
             <summary>
-            override this method to restrict the binary operators inside the $orderby query.
+            Override this method to restrict the binary operators inside the $orderby query.
             That includes all the logical operators except 'not' and all math operators.
             </summary>
             <param name="binaryOperatorNode">The binary operator node to validate.</param>
@@ -12464,7 +12497,7 @@
             <summary>
             The recursive method that validate most of the query node type is of CollectionNode type.
             </summary>
-            <param name="node">The single value node.</param>
+            <param name="node">The collection value node.</param>
             <param name="validatorContext">The validator context.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionResourceCastNode(Microsoft.OData.UriParser.CollectionResourceCastNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedControllers.cs
@@ -1,11 +1,13 @@
 //-----------------------------------------------------------------------------
-// <copyright file="PropertyNameCaseSensitiveControllers.cs" company=".NET Foundation">
+// <copyright file="UntypedController.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //------------------------------------------------------------------------------
 
-using System.IdentityModel.Tokens.Jwt;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
@@ -62,6 +64,48 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Untyped
         public IActionResult Post([FromBody] InModelPerson person)
         {
             Assert.NotNull(person);
+
+            if (person.Id == 90) // primitive
+            {
+                Assert.IsType<Guid>(person.Data);
+                Assert.Equal(new Guid("40EE4E85-C443-41B2-9611-C55F97D80E84"), person.Data);
+                return Created(person);
+            }
+
+            if (person.Id == 91) // enum
+            {
+                Assert.Equal(InModelColor.Blue, person.Data);
+                return Created(person);
+            }
+
+            if (person.Id == 92) // resource
+            {
+                InModelAddress address = Assert.IsType<InModelAddress>(person.Data);
+                Assert.Equal("Redmond", address.City);
+                Assert.Equal("156TH AVE", address.Street);
+                return Created(person);
+            }
+
+            if (person.Id == 93) // collection of primitive
+            {
+                IEnumerable<int> enumerable = person.Data as IEnumerable<int>;
+                Assert.Collection(enumerable,
+                    e => Assert.Equal(4, e),
+                    e => Assert.Equal(5, e));
+                return Created(person);
+            }
+
+            if (person.Id == 94) // collection of mix
+            {
+                EdmUntypedCollection untypedcoll = Assert.IsType<EdmUntypedCollection>(person.Data);
+                Assert.Equal(2, untypedcoll.Count);
+                Assert.Equal(4, untypedcoll.ElementAt(0));
+                InModelAddress address = Assert.IsType<InModelAddress>(untypedcoll.ElementAt(1));
+                Assert.Equal("Earth", address.City);
+                Assert.Equal("Min AVE", address.Street);
+                return Created(person);
+            }
+
             if (person.Id == 98)
             {
                 // 98 is special created

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedDataModel.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Untyped
 
         public object Data { get; set; } // ==> Declared Edm.Untyped
 
-        public IList<object> Infos { get; set; } // ==> Declared Collection(Edm.Untyped)
+        public IList<object> Infos { get; set; } = new List<object>();// ==> Declared Collection(Edm.Untyped)
 
         public IDictionary<string, object> Containers { get; set; }
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Untyped/UntypedTests.cs
@@ -411,6 +411,181 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.Untyped
         }
 
         [Fact]
+        public async Task CreatePerson_WithPrimitiveUntypedValueODataTyped_Works_RoundTrip()
+        {
+            // Arrange
+            const string payload = @"{
+  ""data@odata.type"": ""#Edm.Guid"",
+  ""data"":""40EE4E85-C443-41B2-9611-C55F97D80E84"",
+  ""id"": 90
+}";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "odata/people");
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = payload.Length;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":90," +
+                "\"Name\":null," +
+                "\"Data@odata.type\":\"#Guid\"," +
+                "\"Data\":\"40ee4e85-c443-41b2-9611-c55f97d80e84\"," +
+                "\"Infos\":[]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
+        public async Task CreatePerson_WithEnumUntypedValueODataTyped_Works_RoundTrip()
+        {
+            // Arrange
+            const string payload = @"{
+  ""data@odata.type"": ""#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelColor"",
+  ""data"":""Blue"",
+  ""id"": 91
+}";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "odata/people");
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = payload.Length;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":91," +
+                "\"Name\":null," +
+                "\"Data\":\"Blue\"," +
+                "\"Infos\":[]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
+        public async Task CreatePerson_WithResourceUntypedValueODataTyped_Works_RoundTrip()
+        {
+            // Arrange
+            const string payload = @"{
+  ""data"":{
+    ""@odata.type"":""#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelAddress"",
+    ""City"":""Redmond"",
+    ""Street"":""156TH AVE""
+  },
+  ""id"": 92
+}";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "odata/people");
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = payload.Length;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":92," +
+                "\"Name\":null," +
+                "\"Data\":{\"City\":\"Redmond\",\"Street\":\"156TH AVE\"}," +
+                "\"Infos\":[]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
+        public async Task CreatePerson_WithPrimitiveCollectionUntypedValueODataTyped_Works_RoundTrip()
+        {
+            // Arrange
+            const string payload = @"{
+  ""data"":[
+    4,
+    {
+      ""@odata.type"":""#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelAddress"",
+      ""City"":""Earth"",
+      ""Street"":""Min AVE""
+    }
+  ],
+  ""id"": 94
+}";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "odata/people");
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = payload.Length;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":94," +
+                "\"Name\":null," +
+                "\"Data\":[" +
+                  "4," +
+                  "{" +
+                    "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelAddress\"," +
+                    "\"City\":\"Earth\"," +
+                    "\"Street\":\"Min AVE\"" +
+                  "}" +
+                "]," +
+                "\"Infos\":[]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
+        public async Task CreatePerson_WithCollectionItemUntypedValueODataTyped_Works_RoundTrip()
+        {
+            // Arrange
+            const string payload = @"{
+  ""data@odata.type"":""#Collection(Edm.Int32)"",
+  ""data"":[
+    4,
+    5
+  ],
+  ""id"": 93
+}";
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "odata/people");
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            request.Content.Headers.ContentLength = payload.Length;
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#People/$entity\"," +
+                "\"Id\":93," +
+                "\"Name\":null," +
+                "\"Data\":[4,5]," +
+                "\"Infos\":[]" +
+              "}", payloadBody);
+        }
+
+        [Fact]
         public async Task CreatePerson_Works_RoundTrip()
         {
             // Arrange


### PR DESCRIPTION
fixes #954, enable to read the untyped value with odata.type annotated.

### primitive
{
  "data@odata.type": "#Edm.Guid",
  "data":"40EE4E85-C443-41B2-9611-C55F97D80E84",
}

### enum
{
    "data@odata.type":"#UntypedApp.Models.Gender",
    "data": "Male"
}

### resource/object
{
   "data":{
     "@odata.type":"#Microsoft.AspNetCore.OData.E2E.Tests.Untyped.InModelAddress",
      "City":"Redmond",
     "Street":"156TH AVE"
   }
}

### collection

{
  "data@odata.type":"#Collection(Edm.Int32)",
  "data":[
    4,
    5
  ]
}