### PR TITLE
Avoiding return DateTime.Kind=Unspecified when converting from DateTimeOffset to DateTime (issues 378, 384 and others)

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.OData.Edm
                         DateTimeOffset dateTimeOffsetValue = (DateTimeOffset)value;
                         TimeZoneInfo timeZone = timeZoneInfo ?? TimeZoneInfo.Local;
                         dateTimeOffsetValue = TimeZoneInfo.ConvertTime(dateTimeOffsetValue, timeZone);
-                        return dateTimeOffsetValue.DateTime;
+                        return dateTimeOffsetValue.UtcDateTime;
                     }
 
                     if (value is Date)


### PR DESCRIPTION
fixes #378 , fixes #384 
With this modification we would avoid getting a DateTime value (derived from a conversion from a DateTimeOffset value) that has Kind=Unspecified. The problem is mainly evident when passing Dates as parameters of the ODATA $filter option. With this change the conversion will aways return an UTC datetime when it is originated from a DateTimeOffset value.

I already provided additional [details here:](https://github.com/OData/AspNetCoreOData/issues/378#issuecomment-1672782754) but my original comment remained without answer.

Thanks in advance for considering my request.
D