### PR TITLE
Update ConvertPrimitiveType method

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -134,6 +134,17 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             }
 
             Type type = value.GetType();
+
+            // Return values for supported primitive values. 
+            if (type == typeof(string)
+                || type == typeof(int)
+                || type == typeof(bool)
+                || type == typeof(double)
+                || type == typeof(Guid))
+            {
+                return value;
+            }
+
             if (primitiveType != null && primitiveType.IsDate() && TypeHelper.IsDateTime(type))
             {
                 Date dt = (DateTime)value;


### PR DESCRIPTION
The `ConvertPrimitive` method checks if a primitive is a `Date`, `TimeOfDay`, `Char`, `UInt16`, `UInt32`, `UInt64`. `DateTime`, `char[]`, `XElement` and handles them differently.  

If a primitive type is not any of these types, then the value is returned. 

A lot of checks are done to check for the above-mentioned types which can be avoided if we return the value early if we know the type, we are dealing with is not any of the above-mentioned types that need special processing. 

Making this change leads to the following CPU improvements: 
Before:
![before1](https://github.com/OData/AspNetCoreOData/assets/25525526/4e885b6e-ab85-43bb-bd97-f9057a37cb54)
After:
![after1](https://github.com/OData/AspNetCoreOData/assets/25525526/58794b1c-fe47-4c61-84cf-69658e60a108)