### PR TITLE
fixes #986: pass Order value to selector model generated

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             IServiceProvider sp = context.Options.RouteComponents[prefix].ServiceProvider;
 
             SelectorModel newSelectorModel = CreateActionSelectorModel(prefix, model, sp, newRouteTemplate, actionSelector,
-                        attributeRouteModel.Template, actionModel.ActionName, controllerModel.ControllerName);
+                        attributeRouteModel.Template, actionModel.ActionName, controllerModel.ControllerName, attributeRouteModel.Order);
             if (newSelectorModel != null)
             {
                 IList<SelectorModel> selectors;
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
 
         private SelectorModel CreateActionSelectorModel(string prefix, IEdmModel model, IServiceProvider sp,
             string routeTemplate, SelectorModel actionSelectorModel,
-            string originalTemplate, string actionName, string controllerName)
+            string originalTemplate, string actionName, string controllerName, int? order)
         {
             try
             {
@@ -182,7 +182,8 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
                     // replace the attribute routing template using absolute routing template to avoid appending any controller route template
                     newSelectorModel.AttributeRouteModel = new AttributeRouteModel()
                     {
-                        Template = $"/{originalTemplate}" // add a "/" to make sure it's absolute template, don't combine with controller
+                        Template = $"/{originalTemplate}", // add a "/" to make sure it's absolute template, don't combine with controller
+                        Order = order
                     };
 
                     return newSelectorModel;


### PR DESCRIPTION
fixes #986: pass Order value to selector model generated

Customer maybe specify the order value in the attribute, we should pass this value to the new selector model generated.

```C#
 [Route("/Data(Key1={Key1}, Key2={Key2})", Order = -1)]
 public IActionResult GetOne(long Key1, string Key2)
{
   ..
}
```