### PR TITLE
fix $apply with $groupby with more than one property & $top

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/BinderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/BinderExtensions.cs
@@ -166,8 +166,6 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
                 throw Error.ArgumentNull(nameof(context));
             }
 
-            context.EnsureFlattenedProperties(context.CurrentParameter, query);
-
             OrderByBinderResult orderByResult = binder.BindOrderBy(orderByClause, context);
             IQueryable querySoFar = query;
 

--- a/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
@@ -255,6 +255,8 @@ namespace Microsoft.AspNetCore.OData.Query
                 binderContext.AddComputedProperties(Compute.ComputeClause.ComputedItems);
             }
 
+            binderContext.EnsureFlattenedProperties(binderContext.CurrentParameter, query);
+
             foreach (OrderByNode node in nodes)
             {
                 OrderByPropertyNode propertyNode = node as OrderByPropertyNode;

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/EntitySetAggregation/EntitySetAggregationTests.cs
@@ -151,6 +151,25 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.EntitySetAggregation
         }
 
         [Fact]
+        public async Task GroupByMoreThanOnePropertyWithDollarTopWorks()
+        {
+            // Arrange
+            string queryUrl = "aggregation/Orders?$apply=groupby((Id, Name),aggregate(Price with sum as TotalPrice))&$top=1";
+            string expectedResult = "{\"value\":[{\"Name\":\"Order2\",\"Id\":1,\"TotalPrice\":25}]}";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var stringObject = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(expectedResult, stringObject.ToString());
+        }
+
+        [Fact]
         public async Task AggregationWithFilterWorks()
         {
             // Arrange


### PR DESCRIPTION
This PR Fixes #979 and #969 

Moved the `EnsureFlattenedProperties` method from `ApplyBind` in `BinderExtensions` class to `ApplyToCore` in `OrderByQueryOption` class. The reason for this is to avoid the `EnsureFlattenedProperties` being called more than once since it was in a foreach loop and was assigning null to FlattenedProperties on the second loop. 