### PR TITLE
Perf-improvement: CreateEtag method

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.OData.Edm
         {
             Contract.Assert(model != null);
             Contract.Assert(navigationSource != null);
-
+            
             if (!_cachedConcurrencyProperties.TryGetValue(navigationSource, out IEnumerable<IEdmStructuralProperty> cachedProperties))
             {
                 // Ensure that concurrency properties cache is attached to model as an annotation to avoid expensive calculations each time
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.OData.Edm
                     concurrencyProperties = new ConcurrencyPropertiesAnnotation();
                     model.SetAnnotationValue(model, concurrencyProperties);
                 }
-
+                
                 if (concurrencyProperties.TryGetValue(navigationSource, out cachedProperties))
                 {
                     _cachedConcurrencyProperties[navigationSource] = cachedProperties;

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmModelAnnotationExtensions.cs
@@ -6,7 +6,6 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -775,7 +775,10 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                     properties.Add(etagProperty.Name, resourceContext.GetPropertyValue(etagProperty.Name));
                 }
 
-                return resourceContext.Request.CreateETag(properties, resourceContext.TimeZone);
+                if (properties.Count != 0)
+                {
+                    return resourceContext.Request.CreateETag(properties, resourceContext.TimeZone);
+                }
             }
 
             return null;


### PR DESCRIPTION
The CreateEtag method creates an ETag for a given entity.  This method is called for every resource and seems to take-up a lot of CPU time even in cases where ETags are not being created. 

![c1](https://github.com/OData/AspNetCoreOData/assets/25525526/2be1624f-80ec-451e-a430-480f159cc964)


This is how the CreateEtag method looks like: 
```c#
 public virtual string CreateETag(ResourceContext resourceContext)
 {
     if (resourceContext == null)
     {
         throw Error.ArgumentNull(nameof(resourceContext));
     }

     if (resourceContext.Request != null)
     {
         IEdmModel model = resourceContext.EdmModel;
         IEdmNavigationSource navigationSource = resourceContext.NavigationSource;

         IEnumerable<IEdmStructuralProperty> concurrencyProperties;
         if (model != null && navigationSource != null)
         {
             concurrencyProperties = model.GetConcurrencyProperties(navigationSource).OrderBy(c => c.Name);
         }
         else
         {
             concurrencyProperties = Enumerable.Empty<IEdmStructuralProperty>();
         }

         IDictionary<string, object> properties = new Dictionary<string, object>();
         foreach (IEdmStructuralProperty etagProperty in concurrencyProperties)
         {
             properties.Add(etagProperty.Name, resourceContext.GetPropertyValue(etagProperty.Name));
         }

         return resourceContext.Request.CreateETag(properties, resourceContext.TimeZone);
     }

     return null;
 }
```

We call `return resourceContext.Request.CreateETag(properties, resourceContext.TimeZone)` every time even when the properties are null. This call involves getting the ETag handler from the DI container which seems to take up some CPU time.. Adding a check to only call this method when the concurrency properties are not null seems to improve CPU usage a bit. 

![c2](https://github.com/OData/AspNetCoreOData/assets/25525526/572f7e45-9645-4bbf-b773-93e5621e8682)

Comparing the before and after CPU usage, you can see an improvement in CPU usage of about `1.37%`