### PR TITLE
Perf Fix CreateEtags

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -783,7 +783,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 IDictionary<string, object> properties = null;
                 foreach (IEdmStructuralProperty etagProperty in concurrencyProperties)
                 {
-                    properties ??= new Dictionary<string, object>();
+                    properties ??= new SortedDictionary<string, object>();
                     
                     properties.Add(etagProperty.Name, resourceContext.GetPropertyValue(etagProperty.Name));
                 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -773,20 +773,22 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
                 IEnumerable<IEdmStructuralProperty> concurrencyProperties;
                 if (model != null && navigationSource != null)
                 {
-                    concurrencyProperties = model.GetConcurrencyProperties(navigationSource).OrderBy(c => c.Name);
+                    concurrencyProperties = model.GetConcurrencyProperties(navigationSource);
                 }
                 else
                 {
                     concurrencyProperties = Enumerable.Empty<IEdmStructuralProperty>();
                 }
 
-                IDictionary<string, object> properties = new Dictionary<string, object>();
+                IDictionary<string, object> properties = null;
                 foreach (IEdmStructuralProperty etagProperty in concurrencyProperties)
                 {
+                    properties ??= new Dictionary<string, object>();
+                    
                     properties.Add(etagProperty.Name, resourceContext.GetPropertyValue(etagProperty.Name));
                 }
 
-                if (properties.Count != 0)
+                if (properties != null)
                 {
                     return resourceContext.Request.CreateETag(properties, resourceContext.TimeZone);
                 }


### PR DESCRIPTION
This PR fixes some of the issues raised in this PR: https://github.com/OData/AspNetCoreOData/issues/1111: 
I've made the following updates to the `CreateEtag` method: 

- Set the initial value of the properties dictionary to null and initialize properties only within the foreach loop. This approach guarantees that the dictionary is instantiated only when concurrency properties are present.
- I excluded the OrderBy operation from the IEnumerable of concurrency properties to eliminate the cost associated with OrderedEnumerable.MoveNext(). Consequently, the existing approach retrieves the concurrent properties, orders them, and subsequently inserts them into a dictionary. If the dictionary preserves the order, the crucial factor lies in the manner in which properties are added to the dictionary rather than whether they are sorted before being added to the dictionary.  @xuzhg what are your thoughts on this? 
- Added a null check for the properties, ensuring that the CreateEtag method is invoked only when the properties are non-null.
These changes have the following CPU Usage improvements: 
Before changes:
<img width="659" alt="beforeetag" src="https://github.com/OData/AspNetCoreOData/assets/25525526/efad9185-ae3b-4596-89ca-0b57fbf85738">

After changes: 
<img width="648" alt="createetag" src="https://github.com/OData/AspNetCoreOData/assets/25525526/d8a0cd02-6f3c-45d4-9d45-25aad26cde13">

