### PR TITLE
fix binding readonly properties

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -458,7 +458,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             {
                 foreach (var sp in structuralProperties)
                 {
-                    if (model.GetClrPropertyName(sp) == prop.Name)
+                    if (prop.CanWrite && model.GetClrPropertyName(sp) == prop.Name)
                     {
                         MemberExpression propertyExpression = Expression.Property(source, prop);
                         bindings.Add(Expression.Bind(prop, propertyExpression));

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Expressions;
@@ -295,6 +296,10 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
             SelectExpandWrapper<QueryCustomer> innerInnerCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<QueryCustomer>>(customer);
 
             Assert.Null(innerInnerCustomer.Instance.Orders);
+            Assert.Equal(2, innerInnerCustomer.Instance.TestReadonlyProperty.Count);
+            Assert.Equal("Test1", innerInnerCustomer.Instance.TestReadonlyProperty[0]);
+            Assert.Equal("Test2", innerInnerCustomer.Instance.TestReadonlyProperty[1]);
+            Assert.Equal(2, innerInnerCustomer.Instance.TestReadOnlyWithAttribute);
         }
 
         [Theory]
@@ -2227,6 +2232,26 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions
         public QueryOrder PrivateOrder { get; set; }
 
         public IList<QueryOrder> Orders { get; set; }
+
+        public List<string> TestReadonlyProperty
+        {
+            get { return new List<string>() { "Test1", "Test2" }; }
+        }
+
+        [ReadOnly(true)]
+        public int TestReadOnlyWithAttribute
+        {
+            get
+            {
+                return 2;
+            }
+        }
+
+        [ReadOnly(true)]
+        public int TestReadOnlyWithAttributeAndSetter
+        {
+            get; set;
+        }
 
         public IDictionary<string, object> CustomerProperties { get; set; }
     }


### PR DESCRIPTION
This PR fixes https://github.com/OData/AspNetCoreOData/issues/1026

In this fix https://github.com/OData/AspNetCoreOData/pull/993 we added a fix to remove duplicate joins from the generated sql. This involved making updates to the Instance property of the expression to be created and only including structural properties. 

The changes led to this being generated: 

```c#
{ Instance = new Customer() {Id = $it.Id, Name= $it.Name}}
```

Instead of this: 

```c#
{ Instance = $it }
```

```c#
    foreach (PropertyInfo prop in props)
            {
                foreach (var sp in structuralProperties)
                {
                    if (sp.Name == prop.Name)
                    {
                        MemberExpression propertyExpression = Expression.Property(source, prop);
                        bindings.Add(Expression.Bind(prop, propertyExpression));
                        break;
                    }
                }
            }
```

This is the code that recreates the Instance to only have structural properties.. Calling `Bind` on a read-only property that doesn't have a setter will throw exceptions. This fix adds a check to check if a property has a setter. If it has a setter then we can do a bind, otherwise we don't. 

The readonly properties will be on the response.  This won't affect. 