### PR TITLE
Support Minimal API

### DIFF
--- a/AspNetCoreOData.sln
+++ b/AspNetCoreOData.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ODataAlternateKeySample", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkServer", "sample\BenchmarkServer\BenchmarkServer.csproj", "{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ODataMiniApi", "sample\ODataMiniApi\ODataMiniApi.csproj", "{986A48E0-FA19-49D0-B716-4E60740D243C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Release|Any CPU.Build.0 = Release|Any CPU
+		{986A48E0-FA19-49D0-B716-4E60740D243C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{986A48E0-FA19-49D0-B716-4E60740D243C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{986A48E0-FA19-49D0-B716-4E60740D243C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{986A48E0-FA19-49D0-B716-4E60740D243C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +96,7 @@ Global
 		{647EFCFA-55A7-4F0A-AD40-4B6EB1BFCFFA} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 		{7B153669-A42F-4511-8BDB-587B3B27B2F3} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850} = {B1F86961-6958-4617-ACA4-C231F95AE099}
+		{986A48E0-FA19-49D0-B716-4E60740D243C} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {540C9752-AAC0-49EA-BA60-78490C90FF86}

--- a/sample/ODataMiniApi/AppDb.cs
+++ b/sample/ODataMiniApi/AppDb.cs
@@ -1,0 +1,125 @@
+//-----------------------------------------------------------------------------
+// <copyright file="AppDb.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+
+namespace ODataMiniApi;
+
+public class AppDb : DbContext
+{
+    public AppDb(DbContextOptions<AppDb> options) : base(options) { }
+
+    public DbSet<School> Schools => Set<School>();
+
+    public DbSet<Student> Students => Set<Student>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<School>().HasKey(x => x.SchoolId);
+        modelBuilder.Entity<Student>().HasKey(x => x.StudentId);
+        modelBuilder.Entity<School>().OwnsOne(x => x.MailAddress);
+    }
+}
+
+static class AppDbExtension
+{
+    public static void MakeSureDbCreated(this WebApplication app)
+    {
+        using (var scope = app.Services.CreateScope())
+        {
+            var services = scope.ServiceProvider;
+            var context = services.GetRequiredService<AppDb>();
+
+            if (context.Schools.Count() == 0)
+            {
+                #region Students
+                var students = new List<Student>
+                {
+                    // Mercury school
+                    new Student { SchoolId = 1, StudentId = 10, FirstName = "Spens", LastName = "Alex", FavoriteSport = "Soccer", Grade = 87, BirthDay = new DateOnly(2009, 11, 15) },
+                    new Student { SchoolId = 1, StudentId = 11, FirstName = "Jasial", LastName = "Eaine", FavoriteSport = "Basketball", Grade = 45, BirthDay = new DateOnly(1989, 8, 3) },
+                    new Student { SchoolId = 1, StudentId = 12, FirstName = "Niko", LastName = "Rorigo", FavoriteSport = "Soccer", Grade = 78, BirthDay = new DateOnly(2019, 5, 5) },
+                    new Student { SchoolId = 1, StudentId = 13, FirstName = "Roy", LastName = "Rorigo", FavoriteSport = "Tennis", Grade = 67, BirthDay = new DateOnly(1975, 11, 4) },
+                    new Student { SchoolId = 1, StudentId = 14, FirstName = "Zaral", LastName = "Clak", FavoriteSport = "Basketball", Grade = 54, BirthDay = new DateOnly(2008, 1, 4) },
+
+                    // Venus school
+                    new Student { SchoolId = 2, StudentId = 20, FirstName = "Hugh", LastName = "Briana", FavoriteSport = "Basketball", Grade = 78, BirthDay = new DateOnly(1959, 5, 6) },
+                    new Student { SchoolId = 2, StudentId = 21, FirstName = "Reece", LastName = "Len", FavoriteSport = "Basketball", Grade = 45, BirthDay = new DateOnly(2004, 2, 5) },
+                    new Student { SchoolId = 2, StudentId = 22, FirstName = "Javanny", LastName = "Jay", FavoriteSport = "Soccer", Grade = 87, BirthDay = new DateOnly(2003, 6, 5) },
+                    new Student { SchoolId = 2, StudentId = 23, FirstName = "Ketty", LastName = "Oak", FavoriteSport = "Tennis", Grade = 99, BirthDay = new DateOnly(1998, 7, 25) },
+                    
+                    // Earth School
+                    new Student { SchoolId = 3, StudentId = 30, FirstName = "Mike", LastName = "Wat", FavoriteSport = "Tennis", Grade = 93, BirthDay = new DateOnly(1999, 5, 15) },
+                    new Student { SchoolId = 3, StudentId = 31, FirstName = "Sam", LastName = "Joshi", FavoriteSport = "Soccer", Grade = 78, BirthDay = new DateOnly(2000, 6, 23) },
+                    new Student { SchoolId = 3, StudentId = 32, FirstName = "Kerry", LastName = "Travade", FavoriteSport = "Basketball", Grade = 89, BirthDay = new DateOnly(2001, 2, 6) },
+                    new Student { SchoolId = 3, StudentId = 33, FirstName = "Pett", LastName = "Jay", FavoriteSport = "Tennis", Grade = 63, BirthDay = new DateOnly(1998, 11, 7) },
+
+                    // Mars School
+                    new Student { SchoolId = 4, StudentId = 40, FirstName = "Mike", LastName = "Wat", FavoriteSport = "Soccer", Grade = 64, BirthDay = new DateOnly(2011, 11, 15) },
+                    new Student { SchoolId = 4, StudentId = 41, FirstName = "Sam", LastName = "Joshi", FavoriteSport = "Basketball", Grade = 98, BirthDay = new DateOnly(2005, 6, 6) },
+                    new Student { SchoolId = 4, StudentId = 42, FirstName = "Kerry", LastName = "Travade", FavoriteSport = "Soccer", Grade = 88, BirthDay = new DateOnly(2011, 5, 13) },
+
+                    // Jupiter School
+                    new Student { SchoolId = 5, StudentId = 50, FirstName = "David", LastName = "Padron", FavoriteSport = "Tennis", Grade = 77, BirthDay = new DateOnly(2015, 12, 3) },
+                    new Student { SchoolId = 5, StudentId = 53, FirstName = "Jeh", LastName = "Brook", FavoriteSport = "Basketball", Grade = 69, BirthDay = new DateOnly(2014, 10, 15) },
+                    new Student { SchoolId = 5, StudentId = 54, FirstName = "Steve", LastName = "Johnson", FavoriteSport = "Soccer", Grade = 100, BirthDay = new DateOnly(1995, 3, 2) },
+
+                    // Saturn School
+                    new Student { SchoolId = 6, StudentId = 60, FirstName = "John", LastName = "Haney", FavoriteSport = "Soccer", Grade = 99, BirthDay = new DateOnly(2008, 12, 1) },
+                    new Student { SchoolId = 6, StudentId = 61, FirstName = "Morgan", LastName = "Frost", FavoriteSport = "Tennis", Grade = 17, BirthDay = new DateOnly(2009, 11, 4) },
+                    new Student { SchoolId = 6, StudentId = 62, FirstName = "Jennifer", LastName = "Viles", FavoriteSport = "Basketball", Grade = 54, BirthDay = new DateOnly(1989, 3, 15) },
+
+                    // Uranus School
+                    new Student { SchoolId = 7, StudentId = 72, FirstName = "Matt", LastName = "Dally", FavoriteSport = "Basketball", Grade = 77, BirthDay = new DateOnly(2011, 11, 4) },
+                    new Student { SchoolId = 7, StudentId = 73, FirstName = "Kevin", LastName = "Vax", FavoriteSport = "Basketball", Grade = 93, BirthDay = new DateOnly(2012, 5, 12) },
+                    new Student { SchoolId = 7, StudentId = 76, FirstName = "John", LastName = "Clarey", FavoriteSport = "Soccer", Grade = 95, BirthDay = new DateOnly(2008, 8, 8) },
+
+                    // Neptune School
+                    new Student { SchoolId = 8, StudentId = 81, FirstName = "Adam", LastName = "Singh", FavoriteSport = "Tennis", Grade = 92, BirthDay = new DateOnly(2006, 6, 23) },
+                    new Student { SchoolId = 8, StudentId = 82, FirstName = "Bob", LastName = "Joe", FavoriteSport = "Soccer", Grade = 88, BirthDay = new DateOnly(1978, 11, 15) },
+                    new Student { SchoolId = 8, StudentId = 84, FirstName = "Martin", LastName = "Dalton", FavoriteSport = "Tennis", Grade = 77, BirthDay = new DateOnly(2017, 5, 14) },
+
+                    // Pluto School
+                    new Student { SchoolId = 9, StudentId = 91, FirstName = "Michael", LastName = "Wu", FavoriteSport = "Soccer", Grade = 97, BirthDay = new DateOnly(2022, 9, 22) },
+                    new Student { SchoolId = 9, StudentId = 93, FirstName = "Rachel", LastName = "Wottle", FavoriteSport = "Soccer", Grade = 81, BirthDay = new DateOnly(2022, 10, 5) },
+                    new Student { SchoolId = 9, StudentId = 97, FirstName = "Aakash", LastName = "Aarav", FavoriteSport = "Soccer", Grade = 98, BirthDay = new DateOnly(2003, 3, 15) }
+                };
+
+                foreach (var s in students)
+                {
+                    context.Students.Add(s);
+                }
+                #endregion
+
+                #region Schools
+                var schools = new List<School>
+                {
+                    new School { SchoolId = 1, SchoolName = "Mercury Middle School", MailAddress = new Address { ApartNum = 241, City = "Kirk", Street = "156TH AVE", ZipCode = "98051" } },
+                    new School { SchoolId = 2, SchoolName = "Venus High School", MailAddress = new Address { ApartNum = 543, City = "AR", Street = "51TH AVE PL", ZipCode = "98043" } },
+                    new School { SchoolId = 3, SchoolName = "Earth University", MailAddress = new Address { ApartNum = 101, City = "Belly", Street = "24TH ST", ZipCode = "98029" } },
+                    new School { SchoolId = 4, SchoolName = "Mars Elementary School ", MailAddress = new Address { ApartNum = 123, City = "Issaca", Street = "Mars Rd", ZipCode = "98023" }  },
+                    new School { SchoolId = 5, SchoolName = "Jupiter College", MailAddress = new Address { ApartNum = 443, City = "Redmond", Street = "Sky Freeway", ZipCode = "78123" } },
+                    new School { SchoolId = 6, SchoolName = "Saturn Middle School", MailAddress = new Address { ApartNum = 11, City = "Moon", Street = "187TH ST", ZipCode = "68133" } },
+                    new School { SchoolId = 7, SchoolName = "Uranus High School", MailAddress = new Address { ApartNum = 123, City = "Greenland", Street = "Sun Street", ZipCode = "88155" } },
+                    new School { SchoolId = 8, SchoolName = "Neptune Elementary School", MailAddress = new Address  { ApartNum = 77, City = "BadCity", Street = "Moon way", ZipCode = "89155" } },
+                    new School { SchoolId = 9, SchoolName = "Pluto University", MailAddress = new Address { ApartNum = 12004, City = "Sahamish", Street = "Universals ST", ZipCode = "10293" } }
+                };
+
+                foreach (var s in schools)
+                {
+                    s.Students = students.Where(std => std.SchoolId == s.SchoolId).ToList();
+
+                    context.Schools.Add(s);
+                }
+                #endregion
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/sample/ODataMiniApi/AppModels.cs
+++ b/sample/ODataMiniApi/AppModels.cs
@@ -1,0 +1,65 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="AppModels.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ODataMiniApi;
+
+public class EdmModelBuilder
+{
+    public static IEdmModel GetEdmModel()
+    {
+        var builder = new ODataConventionModelBuilder();
+        builder.EntitySet<School>("Schools");
+        builder.ComplexType<Address>();
+        builder.ComplexType<Student>();
+        return builder.GetEdmModel();
+    }
+}
+
+public class School
+{
+    public int SchoolId { get; set; }
+
+    public string SchoolName { get; set; }
+
+    public Address MailAddress { get; set; }
+
+    public virtual IList<Student> Students { get; set; }
+}
+
+public class Student
+{
+    public int StudentId { get; set; }
+
+    public string FirstName { get; set; }
+
+    public string LastName { get; set; }
+
+    public string FavoriteSport { get; set; }
+
+    public int Grade { get; set; }
+
+    public int SchoolId { get; set; }
+
+    public DateOnly BirthDay { get; set; }
+}
+
+[ComplexType]
+public class Address
+{
+    public int ApartNum { get; set; }
+
+    public string City { get; set; }
+
+    public string Street { get; set; }
+
+    public string ZipCode { get; set; }
+}

--- a/sample/ODataMiniApi/ODataMiniApi.csproj
+++ b/sample/ODataMiniApi/ODataMiniApi.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/sample/ODataMiniApi/Program.cs
+++ b/sample/ODataMiniApi/Program.cs
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------------
+// <copyright file="Program.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Extensions;
+using ODataMiniApi;
+using ODataMiniApi.Students;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddDbContext<AppDb>(options => options.UseInMemoryDatabase("SchoolStudentList"));
+builder.Services.AddOData(opt => opt.EnableQueryFeatures()// This line is required
+    .AddRouteComponents("customized", EdmModelBuilder.GetEdmModel()) // This line is used to test 'UseOData' extension
+); 
+
+var app = builder.Build();
+app.MakeSureDbCreated();
+
+#region School Endpoints
+
+app.MapGet("/schools", (AppDb db, ODataQueryOptions<School> options) => {
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return options.ApplyTo(db.Schools);
+});
+
+app.MapGet("/schools/{id}", async (int id, AppDb db, ODataQueryOptions<School> options) => {
+    School school = await db.Schools.Include(c => c.MailAddress)
+        .Include(c => c.Students).FirstOrDefaultAsync(s => s.SchoolId == id);
+    if (school == null)
+    {
+        return Results.NotFound($"Cannot find school with id '{id}'");
+    }
+    else
+    {
+        return Results.Ok(options.ApplyTo(school, new ODataQuerySettings()));
+    }
+});
+
+app.MapGet("/customized/schools", (AppDb db, ODataQueryOptions<School> options) => {
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return options.ApplyTo(db.Schools);
+}).UseOData("customized"); // In customized OData, MailAddress and Student are complex type, you can also use 'IODataModelConfiguration'
+
+#endregion
+
+// Endpoints for students
+app.MapStudentEndpoints();
+
+app.Run();
+

--- a/sample/ODataMiniApi/Properties/launchSettings.json
+++ b/sample/ODataMiniApi/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:27886",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sample/ODataMiniApi/Students/StudentEndpoints.cs
+++ b/sample/ODataMiniApi/Students/StudentEndpoints.cs
@@ -1,0 +1,209 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="StudentEndpoints.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.EntityFrameworkCore;
+
+namespace ODataMiniApi.Students;
+
+/// <summary>
+/// Add student endpoint to support CRUD operations.
+/// The codes are implemented as simple as possible. Please file issues to us for any issues.
+/// </summary>
+public static class StudentEndpoints
+{
+    public static async Task<IResult> GetStudentByIdAsync(int id, AppDb db, ODataQueryOptions<Student> options)
+    {
+        Student student = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (student == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+        else
+        {
+            return Results.Ok(options.ApplyTo(student, new ODataQuerySettings()));
+        }
+    }
+
+    public static async Task<IResult> PatchStudentByIdAsync(int id, AppDb db, [FromBody] IDictionary<string, object> properties)
+    {
+        // TODO: need to support Delta<Student> to replace IDictionary<string, object> in the next step
+        Student oldStudent = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (oldStudent == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+
+        int oldSchoolId = oldStudent.SchoolId;
+
+        var studentProperties = typeof(Student).GetProperties();
+        foreach (var property in properties)
+        {
+            PropertyInfo propertyInfo = studentProperties.FirstOrDefault(p => string.Equals(p.Name, property.Key, StringComparison.OrdinalIgnoreCase));
+            if (propertyInfo == null)
+            {
+                return Results.BadRequest($"Cannot find property '{property.Key}' on student");
+            }
+
+            // For simplicity
+            if (propertyInfo.PropertyType == typeof(string))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToString());
+            }
+            else if (propertyInfo.PropertyType == typeof(int))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToInt());
+            }
+            else if (propertyInfo.PropertyType == typeof(DateOnly))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToDateOnly());
+            }
+        }
+
+        if (oldSchoolId != oldStudent.SchoolId)
+        {
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == oldSchoolId);
+            school.Students.Remove(oldStudent);
+
+            school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == oldStudent.SchoolId);
+            if (school == null)
+            {
+                return Results.NotFound($"Cannot find school using the school Id '{oldStudent.SchoolId}' that the new student provides.");
+            }
+            else
+            {
+                school.Students.Add(oldStudent);
+            }
+        }
+
+        await db.SaveChangesAsync();
+
+        return Results.Ok(oldStudent);
+    }
+
+    public static async Task<IResult> DeleteStudentByIdAsync(int id, AppDb db)
+    {
+        Student student = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (student == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+        else
+        {
+            db.Students.Remove(student);
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == student.SchoolId);
+            school.Students.Remove(student);
+            await db.SaveChangesAsync();
+            return Results.Ok();
+        }
+    }
+
+    public static IEndpointRouteBuilder MapStudentEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Let's use the group to build the student endpoints
+        var students = app.MapGroup("/odata");
+
+        // GET http://localhost:5177/odata/students?$select=lastName&$top=3
+        students.MapGet("/students", async (AppDb db, ODataQueryOptions<Student> options) =>
+        {
+            await db.Students.ToListAsync();
+            return options.ApplyTo(db.Students);
+        });
+
+        //GET http://localhost:5177/odata/students/12?select=lastName
+        students.MapGet("/students/{id}", GetStudentByIdAsync);
+
+        //GET http://localhost:5177/odata/students(12)?select=lastName
+        students.MapGet("/students({id})", GetStudentByIdAsync);
+
+        // POST http://localhost:5177/odata/students
+        // Content-Type: application/json
+        // BODY:
+        /*
+{
+
+"firstName": "Soda",
+"lastName": "Yu",
+"favoriteSport": "Soccer",
+"grade": 7,
+"schoolId": 3,
+"birthDay": "1977-11-04"
+}
+        */
+        students.MapPost("/students", async (Student student, AppDb db) =>
+        {
+            int studentId = db.Students.Max(s => s.StudentId) + 1;
+            student.StudentId = studentId;
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == student.SchoolId);
+            if (school == null)
+            {
+                return Results.NotFound($"Cannot find school using the school Id '{student.SchoolId}' that the new student provides.");
+            }
+            else
+            {
+                school.Students.Add(student);
+            }
+
+            db.Students.Add(student);
+            await db.SaveChangesAsync();
+
+            return Results.Created($"/odata/students/{studentId}", student);
+        });
+
+        // PATCH http://localhost:5177/odata/students/10
+        // Content-Type: application/json
+        // BODY:
+        /*
+{
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "schoolId": 4
+}
+         */
+        students.MapPatch("/students({id})", PatchStudentByIdAsync);
+        students.MapPatch("/students/{id}", PatchStudentByIdAsync);
+
+        // DELETE http://localhost:5177/odata/students/10
+        students.MapDelete("/students({id})", DeleteStudentByIdAsync);
+        students.MapDelete("/students/{id}", DeleteStudentByIdAsync);
+        return app;
+    }
+
+    private static string ConvertToString(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.String)
+        {
+            return json.GetString();
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to string");
+    }
+
+    private static int ConvertToInt(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.Number)
+        {
+            return json.GetInt32();
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to int");
+    }
+
+    private static DateOnly ConvertToDateOnly(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.String)
+        {
+            string str = json.GetString();
+            return DateOnly.Parse(str);
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to DateOnly");
+    }
+}

--- a/sample/ODataMiniApi/appsettings.Development.json
+++ b/sample/ODataMiniApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sample/ODataMiniApi/appsettings.json
+++ b/sample/ODataMiniApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/sample/ODataMiniApi/readme.md
+++ b/sample/ODataMiniApi/readme.md
@@ -6,7 +6,6 @@ This is an ASP.NET Core OData 8.x minimal API project.
 Minimal APIs are a simplified approach for building fast HTTP APIs with ASP.NET Core. You can build fully functioning REST endpoints with minimal code and configuration. Skip traditional scaffolding and avoid unnecessary controllers by fluently declaring API routes and actions. 
 
 
-
 ## Basic endpoints
 
 1) GET `http://localhost:5177/schools`
@@ -128,3 +127,48 @@ Content-Type: application/json
     "birthDay": "1977-11-04"
 }
 ```
+
+Check using `http://localhost:5177/schools/3`, you can see a new student added:
+
+```json
+[
+  "schoolId": 3,
+    "schoolName": "Earth University",
+    "mailAddress": {
+        "apartNum": 101,
+        "city": "Belly",
+        "street": "24TH ST",
+        "zipCode": "98029"
+    },
+    "students": [
+        ...
+        {
+            "studentId": 98,
+            "firstName": "Sokuda",
+            "lastName": "Yu",
+            "favoriteSport": "Soccer",
+            "grade": 7,
+            "schoolId": 3,
+            "birthDay": "1977-11-04"
+        }
+    ]
+}
+```
+
+3) Patch `http://localhost:5177/odata/students/10`
+Content-Type: application/json
+
+```json
+{
+
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "schoolId": 4
+}
+```
+
+This will change the student, and also move the student from `Schools(1)` to `Schools(4)`
+
+4) Delete `http://localhost:5177/odata/students/10`
+
+This will delete the `Students(10)`

--- a/sample/ODataMiniApi/readme.md
+++ b/sample/ODataMiniApi/readme.md
@@ -1,0 +1,130 @@
+# ASP.NET Core OData (8.x) Minimal API Sample
+
+---
+This is an ASP.NET Core OData 8.x minimal API project. 
+
+Minimal APIs are a simplified approach for building fast HTTP APIs with ASP.NET Core. You can build fully functioning REST endpoints with minimal code and configuration. Skip traditional scaffolding and avoid unnecessary controllers by fluently declaring API routes and actions. 
+
+
+
+## Basic endpoints
+
+1) GET `http://localhost:5177/schools`
+
+```json
+[
+    {
+        "schoolId": 1,
+        "schoolName": "Mercury Middle School",
+        "mailAddress": {
+            "apartNum": 241,
+            "city": "Kirk",
+            "street": "156TH AVE",
+            "zipCode": "98051"
+        },
+        "students": null
+    },
+    {
+        "schoolId": 2,
+        ...
+    }
+    ...
+]    
+```
+
+2) GET `http://localhost:5177/schools?$expand=mailaddress&$select=schoolName&$top=2`
+
+```json
+[
+    {
+        "MailAddress": {
+            "ApartNum": 241,
+            "City": "Kirk",
+            "Street": "156TH AVE",
+            "ZipCode": "98051"
+        },
+        "SchoolName": "Mercury Middle School"
+    },
+    {
+        "MailAddress": {
+            "ApartNum": 543,
+            "City": "AR",
+            "Street": "51TH AVE PL",
+            "ZipCode": "98043"
+        },
+        "SchoolName": "Venus High School"
+    }
+]
+```
+
+3) GET `http://localhost:5177/schools/5?$expand=students($top=1)&$select=schoolName`
+
+```json
+{
+    "Students": [
+        {
+            "StudentId": 50,
+            "FirstName": "David",
+            "LastName": "Padron",
+            "FavoriteSport": "Tennis",
+            "Grade": 77,
+            "SchoolId": 5,
+            "BirthDay": "2015-12-03"
+        }
+    ],
+    "SchoolName": "Jupiter College"
+}
+```
+
+4) GET `http://localhost:5177/customized/schools?$select=schoolName,mailAddress&$orderby=schoolName&$top=1`
+
+This endpoint uses the `OData model` from configuration, which builds `Address` as complex type, so we can use `$select`
+
+```json
+[
+    {
+        "SchoolName": "Earth University",
+        "MailAddress": {
+            "ApartNum": 101,
+            "City": "Belly",
+            "Street": "24TH ST",
+            "ZipCode": "98029"
+        }
+    }
+]
+```
+
+## Student CRUD endpoints
+
+I grouped student endpoints under `odata` group intentionally.
+
+1) GET `http://localhost:5177/odata/students?$select=lastName&$top=3`
+
+```json
+[
+    {
+        "LastName": "Alex"
+    },
+    {
+        "LastName": "Eaine"
+    },
+    {
+        "LastName": "Rorigo"
+    }
+]
+```
+
+2) POST `http://localhost:5177/odata/students`  with the following body:
+Content-Type: application/json
+
+```json
+{
+
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "favoriteSport": "Soccer",
+    "grade": 7,
+    "schoolId": 3,
+    "birthDay": "1977-11-04"
+}
+```

--- a/src/Microsoft.AspNetCore.OData/Edm/DefaultODataEndpointModelMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/DefaultODataEndpointModelMapper.cs
@@ -1,0 +1,18 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DefaultODataEndpointModelMapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    internal class DefaultODataEndpointModelMapper : IODataEndpointModelMapper
+    {
+        public ConcurrentDictionary<Endpoint, IEdmModel> Maps { get; } = new ConcurrentDictionary<Endpoint, IEdmModel>();
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/IODataEndpointModelMapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/IODataEndpointModelMapper.cs
@@ -1,0 +1,25 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataEndpointModelMapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    /// <summary>
+    /// A cache for <see cref="Endpoint"/> and <see cref="IEdmModel"/> mapping.
+    /// It's typically used for minimal API scenario.
+    /// </summary>
+    public interface IODataEndpointModelMapper
+    {
+        /// <summary>
+        /// Gets the map between <see cref="Endpoint"/> and <see cref="IEdmModel"/>
+        /// </summary>
+        ConcurrentDictionary<Endpoint, IEdmModel> Maps { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Edm/IODataModelConfiguration.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/IODataModelConfiguration.cs
@@ -1,0 +1,25 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataModelConfiguration.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.Edm
+{
+    /// <summary>
+    /// Defines a contract used to apply extra logic on the model builder.
+    /// </summary>
+    public interface IODataModelConfiguration
+    {
+        /// <summary>
+        /// Applies model configurations using the provided builder.
+        /// </summary>
+        /// <param name="context">The HttpContext.</param>
+        /// <param name="builder">The <see cref="ODataModelBuilder">builder</see> used to apply configurations.</param>
+        void Apply(HttpContext context, ODataModelBuilder builder);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataEndpointConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataEndpointConventionBuilderExtensions.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Extensions
+{
+    /// <summary>
+    /// Extension methods for annotating OData metadata on an <see cref="Endpoint" />.
+    /// </summary>
+    public static class ODataEndpointConventionBuilderExtensions
+    {
+        /// <summary>
+        /// Adds an OData prefix metadata to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+        /// The prefix should be same as the defined prefix when calling 'AddRouteComponents'
+        /// This method typically is used in Minimal API scenarios.
+        /// </summary>
+        /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+        /// <param name="prefix">The route component prefix.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        /// <remarks>
+        /// When we target on .NET 7 or above, we can get the 'ServiceProvider' from Endpoint builder,
+        /// Then, we should check the 'AddOData' is called and associated route with given prefix registered.
+        /// </remarks>
+        public static TBuilder UseOData<TBuilder>(this TBuilder builder, string prefix) where TBuilder : IEndpointConventionBuilder
+            => builder.WithMetadata(new ODataPrefixMetadata(prefix ?? string.Empty));
+
+        /// <summary>
+        /// Adds an OData model configuration metadata to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+        /// This method typically is used in Minimal API scenarios.
+        /// </summary>
+        /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+        /// <param name="config">The model configuration.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static TBuilder UseOData<TBuilder>(this TBuilder builder, IODataModelConfiguration config) where TBuilder : IEndpointConventionBuilder
+            => builder.WithMetadata(config);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataPrefixMetadata.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataPrefixMetadata.cs
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataPrefixMetadata.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.OData.Extensions
+{
+    /// <summary>
+    /// Defines a contract use to specify the OData prefix metadata in <see cref="Endpoint.Metadata"/>.
+    /// </summary>
+    public sealed class ODataPrefixMetadata
+    {
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="ODataPrefixMetadata"/> class.
+        /// </summary>
+        /// <param name="prefix">The route component prefix</param>
+        public ODataPrefixMetadata(string prefix)
+        {
+            Prefix = prefix ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the route component prefix.
+        /// </summary>
+        public string Prefix { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1102,6 +1102,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -2486,6 +2500,29 @@
             Gets the whole expand path.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper">
+            <summary>
+            A cache for <see cref="T:Microsoft.AspNetCore.Http.Endpoint"/> and <see cref="T:Microsoft.OData.Edm.IEdmModel"/> mapping.
+            It's typically used for minimal API scenario.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper.Maps">
+            <summary>
+            Gets the map between <see cref="T:Microsoft.AspNetCore.Http.Endpoint"/> and <see cref="T:Microsoft.OData.Edm.IEdmModel"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration">
+            <summary>
+            Defines a contract used to apply extra logic on the model builder.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration.Apply(Microsoft.AspNetCore.Http.HttpContext,Microsoft.OData.ModelBuilder.ODataModelBuilder)">
+            <summary>
+            Applies model configurations using the provided builder.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataModelBuilder">builder</see> used to apply configurations.</param>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper">
             <summary>
             Provides the mapping between CLR type and Edm type.
@@ -3107,6 +3144,50 @@
             <param name="request">The Http request.</param>
             <param name="segments">The OData path segments.</param>
             <returns>The generated OData link.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions">
+            <summary>
+            Extension methods for annotating OData metadata on an <see cref="T:Microsoft.AspNetCore.Http.Endpoint" />.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions.UseOData``1(``0,System.String)">
+            <summary>
+            Adds an OData prefix metadata to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            The prefix should be same as the defined prefix when calling 'AddRouteComponents'
+            This method typically is used in Minimal API scenarios.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="prefix">The route component prefix.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+            <remarks>
+            When we target on .NET 7 or above, we can get the 'ServiceProvider' from Endpoint builder,
+            Then, we should check the 'AddOData' is called and associated route with given prefix registered.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions.UseOData``1(``0,Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration)">
+            <summary>
+            Adds an OData model configuration metadata to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            This method typically is used in Minimal API scenarios.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="config">The model configuration.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata">
+            <summary>
+            Defines a contract use to specify the OData prefix metadata in <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata.#ctor(System.String)">
+            <summary>
+             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata"/> class.
+            </summary>
+            <param name="prefix">The route component prefix</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata.Prefix">
+            <summary>
+            Gets the route component prefix.
+            </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Extensions.SerializableErrorExtensions">
             <summary>
@@ -4763,7 +4844,7 @@
             <summary>
             Checks whether a navigation link should be written or not. 
             </summary>
-            <param name="navigationLink">The navigation link to be written</param>
+            <param name="navigationLink">The navigation link to be written.</param>
             <param name="resourceContext">The resource context for the resource whose navigation link is being written.</param>
             <returns>true if navigation link should be written; otherwise false.</returns>
         </member>
@@ -6585,6 +6666,31 @@
             <summary>
             Provides extension methods to add OData services.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Adds essential OData services to the specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+            </summary>
+            <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add services to.</param>
+            <returns>A <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> that can be used to further configure the OData services.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.AspNetCore.OData.ODataOptions})">
+            <summary>
+            Adds essential OData services to the specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+            </summary>
+            <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add services to.</param>
+            <param name="setupAction">The OData options to configure the services with,
+            including access to a service provider which you can resolve services from.</param>
+            <returns>A <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> that can be used to further configure the OData services.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.AspNetCore.OData.ODataOptions,System.IServiceProvider})">
+            <summary>
+            Adds essential OData services to the specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+            </summary>
+            <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add services to.</param>
+            <param name="setupAction">The OData options to configure the services with,
+            including access to a service provider which you can resolve services from.</param>
+            <returns>A <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> that can be used to further configure the OData services.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddODataQueryFilter(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
@@ -10481,6 +10587,14 @@
             <param name="query">The original <see cref="T:System.Linq.IQueryable"/>.</param>
             <param name="querySettings">The settings to use in query composition.</param>
             <returns>The new <see cref="T:System.Linq.IQueryable"/> after the query has been applied to.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.BindAsync(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)">
+            <summary>
+            Bind the <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> and <see cref="T:System.Reflection.ParameterInfo"/> to generate the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/>.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="parameter">The parameter info.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/></returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryParameterBindingAttribute">
             <summary>
@@ -15224,22 +15338,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -238,6 +238,10 @@ Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.IdLink.get -> System.Uri
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.IdLink.set -> void
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.ReadLink.get -> System.Uri
 Microsoft.AspNetCore.OData.Edm.EntitySelfLinks.ReadLink.set -> void
+Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper
+Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper.Maps.get -> System.Collections.Concurrent.ConcurrentDictionary<Microsoft.AspNetCore.Http.Endpoint, Microsoft.OData.Edm.IEdmModel>
+Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration
+Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration.Apply(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.OData.ModelBuilder.ODataModelBuilder builder) -> void
 Microsoft.AspNetCore.OData.Edm.IODataTypeMapper
 Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetClrPrimitiveType(Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable) -> System.Type
 Microsoft.AspNetCore.OData.Edm.IODataTypeMapper.GetClrType(Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver) -> System.Type
@@ -275,6 +279,10 @@ Microsoft.AspNetCore.OData.Extensions.HttpContextExtensions
 Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions
 Microsoft.AspNetCore.OData.Extensions.HttpResponseExtensions
 Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers
+Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions
+Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata
+Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata.ODataPrefixMetadata(string prefix) -> void
+Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata.Prefix.get -> string
 Microsoft.AspNetCore.OData.Extensions.SerializableErrorExtensions
 Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys
 Microsoft.AspNetCore.OData.Formatter.Deserialization.IODataDeserializer
@@ -1212,6 +1220,8 @@ Microsoft.AspNetCore.OData.Query.Wrapper.DynamicTypeWrapper.TryGetPropertyValue(
 Microsoft.AspNetCore.OData.Query.Wrapper.ISelectExpandWrapper
 Microsoft.AspNetCore.OData.Query.Wrapper.ISelectExpandWrapper.ToDictionary() -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.OData.Query.Wrapper.ISelectExpandWrapper.ToDictionary(System.Func<Microsoft.OData.Edm.IEdmModel, Microsoft.OData.Edm.IEdmStructuredType, Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper> propertyMapperProvider) -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter
+Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.SelectExpandWrapperConverter() -> void
 Microsoft.AspNetCore.OData.Results.BadRequestODataResult
 Microsoft.AspNetCore.OData.Results.BadRequestODataResult.BadRequestODataResult(Microsoft.OData.ODataError odataError) -> void
 Microsoft.AspNetCore.OData.Results.BadRequestODataResult.BadRequestODataResult(string message) -> void
@@ -1553,6 +1563,8 @@ override Microsoft.AspNetCore.OData.Query.ETag.TrySetMember(System.Dynamic.SetMe
 override Microsoft.AspNetCore.OData.Query.ETag<TEntity>.ApplyTo(System.Linq.IQueryable query) -> System.Linq.IQueryable
 override Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.ApplyTo(System.Linq.IQueryable query) -> System.Linq.IQueryable
 override Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.ApplyTo(System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> System.Linq.IQueryable
+override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CanConvert(System.Type typeToConvert) -> bool
+override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CreateConverter(System.Type type, System.Text.Json.JsonSerializerOptions options) -> System.Text.Json.Serialization.JsonConverter
 override Microsoft.AspNetCore.OData.Results.BadRequestODataResult.ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.OData.Results.ConflictODataResult.ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.OData.Results.CreatedODataResult<T>.ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) -> System.Threading.Tasks.Task
@@ -1710,6 +1722,8 @@ static Microsoft.AspNetCore.OData.Extensions.HttpRequestExtensions.ODataOptions(
 static Microsoft.AspNetCore.OData.Extensions.HttpResponseExtensions.IsSuccessStatusCode(this Microsoft.AspNetCore.Http.HttpResponse response) -> bool
 static Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers.CreateODataLink(this Microsoft.AspNetCore.Http.HttpRequest request, params Microsoft.OData.UriParser.ODataPathSegment[] segments) -> string
 static Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers.CreateODataLink(this Microsoft.AspNetCore.Http.HttpRequest request, System.Collections.Generic.IList<Microsoft.OData.UriParser.ODataPathSegment> segments) -> string
+static Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions.UseOData<TBuilder>(this TBuilder builder, Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration config) -> TBuilder
+static Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions.UseOData<TBuilder>(this TBuilder builder, string prefix) -> TBuilder
 static Microsoft.AspNetCore.OData.Extensions.SerializableErrorExtensions.CreateODataError(this Microsoft.AspNetCore.Mvc.SerializableError serializableError) -> Microsoft.OData.ODataError
 static Microsoft.AspNetCore.OData.Formatter.LinkGenerationHelpers.GenerateActionLink(this Microsoft.AspNetCore.OData.Formatter.ResourceContext resourceContext, Microsoft.OData.Edm.IEdmOperation action) -> System.Uri
 static Microsoft.AspNetCore.OData.Formatter.LinkGenerationHelpers.GenerateActionLink(this Microsoft.AspNetCore.OData.Formatter.ResourceSetContext resourceSetContext, Microsoft.OData.Edm.IEdmOperation action) -> System.Uri
@@ -1737,6 +1751,9 @@ static Microsoft.AspNetCore.OData.ODataMvcBuilderExtensions.AddOData(this Micros
 static Microsoft.AspNetCore.OData.ODataMvcCoreBuilderExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder) -> Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder
 static Microsoft.AspNetCore.OData.ODataMvcCoreBuilderExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder, System.Action<Microsoft.AspNetCore.OData.ODataOptions, System.IServiceProvider> setupAction) -> Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder
 static Microsoft.AspNetCore.OData.ODataMvcCoreBuilderExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder, System.Action<Microsoft.AspNetCore.OData.ODataOptions> setupAction) -> Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder
+static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.OData.ODataOptions, System.IServiceProvider> setupAction) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.OData.ODataOptions> setupAction) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddODataQueryFilter(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddODataQueryFilter(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.AspNetCore.Mvc.Filters.IActionFilter queryFilter) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.AspNetCore.OData.ODataUriFunctions.AddCustomUriFunction(string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo) -> void
@@ -1758,6 +1775,7 @@ static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.IsSystemQueryOption(st
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.IsSystemQueryOption(string queryOptionName, bool isDollarSignOptional) -> bool
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.LimitResults<T>(System.Linq.IQueryable<T> queryable, int limit, bool parameterize, out bool resultsLimited) -> System.Linq.IQueryable<T>
 static Microsoft.AspNetCore.OData.Query.ODataQueryOptions.LimitResults<T>(System.Linq.IQueryable<T> queryable, int limit, out bool resultsLimited) -> System.Linq.IQueryable<T>
+static Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.BindAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>>
 static Microsoft.AspNetCore.OData.Query.OrderByNode.CreateCollection(Microsoft.OData.UriParser.OrderByClause orderByClause) -> System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Query.OrderByNode>
 static Microsoft.AspNetCore.OData.Results.SingleResult.Create<T>(System.Linq.IQueryable<T> queryable) -> Microsoft.AspNetCore.OData.Results.SingleResult<T>
 static Microsoft.AspNetCore.OData.Routing.Conventions.OperationRoutingConvention.AddSelector(Microsoft.AspNetCore.OData.Routing.Conventions.ODataControllerActionContext context, Microsoft.OData.Edm.IEdmOperation edmOperation, bool hasKeyParameter, Microsoft.OData.Edm.IEdmEntityType entityType, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.OData.Edm.IEdmEntityType castType) -> void
@@ -1778,6 +1796,7 @@ static readonly Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys.Mess
 static readonly Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys.MessageLanguageKey -> string
 static readonly Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys.ModelStateKey -> string
 static readonly Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys.StackTraceKey -> string
+static readonly Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.MapperProvider -> System.Func<Microsoft.OData.Edm.IEdmModel, Microsoft.OData.Edm.IEdmStructuredType, Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper>
 virtual Microsoft.AspNetCore.OData.Batch.DefaultODataBatchHandler.ExecuteRequestMessagesAsync(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem> requests, Microsoft.AspNetCore.Http.RequestDelegate handler) -> System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem>>
 virtual Microsoft.AspNetCore.OData.Batch.DefaultODataBatchHandler.ParseBatchRequestsAsync(Microsoft.AspNetCore.Http.HttpContext context) -> System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.AspNetCore.OData.Batch.ODataBatchRequestItem>>
 virtual Microsoft.AspNetCore.OData.Batch.ODataBatchHandler.CreateResponseMessageAsync(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem> responses, Microsoft.AspNetCore.Http.HttpRequest request) -> System.Threading.Tasks.Task

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/AggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/AggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class AggregationWrapper : GroupByWrapper
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/ComputeWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/ComputeWrapperOfT.cs
@@ -18,6 +18,7 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class ComputeWrapper<T> : GroupByWrapper, IEdmEntityObject
     {
         public T Instance { get; set; }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/DynamicTypeWrapperConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/DynamicTypeWrapperConverter.cs
@@ -47,15 +47,15 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
             if (type.IsGenericType)
             {
                 // Since 'type' is tested in 'CanConvert()', it must be a generic type
-                Type generaticType = type.GetGenericTypeDefinition();
+                Type genericType = type.GetGenericTypeDefinition();
                 Type elementType = type.GetGenericArguments()[0];
 
-                if (generaticType == typeof(ComputeWrapper<>))
+                if (genericType == typeof(ComputeWrapper<>))
                 {
                     return (JsonConverter)Activator.CreateInstance(typeof(ComputeWrapperConverter<>).MakeGenericType(new Type[] { elementType }));
                 }
 
-                if (generaticType == typeof(FlatteningWrapper<>))
+                if (genericType == typeof(FlatteningWrapper<>))
                 {
                     return (JsonConverter)Activator.CreateInstance(typeof(FlatteningWrapperConverter<>).MakeGenericType(new Type[] { elementType }));
                 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/EntitySetAggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/EntitySetAggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class EntitySetAggregationWrapper : GroupByWrapper
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/FlatteningWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/FlatteningWrapperOfT.cs
@@ -12,6 +12,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class FlatteningWrapper<T> : GroupByWrapper
     {
         // TODO: how to use 'Source'?

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/GroupByWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/GroupByWrapper.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.OData.Query.Container;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class GroupByWrapper : DynamicTypeWrapper
     {
         private Dictionary<string, object> _values;

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByAggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByAggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class NoGroupByAggregationWrapper : GroupByWrapper
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class NoGroupByWrapper : GroupByWrapper
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllAndExpandOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllAndExpandOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal class SelectAllAndExpand<TEntity> : SelectExpandWrapper<TEntity>
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal class SelectAll<TEntity> : SelectExpandWrapper<TEntity>
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Formatter.Value;
 using Microsoft.AspNetCore.OData.Query.Container;
@@ -14,6 +15,7 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal abstract class SelectExpandWrapper : IEdmEntityObject, ISelectExpandWrapper
     {
         private static readonly IPropertyMapper DefaultPropertyMapper = new IdentityPropertyMapper();

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
     /// <summary>
     /// Supports converting <see cref="SelectExpandWrapper{T}"/> types by using a factory pattern.
     /// </summary>
-    internal class SelectExpandWrapperConverter : JsonConverterFactory
+    public class SelectExpandWrapperConverter : JsonConverterFactory
     {
         public static readonly Func<IEdmModel, IEdmStructuredType, IPropertyMapper> MapperProvider =
             (IEdmModel model, IEdmStructuredType type) => new JsonPropertyNameMapper(model, type);
@@ -65,30 +65,30 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper
             }
 
             // Since 'type' is tested in 'CanConvert()', it must be a generic type
-            Type generaticType = type.GetGenericTypeDefinition();
+            Type genericType = type.GetGenericTypeDefinition();
             Type entityType = type.GetGenericArguments()[0];
 
-            if (generaticType == typeof(SelectSome<>))
+            if (genericType == typeof(SelectSome<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SelectSomeConverter<>).MakeGenericType(new Type[] { entityType }));
             }
 
-            if (generaticType == typeof(SelectSomeAndInheritance<>))
+            if (genericType == typeof(SelectSomeAndInheritance<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SelectSomeAndInheritanceConverter<>).MakeGenericType(new Type[] { entityType }));
             }
 
-            if (generaticType == typeof(SelectAll<>))
+            if (genericType == typeof(SelectAll<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SelectAllConverter<>).MakeGenericType(new Type[] { entityType }));
             }
 
-            if (generaticType == typeof(SelectAllAndExpand<>))
+            if (genericType == typeof(SelectAllAndExpand<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SelectAllAndExpandConverter<>).MakeGenericType(new Type[] { entityType }));
             }
 
-            if (generaticType == typeof(SelectExpandWrapper<>))
+            if (genericType == typeof(SelectExpandWrapper<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SelectExpandWrapperConverter<>).MakeGenericType(new Type[] { entityType }));
             }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
@@ -25,6 +25,7 @@ property selection combination possible. */
     /// Represents a container class that contains properties that are either selected or expanded using $select and $expand.
     /// </summary>
     /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeAndInheritanceOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeAndInheritanceOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal class SelectSomeAndInheritance<TEntity> : SelectExpandWrapper<TEntity>
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper
 {
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
     internal class SelectSome<TEntity> : SelectAllAndExpand<TEntity>
     {
     }

--- a/src/Microsoft.AspNetCore.OData/Results/PageResultOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/PageResultOfT.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Results
 {
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.OData.Results
     /// </remarks>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "Collection suffix not appropriate")]
     [DataContract]
+    [JsonConverter(typeof(PageResultValueConverter))]
     public class PageResult<T> : PageResult, IEnumerable<T>
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Results/PageResultValueConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/PageResultValueConverter.cs
@@ -21,8 +21,8 @@ namespace Microsoft.AspNetCore.OData.Results
                 return false;
             }
 
-            Type generaticType = typeToConvert.GetGenericTypeDefinition();
-            return generaticType == typeof(PageResult<>);
+            Type genericType = typeToConvert.GetGenericTypeDefinition();
+            return genericType == typeof(PageResult<>);
         }
 
         /// <summary>
@@ -34,10 +34,10 @@ namespace Microsoft.AspNetCore.OData.Results
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             // Since 'type' is tested in 'CanConvert()', it must be a generic type
-            Type generaticType = type.GetGenericTypeDefinition();
+            Type genericType = type.GetGenericTypeDefinition();
             Type entityType = type.GetGenericArguments()[0];
 
-            if (generaticType == typeof(PageResult<>))
+            if (genericType == typeof(PageResult<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(PageResultConverter<>).MakeGenericType(new Type[] { entityType }));
             }

--- a/src/Microsoft.AspNetCore.OData/Results/SingleResultOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/SingleResultOfT.cs
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Results
 {
@@ -14,6 +15,7 @@ namespace Microsoft.AspNetCore.OData.Results
     /// <c>[EnableQuery]</c>.
     /// </summary>
     /// <typeparam name="T">The type of the data in the data source.</typeparam>
+    [JsonConverter(typeof(SingleResultValueConverter))]
     public sealed class SingleResult<T> : SingleResult
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Results/SingleResultValueConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/SingleResultValueConverter.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.OData.Results
                 return false;
             }
 
-            Type generaticType = typeToConvert.GetGenericTypeDefinition();
-            return generaticType == typeof(SingleResult<>);
+            Type genericType = typeToConvert.GetGenericTypeDefinition();
+            return genericType == typeof(SingleResult<>);
         }
 
         /// <summary>
@@ -36,10 +36,10 @@ namespace Microsoft.AspNetCore.OData.Results
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             // Since 'type' is tested in 'CanConvert()', it must be a generic type
-            Type generaticType = type.GetGenericTypeDefinition();
+            Type genericType = type.GetGenericTypeDefinition();
             Type entityType = type.GetGenericArguments()[0];
 
-            if (generaticType == typeof(SingleResult<>))
+            if (genericType == typeof(SingleResult<>))
             {
                 return (JsonConverter)Activator.CreateInstance(typeof(SingleResultConverter<>).MakeGenericType(new Type[] { entityType }));
             }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -70,6 +70,21 @@ public sealed class Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions 
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action`1[[Microsoft.AspNetCore.OData.ODataOptions]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action`2[[Microsoft.AspNetCore.OData.ODataOptions],[System.IServiceProvider]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddODataQueryFilter (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
@@ -550,6 +565,14 @@ public class Microsoft.AspNetCore.OData.Deltas.DeltaSet`1 : System.Collections.O
 	System.Type StructuredType  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper {
+	System.Collections.Concurrent.ConcurrentDictionary`2[[Microsoft.AspNetCore.Http.Endpoint],[Microsoft.OData.Edm.IEdmModel]] Maps  { public abstract get; }
+}
+
+public interface Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration {
+	void Apply (Microsoft.AspNetCore.Http.HttpContext context, Microsoft.OData.ModelBuilder.ODataModelBuilder builder)
+}
+
 public interface Microsoft.AspNetCore.OData.Edm.IODataTypeMapper {
 	System.Type GetClrPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
 	System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
@@ -933,6 +956,21 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers {
 }
 
 [
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder UseOData (TBuilder builder, Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration config)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder UseOData (TBuilder builder, string prefix)
+}
+
+[
 EditorBrowsableAttribute(),
 ExtensionAttribute(),
 ]
@@ -953,6 +991,12 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys 
 	public static readonly string MessageLanguageKey = "MessageLanguage"
 	public static readonly string ModelStateKey = "ModelState"
 	public static readonly string StackTraceKey = "StackTrace"
+}
+
+public sealed class Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata {
+	public ODataPrefixMetadata (string prefix)
+
+	string Prefix  { public get; }
 }
 
 public enum Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel : int {
@@ -1427,6 +1471,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.As
 
 	public virtual System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query)
 	public virtual System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
+	public static ValueTask`1 BindAsync (Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter)
 	internal virtual Microsoft.AspNetCore.OData.Query.ETag GetETag (Microsoft.Net.Http.Headers.EntityTagHeaderValue etagHeaderValue)
 }
 
@@ -1688,6 +1733,7 @@ public class Microsoft.AspNetCore.OData.Results.ODataErrorResult : Microsoft.Asp
 
 [
 DataContractAttribute(),
+JsonConverterAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Results.PageResult`1 : Microsoft.AspNetCore.OData.Results.PageResult, IEnumerable`1, IEnumerable {
 	public PageResult`1 (IEnumerable`1 items, System.Uri nextPageLink, System.Nullable`1[[System.Int64]] count)
@@ -1737,6 +1783,9 @@ public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 
+[
+JsonConverterAttribute(),
+]
 public sealed class Microsoft.AspNetCore.OData.Results.SingleResult`1 : Microsoft.AspNetCore.OData.Results.SingleResult {
 	public SingleResult`1 (IQueryable`1 queryable)
 
@@ -3114,6 +3163,15 @@ public abstract class Microsoft.AspNetCore.OData.Query.Wrapper.DynamicTypeWrappe
 	System.Collections.Generic.Dictionary`2[[System.String],[System.Object]] Values  { public abstract get; }
 
 	public virtual bool TryGetPropertyValue (string propertyName, out System.Object& value)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter : System.Text.Json.Serialization.JsonConverterFactory {
+	public static readonly System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]] MapperProvider = System.Func`3[Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]
+
+	public SelectExpandWrapperConverter ()
+
+	public virtual bool CanConvert (System.Type typeToConvert)
+	public virtual System.Text.Json.Serialization.JsonConverter CreateConverter (System.Type type, System.Text.Json.JsonSerializerOptions options)
 }
 
 [

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -70,6 +70,21 @@ public sealed class Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions 
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action`1[[Microsoft.AspNetCore.OData.ODataOptions]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action`2[[Microsoft.AspNetCore.OData.ODataOptions],[System.IServiceProvider]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddODataQueryFilter (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
@@ -550,6 +565,14 @@ public class Microsoft.AspNetCore.OData.Deltas.DeltaSet`1 : System.Collections.O
 	System.Type StructuredType  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Edm.IODataEndpointModelMapper {
+	System.Collections.Concurrent.ConcurrentDictionary`2[[Microsoft.AspNetCore.Http.Endpoint],[Microsoft.OData.Edm.IEdmModel]] Maps  { public abstract get; }
+}
+
+public interface Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration {
+	void Apply (Microsoft.AspNetCore.Http.HttpContext context, Microsoft.OData.ModelBuilder.ODataModelBuilder builder)
+}
+
 public interface Microsoft.AspNetCore.OData.Edm.IODataTypeMapper {
 	System.Type GetClrPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
 	System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
@@ -933,6 +956,21 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.LinkGeneratorHelpers {
 }
 
 [
+ExtensionAttribute(),
+]
+public sealed class Microsoft.AspNetCore.OData.Extensions.ODataEndpointConventionBuilderExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder UseOData (TBuilder builder, Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration config)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder UseOData (TBuilder builder, string prefix)
+}
+
+[
 EditorBrowsableAttribute(),
 ExtensionAttribute(),
 ]
@@ -953,6 +991,12 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys 
 	public static readonly string MessageLanguageKey = "MessageLanguage"
 	public static readonly string ModelStateKey = "ModelState"
 	public static readonly string StackTraceKey = "StackTrace"
+}
+
+public sealed class Microsoft.AspNetCore.OData.Extensions.ODataPrefixMetadata {
+	public ODataPrefixMetadata (string prefix)
+
+	string Prefix  { public get; }
 }
 
 public enum Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel : int {
@@ -1688,6 +1732,7 @@ public class Microsoft.AspNetCore.OData.Results.ODataErrorResult : Microsoft.Asp
 
 [
 DataContractAttribute(),
+JsonConverterAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Results.PageResult`1 : Microsoft.AspNetCore.OData.Results.PageResult, IEnumerable`1, IEnumerable {
 	public PageResult`1 (IEnumerable`1 items, System.Uri nextPageLink, System.Nullable`1[[System.Int64]] count)
@@ -1737,6 +1782,9 @@ public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 
+[
+JsonConverterAttribute(),
+]
 public sealed class Microsoft.AspNetCore.OData.Results.SingleResult`1 : Microsoft.AspNetCore.OData.Results.SingleResult {
 	public SingleResult`1 (IQueryable`1 queryable)
 
@@ -3114,6 +3162,15 @@ public abstract class Microsoft.AspNetCore.OData.Query.Wrapper.DynamicTypeWrappe
 	System.Collections.Generic.Dictionary`2[[System.String],[System.Object]] Values  { public abstract get; }
 
 	public virtual bool TryGetPropertyValue (string propertyName, out System.Object& value)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter : System.Text.Json.Serialization.JsonConverterFactory {
+	public static readonly System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]] MapperProvider = System.Func`3[Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]
+
+	public SelectExpandWrapperConverter ()
+
+	public virtual bool CanConvert (System.Type typeToConvert)
+	public virtual System.Text.Json.Serialization.JsonConverter CreateConverter (System.Type type, System.Text.Json.JsonSerializerOptions options)
 }
 
 [


### PR DESCRIPTION
Fixes #578

Minimal APIs are a simplified approach for building fast HTTP APIs with ASP.NET Core. You can build fully functioning REST endpoints with minimal code and configuration. Skip traditional scaffolding and avoid unnecessary controllers by fluently declaring API routes and actions. For example, the following code creates an API at the root of the web app that returns the text, "Hello World!".

```C#
var app = WebApplication.Create(args);
app.MapGet("/", () => "Hello World!");
app.Run();
```

Customer want to get the OData query options functionalities.  We can provide couple solutions

1) Provide a HttpRequest-less ODataQueryOptions< T > (Without using IEdmModel, using CLR type directly) and customer can use it in the `Delegate` to generate the Linq Expression and apply to the data. 

2) Use the existing ODataQueryOptions< T >. It convers two scenarios: 1) EdmModel based  2) Non-EdmModel (but will create EdmModel on the fly)

This PR is to support the second. 

```C#
app.MapGet("/schools", (AppDb db, ODataQueryOptions<School> options) => {
     ....
    return options.ApplyTo(db.Schools);
});
```

Then, client can send request the "/schools" using OData query options, for example, `$select`, etc.
