### PR TITLE
Fixes #1131, doube unescaped for function parameters

### DIFF
--- a/sample/ODataRoutingSample/Controllers/ProductsController.cs
+++ b/sample/ODataRoutingSample/Controllers/ProductsController.cs
@@ -178,6 +178,17 @@ namespace ODataRoutingSample.Controllers
         public string GetWholeSalary(string order, string name)
         {
             return $"Products/GetWholeSalary: {order}, {name}";
+
+            // Be noted:
+            // The function parameter from route value is unescaped, so we don't need to do it again.
+            // for example: we can send request like: 
+            // http://localhost:5000/Products/Default.GetWholeSalary(order='2',name='key%253A')
+            // The response should look like:
+            //
+            // {
+            //    "@odata.context": "http://localhost:5000/$metadata#Edm.String",
+            //   "value": "Products/GetWholeSalary: 2, key%3A"
+            // }
         }
 
         [HttpGet]

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -4763,7 +4763,7 @@
             <summary>
             Checks whether a navigation link should be written or not. 
             </summary>
-            <param name="navigationLink">The navigation link to be written</param>
+            <param name="navigationLink">The navigation link to be written.</param>
             <param name="resourceContext">The resource context for the resource whose navigation link is being written.</param>
             <returns>true if navigation link should be written; otherwise false.</returns>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
@@ -59,7 +59,9 @@ namespace Microsoft.AspNetCore.OData.Routing.Template
                 {
                     string strValue = rawValue as string;
                     string newStrValue = context.GetParameterAliasOrSelf(strValue);
-                    newStrValue = Uri.UnescapeDataString(newStrValue);
+
+                    // rawValue from Request route values, it's unescaped except the back-slash.
+                    newStrValue = newStrValue.UnescapeBackSlashUriString();
                     if (newStrValue != strValue)
                     {
                         updatedValues[parameterTemp] = newStrValue;

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/FunctionSegmentTemplateTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/Template/FunctionSegmentTemplateTests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing.Template
             Assert.Same(function, functionSegment.Operations.First());
             var parameter = Assert.Single(functionSegment.Parameters);
             Assert.Equal("name", parameter.Name);
-            Assert.Equal("Ji/Change# T", parameter.Value.ToString());
+            Assert.Equal("Ji/Change%23%20T", parameter.Value.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
For example: using https://github.com/OData/AspNetCoreOData/tree/main/sample/ODataRoutingSample sample, and send request

http://localhost:5000/Products/Default.GetWholeSalary(order='2',name='key%253A')

Before this change:

The respose is:
<img width="554" alt="image" src="https://github.com/OData/AspNetCoreOData/assets/9426627/885f540c-ff5b-4a89-b986-06bdad189b8e">

After this change:
the response is:
<img width="559" alt="image" src="https://github.com/OData/AspNetCoreOData/assets/9426627/9490f8ab-2276-4699-972b-102e45c47754">

