### PR TITLE
Stable ordering should be applied when using the EDM model for paging (in addition to EnableQueryAttribute.PageSize)

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -420,7 +420,8 @@ namespace Microsoft.AspNetCore.OData.Query
             if (querySettings.EnsureStableOrdering &&
                 (IsAvailableODataQueryOption(Skip, querySettings, AllowedQueryOptions.Skip) ||
                  IsAvailableODataQueryOption(Top, querySettings, AllowedQueryOptions.Top) ||
-                 querySettings.PageSize.HasValue))
+                 querySettings.PageSize.HasValue ||
+                 querySettings.ModelBoundPageSize.HasValue))
             {
                 // If there is no OrderBy present, we manufacture a default.
                 // If an OrderBy is already present, we add any missing


### PR DESCRIPTION
We use server-side paging feature and encountered an issue where OData applies stable ordering to the output dataset for $skip, $top, and EnableQueryAttribute.PageSize.

However, OData overlooks scenarios in which paging is defined through the EDM model, even though stable ordering logic should also be applied in such cases.

Although EnableQueryAttribute.PageSize is useful, it can become unwieldy in specific situations, especially when it propagates throughout all internal collections. This can lead to unexpected navigation through internal structures and retrieval of missing data. Additionally, issues may arise when constructing the @odata.nextLink for contained collections.