### PR TITLE
Generate valid id/read/edit links for expanded non-contained resource with a contained navigation source

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -581,7 +581,18 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
 
             if (resourceContext.StructuredType.TypeKind == EdmTypeKind.Entity && resourceContext.NavigationSource != null)
             {
-                if (!(resourceContext.NavigationSource is IEdmContainedEntitySet))
+                // Condition 1. If resourceContext.NavigationSource is a contained entity set
+                //    and a contained resource is being written, the id/read/edit links can be derived
+                //    from the entity set or parent resource, i.e., no need to use link builder to build the links.
+                // Condition 2. If resourceContext.NavigationSource is a contained entity set
+                //    but an expanded non-contained resource is being written,
+                //    deriving the id/read/edit links from the entity set or parent resource will
+                //    most likely result into invalid links.
+                //    A navigation property binding should exist and we should try
+                //    to use the navigation link builder to build the links.
+                // NOTE: resourceContext.SerializerContext.NavigationProperty will not be null when writing an expanded resource
+                if (!(resourceContext.NavigationSource is IEdmContainedEntitySet)
+                    || resourceContext.SerializerContext.NavigationProperty?.ContainsTarget == false)
                 {
                     IEdmModel model = resourceContext.SerializerContext.Model;
                     NavigationSourceLinkBuilderAnnotation linkBuilder = EdmModelLinkBuilderExtensions.GetNavigationSourceLinkBuilder(model, resourceContext.NavigationSource);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesController.cs
@@ -1,0 +1,98 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MetadataPropertiesController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties
+{
+    [Route("NonContainedNavPropInContainedNavSource")]
+    [Route("ContainedNavPropInContainedNavSource")]
+    public class SitesController : ODataController
+    {
+        [EnableQuery]
+        [HttpGet("Sites")]
+        public ActionResult<IEnumerable<Site>> Get()
+        {
+            return MetadataPropertiesDataSource.Sites;
+        }
+
+        [EnableQuery]
+        [HttpGet("Sites({key})")]
+        public ActionResult<Site> Get(int key)
+        {
+            var site = MetadataPropertiesDataSource.Sites.SingleOrDefault(d => d.Id == key);
+
+            if (site == null)
+            {
+                return NotFound();
+            }
+
+            return site;
+        }
+
+        [EnableQuery]
+        [HttpGet("Sites({key})/Plants")]
+        public ActionResult<IEnumerable<Plant>> GetPlants(int key)
+        {
+            var site = MetadataPropertiesDataSource.Sites.SingleOrDefault(d => d.Id == key);
+
+            if (site == null || site.Plants == null)
+            {
+                return Enumerable.Empty<Plant>().ToList();
+            }
+
+            return site.Plants.ToList();
+        }
+
+        [EnableQuery]
+        [HttpGet("Sites({siteKey})/Plants({plantKey})")]
+        public ActionResult<Plant> GetPlant(int siteKey, int plantKey)
+        {
+            var plant = MetadataPropertiesDataSource.Sites.SingleOrDefault(d => d.Id == siteKey)?.Plants?.SingleOrDefault(d => d.Id == plantKey);
+
+            if (plant == null)
+            {
+                return NotFound();
+            }
+
+            return plant;
+        }
+
+        [EnableQuery]
+        [HttpGet("Sites({siteKey})/Plants({plantKey})/Pipelines")]
+        public ActionResult<IEnumerable<PipelineBase>> GetPipelines(int siteKey, int plantKey)
+        {
+            var plant = MetadataPropertiesDataSource.Sites.SingleOrDefault(d => d.Id == siteKey)?.Plants?.SingleOrDefault(d => d.Id == plantKey);
+
+            if (plant == null || plant.Pipelines == null)
+            {
+                return Enumerable.Empty<PipelineBase>().ToList();
+            }
+
+            return plant.Pipelines.ToList();
+        }
+
+        [EnableQuery]
+        [HttpGet("Sites({siteKey})/Plants({plantKey})/Pipelines({pipelineKey})")]
+        public ActionResult<PipelineBase> GetPlantPipeline(int siteKey, int plantKey, int pipelineKey)
+        {
+            var pipeline = MetadataPropertiesDataSource.Sites.SingleOrDefault(d => d.Id == siteKey)?.Plants?.SingleOrDefault(d => d.Id == plantKey)?.Pipelines?.SingleOrDefault(d => d.Id == pipelineKey);
+
+            if (pipeline == null)
+            {
+                return NotFound();
+            }
+
+            return pipeline;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesDataModel.cs
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MetadataPropertiesDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.OData.ModelBuilder;
+
+    public abstract class EntityBase
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Dictionary<string, object> Attributes { get; set; }
+    }
+
+    public class Site : EntityBase
+    {
+        [Contained]
+        public IEnumerable<Plant> Plants { get; set; }
+    }
+
+    public class Plant : EntityBase
+    {
+        public Site Site { get; set; }
+        [Contained]
+        public IEnumerable<PipelineBase> Pipelines { get; set; }
+    }
+
+    public abstract class PipelineBase : EntityBase
+    {
+        public Plant Plant { get; set; }
+    }
+}
+
+// NOTE: Pipeline class defined in a different namespace to repro a reported scenario
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Plant1
+{
+    using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core;
+
+    public class Pipeline : PipelineBase
+    {
+        public int? Length { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesDataSource.cs
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MetadataPropertiesDataSource.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Plant1;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties
+{
+    internal static class MetadataPropertiesDataSource
+    {
+        private readonly static List<Site> sites;
+        private readonly static List<Plant> plants;
+        private readonly static List<PipelineBase> pipelines;
+
+        static MetadataPropertiesDataSource()
+        {
+            pipelines = new List<PipelineBase>(Enumerable.Range(1, 8).Select(idx => new Pipeline
+            {
+                Id = idx,
+                Name = $"Pipeline {idx}",
+                Length = idx * 100
+            }));
+
+            plants = new List<Plant>(Enumerable.Range(1, 4).Select(idx => new Plant
+            {
+                Id = idx,
+                Name = $"Plant {idx}",
+                Pipelines = pipelines.Skip((idx - 1) * 2).Take(2)
+            }));
+
+            sites = new List<Site>(Enumerable.Range(1, 2).Select(idx => new Site
+            {
+                Id = idx,
+                Name = $"Site {idx}",
+                Plants = plants.Skip((idx - 1) * 2).Take(2)
+            }));
+
+            for (var i = 0; i < plants.Count; i++)
+            {
+                plants[i].Site = sites[i / 2];
+            }
+
+            for (var i = 0; i < pipelines.Count; i++)
+            {
+                pipelines[i].Plant = plants[i / 2];
+            }
+        }
+
+        public static List<Site> Sites => sites;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesEdmModel.cs
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MetadataPropertiesEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Linq;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Plant1;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties
+{
+    public class MetadataPropertiesEdmModel
+    {
+        /// <summary>
+        /// Returns model where Site and Plant navigation properties are non-contained and navigation source is contained.
+        /// </summary>
+        /// <returns>Returns Edm model.</returns>
+        public static IEdmModel GetEdmModelWithNonContainedNavPropInContainedNavSource()
+        {
+            var modelBuilder = new ODataConventionModelBuilder();
+            modelBuilder.EntityType<EntityBase>();
+            modelBuilder.EntityType<Site>();
+            modelBuilder.EntityType<Plant>();
+            modelBuilder.EntityType<PipelineBase>();
+            modelBuilder.EntityType<Pipeline>();
+            modelBuilder.EntitySet<Site>("Sites");
+
+            var model = modelBuilder.GetEdmModel();
+
+            var sitesEntitySet = (EdmEntitySet)model.FindDeclaredEntitySet("Default.Container.Sites");
+            var plantsNavigationProperty = sitesEntitySet.EntityType().DeclaredNavigationProperties().Single(d => d.Name.Equals("Plants"));
+            var plantsContainedEntitySet = sitesEntitySet.FindNavigationTarget(plantsNavigationProperty);
+            var siteNavigationProperty = plantsContainedEntitySet.EntityType().DeclaredNavigationProperties().Single(d => d.Name.Equals("Site"));
+            var pipelinesNavigationProperty = plantsContainedEntitySet.EntityType().DeclaredNavigationProperties().Single(d => d.Name.Equals("Pipelines"));
+            var pipelineContainedEntitySet = plantsContainedEntitySet.FindNavigationTarget(pipelinesNavigationProperty, new EdmPathExpression("Plants", "Pipelines"));
+            var plantNavigationProperty = pipelineContainedEntitySet.EntityType().DeclaredNavigationProperties().Single(d => d.Name.Equals("Plant"));
+
+            sitesEntitySet.AddNavigationTarget(siteNavigationProperty, sitesEntitySet, new EdmPathExpression("Plants", "Site"));
+            sitesEntitySet.AddNavigationTarget(plantNavigationProperty, plantsContainedEntitySet, new EdmPathExpression("Plants", "Pipelines", "Plant"));
+
+            return model;
+        }
+
+        /// <summary>
+        /// Returns model where Site and Plant navigation properties are contained and navigation source is contained.
+        /// </summary>
+        /// <returns>Returns Edm model.</returns>
+        public static IEdmModel GetEdmModelWithContainedNavPropInContainedNavSource()
+        {
+            var modelBuilder = new ODataConventionModelBuilder();
+            modelBuilder.EntityType<EntityBase>();
+            modelBuilder.EntityType<Site>();
+            // Make Site and Plant navigation properties contained
+            modelBuilder.EntityType<Plant>().ContainsRequired(d => d.Site).Contained();
+            modelBuilder.EntityType<PipelineBase>().ContainsRequired(d => d.Plant).Contained();
+            modelBuilder.EntityType<Pipeline>();
+            modelBuilder.EntitySet<Site>("Sites");
+
+            var model = modelBuilder.GetEdmModel();
+
+            return model;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MetadataProperties/MetadataPropertiesTests.cs
@@ -1,0 +1,262 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MetadataPropertiesTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Core;
+using Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties.Plant1;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MetadataProperties
+{
+    public class MetadataPropertiesTests : WebApiTestBase<MetadataPropertiesTests>
+    {
+        public MetadataPropertiesTests(WebApiTestFixture<MetadataPropertiesTests> fixture)
+            : base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            var nonContainedNavPropInContainedNavSourceModel = MetadataPropertiesEdmModel.GetEdmModelWithNonContainedNavPropInContainedNavSource();
+            var containedNavPropertyInContainedNavSourceModel = MetadataPropertiesEdmModel.GetEdmModelWithContainedNavPropInContainedNavSource();
+
+            services.ConfigureControllers(typeof(SitesController));
+
+            services.AddControllers().AddOData(
+                options => options.EnableQueryFeatures()
+                .AddRouteComponents(
+                    routePrefix: "NonContainedNavPropInContainedNavSource",
+                    model: nonContainedNavPropInContainedNavSourceModel)
+                .AddRouteComponents(
+                    routePrefix: "ContainedNavPropInContainedNavSource",
+                    model: containedNavPropertyInContainedNavSourceModel));
+        }
+
+        [Theory]
+        [InlineData("NonContainedNavPropInContainedNavSource", "Sites(1)/Plants(1)")]
+        [InlineData("ContainedNavPropInContainedNavSource", "Sites(1)/Plants(1)/Pipelines(1)/Plant")]
+        public async Task TestExpandPlantNavigationPropertyOnContainedNavigationSource(string routePrefix, string plantResourceBase)
+        {
+            // Arrange
+            var requestUri = $"{routePrefix}/Sites(1)/Plants(1)/Pipelines(1)?$expand=Plant";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            var client = CreateClient();
+            var typeofPipeline = typeof(Pipeline);
+            var typeofPlant = typeof(Plant);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+
+            Assert.EndsWith($"{routePrefix}/$metadata#Sites(1)/Plants(1)/Pipelines/{typeofPipeline}(Plant())/$entity", result.Value<string>("@odata.context"));
+            Assert.Equal($"#{typeofPipeline}", result.Value<string>("@odata.type"));
+            Assert.EndsWith("Sites(1)/Plants(1)/Pipelines(1)", result.Value<string>("@odata.id"));
+            Assert.EndsWith($"Sites(1)/Plants(1)/Pipelines(1)/{typeofPipeline}", result.Value<string>("@odata.editLink"));
+            Assert.Equal(1, result.Value<int>("Id"));
+            Assert.Equal("Pipeline 1", result.Value<string>("Name"));
+            Assert.Equal(100, result.Value<int?>("Length"));
+            Assert.EndsWith($"/Sites(1)/Plants(1)/Pipelines(1)/{typeofPipeline}/Plant/$ref", result.Value<string>("Plant@odata.associationLink"));
+            Assert.EndsWith($"/Sites(1)/Plants(1)/Pipelines(1)/{typeofPipeline}/Plant", result.Value<string>("Plant@odata.navigationLink"));
+
+            var plant = result.GetValue("Plant") as JObject;
+            Assert.NotNull(plant);
+            Assert.Equal($"#{typeofPlant}", plant.Value<string>("@odata.type"));
+            Assert.EndsWith($"{plantResourceBase}", plant.Value<string>("@odata.id"));
+            Assert.EndsWith($"{plantResourceBase}", plant.Value<string>("@odata.editLink"));
+            Assert.Equal(1, plant.Value<int>("Id"));
+            Assert.Equal("Plant 1", plant.Value<string>("Name"));
+            Assert.EndsWith($"{routePrefix}/{plantResourceBase}/Site/$ref", plant.Value<string>("Site@odata.associationLink"));
+            Assert.EndsWith($"{routePrefix}/{plantResourceBase}/Site", plant.Value<string>("Site@odata.navigationLink"));
+            Assert.EndsWith($"{routePrefix}/{plantResourceBase}/Pipelines/$ref", plant.Value<string>("Pipelines@odata.associationLink"));
+            Assert.EndsWith($"{routePrefix}/{plantResourceBase}/Pipelines", plant.Value<string>("Pipelines@odata.navigationLink"));
+        }
+
+        [Theory]
+        [InlineData("NonContainedNavPropInContainedNavSource", "Sites(1)")]
+        [InlineData("ContainedNavPropInContainedNavSource", "Sites(1)/Plants(1)/Site")]
+        public async Task TestExpandSiteNavigationPropertyOnContainedNavigationSource(string routePrefix, string siteResourceBase)
+        {
+            // Arrange
+            var requestUri = $"{routePrefix}/Sites(1)/Plants(1)?$expand=Site";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            var client = CreateClient();
+            var typeofPlant = typeof(Plant);
+            var typeofSite = typeof(Site);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+
+            Assert.EndsWith($"{routePrefix}/$metadata#Sites(1)/Plants(Site())/$entity", result.Value<string>("@odata.context"));
+            Assert.Equal($"#{typeofPlant}", result.Value<string>("@odata.type"));
+            Assert.EndsWith("Sites(1)/Plants(1)", result.Value<string>("@odata.id"));
+            Assert.EndsWith("Sites(1)/Plants(1)", result.Value<string>("@odata.editLink"));
+            Assert.Equal(1, result.Value<int>("Id"));
+            Assert.Equal("Plant 1", result.Value<string>("Name"));
+            Assert.EndsWith($"{routePrefix}/Sites(1)/Plants(1)/Pipelines/$ref", result.Value<string>("Pipelines@odata.associationLink"));
+            Assert.EndsWith($"{routePrefix}/Sites(1)/Plants(1)/Pipelines", result.Value<string>("Pipelines@odata.navigationLink"));
+            Assert.EndsWith($"{routePrefix}/Sites(1)/Plants(1)/Site/$ref", result.Value<string>("Site@odata.associationLink"));
+            Assert.EndsWith($"{routePrefix}/Sites(1)/Plants(1)/Site", result.Value<string>("Site@odata.navigationLink"));
+
+            var site = result.GetValue("Site") as JObject;
+            Assert.NotNull(site);
+            Assert.Equal($"#{typeofSite}", site.Value<string>("@odata.type"));
+            Assert.EndsWith($"{siteResourceBase}", site.Value<string>("@odata.id"));
+            Assert.EndsWith($"{siteResourceBase}", site.Value<string>("@odata.editLink"));
+            Assert.Equal(1, site.Value<int>("Id"));
+            Assert.Equal("Site 1", site.Value<string>("Name"));
+            Assert.EndsWith($"{routePrefix}/{siteResourceBase}/Plants/$ref", site.Value<string>("Plants@odata.associationLink"));
+            Assert.EndsWith($"{routePrefix}/{siteResourceBase}/Plants", site.Value<string>("Plants@odata.navigationLink"));
+        }
+
+        [Theory]
+        [InlineData("NonContainedNavPropInContainedNavSource", "Sites(1)/Plants(2)")]
+        [InlineData("ContainedNavPropInContainedNavSource", "Sites(1)/Plants(2)/Pipelines({0})/Plant")]
+        public async Task TestExpandPipelinesNavigationPropertyOnContainedNavigationSource(string routePrefix, string plantResourceBase)
+        {
+            // Arrange
+            var requestUri = $"{routePrefix}/Sites(1)/Plants(2)?$expand=Pipelines($expand=Plant)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            var client = CreateClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+
+            Action<JObject, string, string> verifyPlantAction = (plant, localRoutePrefix, localPlantResourceBase) =>
+            {
+                Assert.NotNull(plant);
+                Assert.Equal($"#{typeof(Plant)}", plant.Value<string>("@odata.type"));
+                Assert.EndsWith($"{localPlantResourceBase}", plant.Value<string>("@odata.id"));
+                Assert.EndsWith($"{localPlantResourceBase}", plant.Value<string>("@odata.editLink"));
+                Assert.Equal(2, plant.Value<int>("Id"));
+                Assert.Equal($"Plant 2", plant.Value<string>("Name"));
+                Assert.EndsWith($"{localRoutePrefix}/{localPlantResourceBase}/Pipelines/$ref", plant.Value<string>("Pipelines@odata.associationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/{localPlantResourceBase}/Pipelines", plant.Value<string>("Pipelines@odata.navigationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/{localPlantResourceBase}/Site/$ref", plant.Value<string>("Site@odata.associationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/{localPlantResourceBase}/Site", plant.Value<string>("Site@odata.navigationLink"));
+            };
+
+            verifyPlantAction(result, routePrefix, "Sites(1)/Plants(2)");
+
+            var pipelines = result.GetValue("Pipelines") as JArray;
+            Assert.NotNull(pipelines);
+            Assert.Equal(2, pipelines.Count);
+
+            var pipelineAt0 = pipelines[0] as JObject;
+            var pipelineAt1 = pipelines[1] as JObject;
+
+            Action<JObject, string, int> verifyPipelineAction = (pipeline, localRoutePrefix, pipelineId) =>
+            {
+                var typeofPipeline = typeof(Pipeline);
+
+                Assert.NotNull(pipeline);
+                Assert.Equal($"#{typeofPipeline}", pipeline.Value<string>("@odata.type"));
+                Assert.EndsWith($"Sites(1)/Plants(2)/Pipelines({pipelineId})", pipeline.Value<string>("@odata.id"));
+                Assert.EndsWith($"Sites(1)/Plants(2)/Pipelines({pipelineId})/{typeofPipeline}", pipeline.Value<string>("@odata.editLink"));
+                Assert.Equal(pipelineId, pipeline.Value<int>("Id"));
+                Assert.Equal($"Pipeline {pipelineId}", pipeline.Value<string>("Name"));
+                Assert.Equal(pipelineId * 100, pipeline.Value<int?>("Length"));
+                Assert.EndsWith($"/Sites(1)/Plants(2)/Pipelines({pipelineId})/{typeofPipeline}/Plant/$ref", pipeline.Value<string>("Plant@odata.associationLink"));
+                Assert.EndsWith($"/Sites(1)/Plants(2)/Pipelines({pipelineId})/{typeofPipeline}/Plant", pipeline.Value<string>("Plant@odata.navigationLink"));
+
+                var plant = pipeline.GetValue("Plant") as JObject;
+                verifyPlantAction(plant, localRoutePrefix, string.Format(plantResourceBase, pipelineId));
+            };
+
+            verifyPipelineAction(pipelineAt0, routePrefix, 3); // Pipeline Id = 3
+            verifyPipelineAction(pipelineAt1, routePrefix, 4); // Pipeline Id = 4
+        }
+
+        [Theory]
+        [InlineData("NonContainedNavPropInContainedNavSource", "Sites(2)")]
+        [InlineData("ContainedNavPropInContainedNavSource", "Sites(2)/Plants({0})/Site")]
+        public async Task TestExpandPlantsNavigationPropertyOnNonContainedNavigationSource(string routePrefix, string siteResourceBase)
+        {
+            // Arrange
+            var requestUri = $"{routePrefix}/Sites(2)?$expand=Plants($expand=Site)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=full"));
+            var client = CreateClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+
+            Action<JObject, string, string> verifySiteAction = (site, localRoutePrefix, localSiteResourceBase) =>
+            {
+                Assert.Equal($"#{typeof(Site)}", site.Value<string>("@odata.type"));
+                Assert.EndsWith($"{localSiteResourceBase}", site.Value<string>("@odata.id"));
+                Assert.EndsWith($"{localSiteResourceBase}", site.Value<string>("@odata.editLink"));
+                Assert.Equal(2, site.Value<int>("Id"));
+                Assert.Equal("Site 2", site.Value<string>("Name"));
+                Assert.EndsWith($"{localRoutePrefix}/{localSiteResourceBase}/Plants/$ref", site.Value<string>("Plants@odata.associationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/{localSiteResourceBase}/Plants", site.Value<string>("Plants@odata.navigationLink"));
+            };
+
+            verifySiteAction(result, routePrefix, "Sites(2)");
+
+            var plants = result.GetValue("Plants") as JArray;
+            Assert.NotNull(plants);
+            Assert.Equal(2, plants.Count);
+
+            var plantAt0 = plants[0] as JObject;
+            var plantAt1 = plants[1] as JObject;
+
+            Action<JObject, string, int> verifyPlantAction = (plant, localRoutePrefix, plantId) =>
+            {
+                Assert.NotNull(plant);
+                Assert.Equal($"#{typeof(Plant)}", plant.Value<string>("@odata.type"));
+                Assert.EndsWith($"Sites(2)/Plants({plantId})", plant.Value<string>("@odata.id"));
+                Assert.EndsWith($"Sites(2)/Plants({plantId})", plant.Value<string>("@odata.editLink"));
+                Assert.Equal(plantId, plant.Value<int>("Id"));
+                Assert.Equal($"Plant {plantId}", plant.Value<string>("Name"));
+                Assert.EndsWith($"{localRoutePrefix}/Sites(2)/Plants({plantId})/Pipelines/$ref", plant.Value<string>("Pipelines@odata.associationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/Sites(2)/Plants({plantId})/Pipelines", plant.Value<string>("Pipelines@odata.navigationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/Sites(2)/Plants({plantId})/Site/$ref", plant.Value<string>("Site@odata.associationLink"));
+                Assert.EndsWith($"{localRoutePrefix}/Sites(2)/Plants({plantId})/Site", plant.Value<string>("Site@odata.navigationLink"));
+
+                var site = plant.GetValue("Site") as JObject;
+                verifySiteAction(site, localRoutePrefix, string.Format(siteResourceBase, plantId));
+            };
+
+            verifyPlantAction(plantAt0, routePrefix, 3); // Plant Id = 3
+            verifyPlantAction(plantAt1, routePrefix, 4); // Plant Id = 4
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes https://github.com/OData/odata.net/issues/2273.

### Description
In the described scenario, a `Site` entity type has a **contained** `Plants` navigation property. The `Plant` entity type in turn has a **contained** `Pipelines` navigation property. The `Pipeline` entity type in turn has a **non-contained** single-valued `Plant` navigation property.

The **non-contained** `Plant` navigation property is bound to the `Plants` **contained** entity set via the Edm path `Sites/Plants`:

```csharp
namespace Core
{
    public abstract class EntityBase
    {
        [Key]
        public int Id { get; set; }
        public string Name { get; set; }
        public Dictionary<string, object>? Attributes { get; set; }
    }

    public class Site : EntityBase
    {
        [Contained]
        public IEnumerable<Plant>? Plants { get; set; }
    }

    public class Plant : EntityBase
    {
        public Site Site { get; set; }
        [Contained]
        public IEnumerable<PipelineBase> Pipelines { get; set; }
    }

    public abstract class PipelineBase : EntityBase
    {
        public Plant Plant { get; set; }
    }
}

namespace Plant1
{
    public class Pipeline : PipelineBase
    {
        public int? Length { get; set; }
    }
}
```
The `Sites` entity set and the navigation property bindings are as follows:
```xml
<EntitySet Name=""Sites"" EntityType=""Core.Site"">
    <NavigationPropertyBinding Path=""Plants/Pipelines/Plant"" Target=""Sites/Plants""/>
    <NavigationPropertyBinding Path=""Plants/Site"" Target=""Sites""/>
</EntitySet>
```
If the `$format` or `Accept` request headers specify `odata.metadata=full`, and we attempt to expand the `Plant` navigation property, i.e., `/Sites(1)/Plants(1)/Pipelines(1)?$expand=Plant` - where `Plant` is non-contained, failure to use the link builder to build the id/read/edit links results into invalid links since we generate the links by appending `/Plants(1)` to the parent `Pipeline` resource id - `/Sites(1)/Plants(1)/Pipelines(1)` => `/Sites(1)/Plants(1)/Pipelines(1)/Plants(1)`. This link is invalid since there's no `Plants` navigation property on `Pipeline` entity type.

The following line causes us not to use the link builder to generate the id/read/edit links if the `resourceContext.NavigationSource` is a contained entity set:

https://github.com/OData/AspNetCoreOData/blob/d94daadf7efdc55d9e0533f21a9d333322cfc900/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs#L584

This PR fixes the issue by causing the link builder to be used if `resourceContext.NavigationSource` is a contained entity set and an expanded non-contained resource is being written. A navigation property binding should exist and a navigation link builder should be on hand to build the links.

Tests verify that expected behaviour is observed even when the non-contained navigation property is in a nested expand.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*