### PR TITLE
Perf Fix : AddWithResize(T)

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1255,8 +1255,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
 
-            int listSize = (selectExpandNode.SelectedStructuralProperties?.Count ?? 0) + (selectExpandNode.SelectedComputedProperties?.Count ?? 0);
-            List<ODataProperty> properties = new List<ODataProperty>(listSize);
+            int propertiesCount = (selectExpandNode.SelectedStructuralProperties?.Count ?? 0) + (selectExpandNode.SelectedComputedProperties?.Count ?? 0);
+            List<ODataProperty> properties = new List<ODataProperty>(propertiesCount);
 
             if (selectExpandNode.SelectedStructuralProperties != null)
             {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1255,7 +1255,9 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
 
-            List<ODataProperty> properties = new List<ODataProperty>();
+            int listSize = (selectExpandNode.SelectedStructuralProperties?.Count ?? 0) + (selectExpandNode.SelectedComputedProperties?.Count ?? 0);
+            List<ODataProperty> properties = new List<ODataProperty>(listSize);
+
             if (selectExpandNode.SelectedStructuralProperties != null)
             {
                 IEnumerable<IEdmStructuralProperty> structuralProperties = selectExpandNode.SelectedStructuralProperties;


### PR DESCRIPTION
The `CreateStructuralPropertyBag` method begins by initializing an empty list of properties. It then iterates through the structural and computed properties in a resource, appending them to the empty list. Currently, the frequent invocation of the `AddWithResize(T)` method appears to be resource-intensive. To mitigate this, preallocating a list with a specific size helps minimize this expense.

CPU Usage before these changes
<img width="757" alt="addwithresize1" src="https://github.com/OData/AspNetCoreOData/assets/25525526/cca35811-d667-41d2-8399-76c3eb739090">

CPU usage after these changes:
<img width="626" alt="addwithresize" src="https://github.com/OData/AspNetCoreOData/assets/25525526/da6de478-d294-4df6-8c3f-badf839d0cb1">
