### PR TITLE
support ActionResult<IAsyncEnumerable<T>>

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Diagnostics;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.OData.Common;
@@ -260,15 +259,7 @@ namespace Microsoft.AspNetCore.OData.Query
                     ControllerActionDescriptor controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
                     Type returnType = controllerActionDescriptor.MethodInfo.ReturnType;
 
-                    if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ActionResult<>))
-                    {
-                        returnType = returnType.GetGenericArguments().First();
-
-                        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                        {
-                            responseContent.DeclaredType = returnType;
-                        }
-                    }
+                    responseContent.DeclaredType = returnType;
 
                     if (responseContent != null)
                     {

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -259,7 +259,15 @@ namespace Microsoft.AspNetCore.OData.Query
                     ControllerActionDescriptor controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
                     Type returnType = controllerActionDescriptor.MethodInfo.ReturnType;
 
-                    responseContent.DeclaredType = returnType;
+                    if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ActionResult<>))
+                    {
+                        returnType = returnType.GetGenericArguments().First();
+
+                        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                        {
+                            responseContent.DeclaredType = returnType;
+                        }
+                    }
 
                     if (responseContent != null)
                     {

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableController.cs
@@ -45,6 +45,13 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.IAsyncEnumerableTests
             return _context.Customers.AsAsyncEnumerable();
         }
 
+        [EnableQuery]
+        [HttpGet("v2/Customers")]
+        public ActionResult<IAsyncEnumerable<Customer>> CustomersDataNew()
+        {
+            return Ok(_context.Customers.AsAsyncEnumerable());
+        }
+
         public async IAsyncEnumerable<Customer> CreateCollectionAsync<T>()
         {
             await Task.Delay(5);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
@@ -35,6 +35,9 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.IAsyncEnumerableTests
 
                 services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
                     .AddRouteComponents("v1", edmModel));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("v2", edmModel));
             }
        }
 
@@ -83,6 +86,28 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.IAsyncEnumerableTests
 
             List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
             Assert.Equal(2, customers.Count);
+        }
+
+        [Fact]
+        public async Task UsingAsAsyncEnumerableWithActionResultWorks()
+        {
+            // Arrange
+            string queryUrl = "v2/Customers?$expand=Orders";
+            var expectedResult = "{\"@odata.context\":\"http://localhost/v2/$metadata#Customers(Orders())\",\"value\":[{\"Id\":1,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"},\"Orders\":[{\"Id\":1,\"Name\":\"Order2\",\"Price\":25},{\"Id\":2,\"Name\":\"Order21\",\"Price\":75}]},{\"Id\":2,\"Name\":\"Customer1\",\"Address\":{\"Name\":\"City0\",\"Street\":\"Street0\"},\"Orders\":[{\"Id\":3,\"Name\":\"Order4\",\"Price\":50},{\"Id\":4,\"Name\":\"Order41\",\"Price\":150}]},{\"Id\":3,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"},\"Orders\":[{\"Id\":5,\"Name\":\"Order6\",\"Price\":75},{\"Id\":6,\"Name\":\"Order61\",\"Price\":225}]}]}";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var resultObject = await response.Content.ReadAsStringAsync();
+            Assert.Equal(expectedResult, resultObject);
+
+            List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
+            Assert.Equal(3, customers.Count);
+            Assert.Equal(2, customers[0].Orders.Count);
         }
     }
 }


### PR DESCRIPTION
We added support for the `IAsyncEnumerable` interface. The current support can only be used like this: 

```c#

[HttpGet] 
 [EnableQuery] 
 public IAsyncEnumerable<Customer> Get() 
 { 
     return this.context.Customers.AsAsyncEnumerable(); 
 } 
```
This PR adds support for this format: 

```c#
[EnableQuery] 
public ActionResult<IAsyncEnumerable<Customer>> Get() 
{ 
    var query = this.context.Customers.AsAsyncEnumerable(); 
    return this.Ok(query); 
} 
```

In the second format, the declared type of the returned object is null `ObjectResult responseContent = actionExecutedContext.Result as ObjectResult`. This is the type that is used to determine how to retrieve items from the database during serialization. That's if the type is `IAsyncEnumerable<T>` then we use `await foreach` otherwise we just use a `foreach`. 

The changes here get the type `T` in `ActionResult<T>` and check if `T` is of type `IAsyncEnumerable<>`. If it is, then we update the response content's DeclaredType to `IAsyncEnumerable<>`
