### PR TITLE
Write Nav links when metadata full

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ResourceContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ResourceContext.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.OData.Formatter.Deserialization;
 using Microsoft.AspNetCore.OData.Formatter.Serialization;
 using Microsoft.AspNetCore.OData.Formatter.Value;
 using Microsoft.AspNetCore.OData.Query.Wrapper;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Formatter
@@ -52,6 +53,11 @@ namespace Microsoft.AspNetCore.OData.Formatter
             if (serializerContext == null)
             {
                 throw Error.ArgumentNull(nameof(serializerContext));
+            }
+
+            if (serializerContext.MetadataLevel == ODataMetadataLevel.Full)
+            {
+                this.WriteNavigationLinks = true;
             }
 
             SerializerContext = serializerContext;
@@ -91,6 +97,11 @@ namespace Microsoft.AspNetCore.OData.Formatter
         /// Gets or sets the <see cref="IEdmStructuredObject"/> backing this instance.
         /// </summary>
         public IEdmStructuredObject EdmObject { get; set; }
+
+        /// <summary>
+        ///  Get or sets whether navigation links should be written.
+        /// </summary>
+        internal bool WriteNavigationLinks { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the value of this resource instance.

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -25,7 +25,6 @@ using NavigationSourceLinkBuilderAnnotation = Microsoft.AspNetCore.OData.Edm.Nav
 using Microsoft.AspNetCore.OData.Common;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Deltas;
-using System.Xml.Linq;
 
 namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 {
@@ -799,8 +798,12 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             IEnumerable<ODataNestedResourceInfo> navigationLinks = CreateNavigationLinks(selectExpandNode.SelectedNavigationProperties, resourceContext);
             foreach (ODataNestedResourceInfo navigationLink in navigationLinks)
             {
-                await writer.WriteStartAsync(navigationLink).ConfigureAwait(false);
-                await writer.WriteEndAsync().ConfigureAwait(false);
+                if (resourceContext.WriteNavigationLinks)
+                {
+                    await writer.WriteStartAsync(navigationLink).ConfigureAwait(false);
+                    await writer.WriteEndAsync().ConfigureAwait(false);
+
+                }
             }
         }
 
@@ -1214,6 +1217,15 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                     if (navigationUrl != null)
                     {
                         navigationLink.Url = navigationUrl;
+                        resourceContext.WriteNavigationLinks = true;
+                    }
+                    else if (writeContext.MetadataLevel == ODataMetadataLevel.Full)
+                    {
+                        resourceContext.WriteNavigationLinks = true;
+                    }
+                    else
+                    {
+                        resourceContext.WriteNavigationLinks = false;
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -4220,6 +4220,11 @@
             Gets or sets the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmStructuredObject"/> backing this instance.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.ResourceContext.WriteNavigationLinks">
+            <summary>
+             Get or sets whether navigation links should be written.
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.ResourceContext.ResourceInstance">
             <summary>
             Gets or sets the value of this resource instance.

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -322,8 +322,11 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             serializer.Setup(s => s.CreateNavigationLink(selectExpandNode.SelectedNavigationProperties.ElementAt(0), It.IsAny<ResourceContext>())).Verifiable();
             serializer.Setup(s => s.CreateNavigationLink(selectExpandNode.SelectedNavigationProperties.ElementAt(1), It.IsAny<ResourceContext>())).Verifiable();
 
+            ODataSerializerContext writeContext = new ODataSerializerContext() { NavigationSource = _customerSet, Model = _model, Path = _path };
+            writeContext.MetadataLevel = ODataMetadataLevel.Full;
+
             // Act
-            await serializer.Object.WriteObjectInlineAsync(_customer, _customerType, writer.Object, _writeContext);
+            await serializer.Object.WriteObjectInlineAsync(_customer, _customerType, writer.Object, writeContext);
 
             // Assert
             serializer.Verify();
@@ -360,8 +363,11 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             writer.Setup(w => w.WriteStartAsync(navigationLinks[0])).Verifiable();
             writer.Setup(w => w.WriteStartAsync(navigationLinks[1])).Verifiable();
 
+            ODataSerializerContext writeContext = new ODataSerializerContext() { NavigationSource = _customerSet, Model = _model, Path = _path };
+            writeContext.MetadataLevel = ODataMetadataLevel.Full;
+
             // Act
-            await serializer.Object.WriteObjectInlineAsync(_customer, _customerType, writer.Object, _writeContext);
+            await serializer.Object.WriteObjectInlineAsync(_customer, _customerType, writer.Object, writeContext);
 
             // Assert
             writer.Verify();


### PR DESCRIPTION
Fixes #1071

Navigation links only get written when `MetadataLevel` is set to `ODataMetadataLevel.Full` or when `MetadataLevel` is set to `ODataMetadataLevel.Minimal` and the `NavigationLinkBuilder's` FollowsConvention property is set to false. The ODataWriter methods for writing navigation links get called every time even when the navigation links are not being written. Calling these methods leads to a lot of CPU usage and high latency when the navigation links are not being written. 

In this PR, I've added a bool property `WriteNavigationLinks` in the ResourceContext... The default value for this property is `false`. If the metadata level is set to full or minimal and FollowsConvention is set to false, then the `WriteNavigationLinks`
is set to true. Otherwise, it is set to false.

So, before calling the writer methods for writing navigation links, we'll be checking the value of the `WriteNavigationLinks` property. If it is set to true, then the writer methods are called. Otherwise, the writer methods do not get called. 

NOTE: The response has 3000 records. 

Latency before this change: 
Bombarding https://localhost:7034/odata/Products for 10s using 50 connection(s)
[=================================================================================================================] 10s
Done!
```table
Statistics        Avg      Stdev        Max
  Reqs/sec        37.18     181.19    2499.47
  Latency         1.94s      0.91s      8.79s
  Latency Distribution
     50%      1.78s
     75%      1.92s
     90%      2.12s
     95%      4.24s
     99%      4.57s
  HTTP codes:
    1xx - 0, 2xx - 267, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    10.42MB/s
```
Latency after this change:
Bombarding https://localhost:7034/odata/Products for 10s using 50 connection(s)
[=================================================================================================================] 10s
Done!
```table
Statistics        Avg      Stdev        Max
  Reqs/sec        57.94     173.85    2249.86
  Latency         1.15s   244.10ms      1.88s
  Latency Distribution
     50%      1.19s
     75%      1.29s
     90%      1.38s
     95%      1.50s
     99%      1.88s
  HTTP codes:
    1xx - 0, 2xx - 449, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    16.27MB/s
```

This gives a `40.7%` latency improvement. 

CPU usage: 
Before
![ssas](https://github.com/OData/AspNetCoreOData/assets/25525526/7c9596fc-c893-4fc9-8f39-5d97d3b7cf86)

After
![popo](https://github.com/OData/AspNetCoreOData/assets/25525526/53b4ebe9-040c-4903-b9c4-342c2ce5f2c5)