### PR TITLE
Fixes #1103: Enable any/all in $compute

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ResourceContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ResourceContext.cs
@@ -201,10 +201,10 @@ namespace Microsoft.AspNetCore.OData.Formatter
                 return null;
             }
 
-            TypedEdmStructuredObject edmStructruredObject = EdmObject as TypedEdmStructuredObject;
-            if (edmStructruredObject != null)
+            TypedEdmStructuredObject edmStructuredObject = EdmObject as TypedEdmStructuredObject;
+            if (edmStructuredObject != null)
             {
-                return edmStructruredObject.Instance;
+                return edmStructuredObject.Instance;
             }
 
             SelectExpandWrapper selectExpandWrapper = EdmObject as SelectExpandWrapper;

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             }
 
             // Be noted: it's used in $compute for $select and $expand.
-            if (context.Source != null)
+            if (context.Source != null && rangeVariable.Name == "$it")
             {
                 return context.Source;
             }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -792,6 +792,7 @@ namespace Microsoft.AspNetCore.OData.Query.Expressions
             {
                 foreach (var computedProperty in computedProperties)
                 {
+                    // $select=computed&$compute=.... as computed
                     BindComputedProperty(source, context, computedProperty, includedProperties);
                 }
             }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataModel.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarCompute
 
         public int Qty { get; set; }
 
+        public IList<string> Candys { get; set; }
+
         public ComputeAddress Location { get; set; }
 
         public IList<ComputeSale> Sales { get; set; }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataSource.cs
@@ -25,11 +25,11 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarCompute
         {
             _customers = new List<ComputeCustomer>
             {
-                new ComputeCustomer { Id = 1, Name = "Peter", Age = 19, Price = 1.99, Qty = 10 },
-                new ComputeCustomer { Id = 2, Name = "Sam",   Age = 40, Price = 2.99, Qty = 15 },
-                new ComputeCustomer { Id = 3, Name = "John",  Age = 34, Price = 6.99, Qty = 4 },
-                new ComputeCustomer { Id = 4, Name = "Kerry", Age = 29, Price = 3.99, Qty = 15 },
-                new ComputeCustomer { Id = 5, Name = "Alex",  Age = 08, Price = 9.01, Qty = 20 },
+                new ComputeCustomer { Id = 1, Name = "Peter", Age = 19, Price = 1.99, Qty = 10, Candys = new List<string>(){ "kit kat"} },
+                new ComputeCustomer { Id = 2, Name = "Sam",   Age = 40, Price = 2.99, Qty = 15, Candys = new List<string>(){ "BasicBerry"} },
+                new ComputeCustomer { Id = 3, Name = "John",  Age = 34, Price = 6.99, Qty = 4, Candys = new List<string>(){ "Snickers", "Hershey"} },
+                new ComputeCustomer { Id = 4, Name = "Kerry", Age = 29, Price = 3.99, Qty = 15, Candys = new List<string>(){ "Snickers", "M&M"} },
+                new ComputeCustomer { Id = 5, Name = "Alex",  Age = 08, Price = 9.01, Qty = 20, Candys = new List<string>(){ "M&M", "Twix"} },
             };
             int[] zipcode = { 98029, 32509, 98052, 88309, 12304 };
 


### PR DESCRIPTION
Fixes #1103: Compute with lambda expression

When we $select a computed property from a $compute containing a lambda expression, we should be careful to process the "source" for rangeVariable.

So, for example: `
http://localhost:5102/odata/products?$select=HasSnikers&$compute=Candys/any(r:r eq 'Snikers') as HasSnikers
`

The compute.expression is an `AnyNode` and the body is the binary operator node. so, the rangeVariable ($it) of source for `AnyNode` is the toplevel source, but the rangeVariable (r) is the lambda variable. 
