### PR TITLE
Fixes #1126: enable built-in expression in $orderby

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1102,6 +1102,20 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -4763,7 +4777,7 @@
             <summary>
             Checks whether a navigation link should be written or not. 
             </summary>
-            <param name="navigationLink">The navigation link to be written</param>
+            <param name="navigationLink">The navigation link to be written.</param>
             <param name="resourceContext">The resource context for the resource whose navigation link is being written.</param>
             <returns>true if navigation link should be written; otherwise false.</returns>
         </member>
@@ -7359,6 +7373,11 @@
               Looks up a localized string similar to Action import and function import &apos;{0}&apos; MUST be unique within an entity container..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.OrderByClauseInvalid">
+            <summary>
+              Looks up a localized string similar to OrderBy clause kind &apos;{0}&apos; is not valid. Only kind &apos;{1}&apos; is accepted..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.OrderByClauseNotSupported">
             <summary>
               Looks up a localized string similar to Only ordering by properties is supported for non-primitive collections. Expressions are not supported..
@@ -9938,6 +9957,24 @@
             Copy the $filter configuration of properties.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.OrderByClauseNode">
+            <summary>
+            Represents the order by expression in the $orderby clause.
+            Use this to represent other $orderby except 'Property,OpenProperty,$count, $it' orderBy expression.
+            Again, in the next major release, we don't need this class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.OrderByClauseNode.#ctor(Microsoft.OData.UriParser.OrderByClause)">
+            <summary>
+            Instantiates a new instance of <see cref="T:Microsoft.AspNetCore.OData.Query.OrderByClauseNode"/> class.
+            </summary>
+            <param name="orderByClause">The order by clause.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.OrderByClauseNode.OrderByClause">
+            <summary>
+            Gets the <see cref="P:Microsoft.AspNetCore.OData.Query.OrderByClauseNode.OrderByClause"/> of this node.
+            </summary>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.OrderByCountNode">
             <summary>
             Represents an order by <see cref="T:Microsoft.OData.Edm.IEdmProperty"/> expression.
@@ -9965,9 +10002,21 @@
             </summary>
             <param name="direction">The <see cref="T:Microsoft.OData.UriParser.OrderByDirection"/> for this node.</param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.OrderByItNode.#ctor(Microsoft.OData.UriParser.OrderByClause)">
+            <summary>
+            Instantiates a new instance of <see cref="T:Microsoft.AspNetCore.OData.Query.OrderByItNode"/> class.
+            </summary>
+            <param name="clause">The orderby clause.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.OrderByItNode.Name">
+            <summary>
+            Gets the range variable name
+            </summary>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.OrderByNode">
             <summary>
             Represents a single order by expression in the $orderby clause.
+            saxu: Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.OrderByNode.#ctor(Microsoft.OData.UriParser.OrderByDirection)">
@@ -12256,6 +12305,185 @@
             <param name="orderByOption">The $orderby query.</param>
             <param name="validationSettings">The validation settings.</param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateOrderBy(Microsoft.OData.UriParser.OrderByClause,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Validates a <see cref="T:Microsoft.OData.UriParser.OrderByClause" />.
+            </summary>
+            <param name="orderByClause">The <see cref="T:Microsoft.OData.UriParser.OrderByClause" />.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateQueryNode(Microsoft.OData.UriParser.QueryNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)" -->
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueNode(Microsoft.OData.UriParser.SingleValueNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext,System.Boolean)">
+            <summary>
+            The recursive method that validate most of the SingleValueNode type.
+            </summary>
+            <param name="node">The single value node.</param>
+            <param name="validatorContext">The validator context.</param>
+            <param name="skipRangeVariable">The boolean value indicating skip the range variable validation. Typically, if it's 'Source' of a query node, we should skip it.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueOpenPropertyNode(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the dynamic property inside the $orderby query.
+            </summary>
+            <param name="openPropertyNode">The in operator node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateInNode(Microsoft.OData.UriParser.InNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the 'in' operator in the $orderby query.
+            </summary>
+            <param name="inNode">The in operator node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateConstantNode(Microsoft.OData.UriParser.ConstantNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the 'constant' inside the $orderby query.
+            </summary>
+            <param name="constantNode">The constant node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateConvertNode(Microsoft.OData.UriParser.ConvertNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the 'cast' inside the $orderby query.
+            </summary>
+            <param name="convertNode">The convert node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCountNode(Microsoft.OData.UriParser.CountNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the '$count' inside the $orderBy query.
+            </summary>
+            <param name="countNode">The count node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateBinaryOperatorNode(Microsoft.OData.UriParser.BinaryOperatorNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            override this method to restrict the binary operators inside the $orderby query.
+            That includes all the logical operators except 'not' and all math operators.
+            </summary>
+            <param name="binaryOperatorNode">The binary operator node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateRangeVariable(Microsoft.OData.UriParser.RangeVariable,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate the parameter used in the $orderby query.
+            </summary>
+            <param name="rangeVariable">The range variable node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValuePropertyAccessNode(Microsoft.OData.UriParser.SingleValuePropertyAccessNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate property accessors.
+            </summary>
+            <param name="propertyAccessNode">The single value property access node.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueFunctionCallNode(Microsoft.OData.UriParser.SingleValueFunctionCallNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate Function calls, such as 'length', 'year', etc.
+            </summary>
+            <param name="node">The single value function call node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleComplexNode(Microsoft.OData.UriParser.SingleComplexNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate single complex property accessors.
+            </summary>
+            <param name="singleComplexNode">The single complex node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleResourceFunctionCallNode(Microsoft.OData.UriParser.SingleResourceFunctionCallNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate single resource function calls.
+            </summary>
+            <param name="node">The node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleResourceCastNode(Microsoft.OData.UriParser.SingleResourceCastNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method if you want to validate casts on single resource.
+            </summary>
+            <param name="singleResourceCastNode">The single resource cast node.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)" -->
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateNavigationPropertyNode(Microsoft.OData.UriParser.CollectionNavigationNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method for the collection value navigation property node.
+            </summary>
+            <param name="collectionNavigation">The source node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateNavigationPropertyNode(Microsoft.OData.UriParser.SingleNavigationNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method for the single value navigation property node.
+            </summary>
+            <param name="singleNavigation">The source node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateAllNode(Microsoft.OData.UriParser.AllNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the 'all' query inside the $orderby query.
+            </summary>
+            <param name="allNode">The all node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateAnyNode(Microsoft.OData.UriParser.AnyNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to restrict the 'any' query inside the $orderby query.
+            </summary>
+            <param name="anyNode">The any node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionNode(Microsoft.OData.UriParser.CollectionNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            The recursive method that validate most of the query node type is of CollectionNode type.
+            </summary>
+            <param name="node">The single value node.</param>
+            <param name="validatorContext">The validator context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionResourceCastNode(Microsoft.OData.UriParser.CollectionResourceCastNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method if you want to validate on resource collections cast node.
+            </summary>
+            <param name="collectionResourceCastNode">The collection resource cast node.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionPropertyAccessNode(Microsoft.OData.UriParser.CollectionPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate collection property accessors.
+            </summary>
+            <param name="propertyAccessNode">The collection property access node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionComplexNode(Microsoft.OData.UriParser.CollectionComplexNode,Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext)">
+            <summary>
+            Override this method to validate collection complex property accessors.
+            </summary>
+            <param name="collectionComplexNode">The collection complex node to validate.</param>
+            <param name="validatorContext">The validation context.</param>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext">
+            <summary>
+            The metadata context for $orderby validator.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderBy">
+            <summary>
+            The top level $orderby query option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderByNodeCount">
+            <summary>
+            Gets current orderby node count.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.IncrementNodeCount">
+            <summary>
+            Increment orderby node count.
+            </summary>
+            <exception cref="T:Microsoft.OData.ODataException">Throw OData exception.</exception>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext">
             <summary>
             The base for validator context.
@@ -12278,7 +12506,7 @@
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext.StructuredType">
             <summary>
-            The applied strutured type.
+            The applied structured type.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext.CurrentDepth">
@@ -12290,6 +12518,18 @@
             <summary>
             Gets the Edm model.
             </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorHelpers">
+            <summary>
+            Helper methods for validation.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorHelpers.ValidateFunction(Microsoft.OData.UriParser.SingleValueFunctionCallNode,Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings)">
+            <summary>
+            Validates a single value function call.
+            </summary>
+            <param name="functionCallNode">The function name.</param>
+            <param name="settings">The validation settings.</param>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator">
             <summary>
@@ -15224,22 +15464,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -9961,8 +9961,11 @@
             <summary>
             Represents the order by expression in the $orderby clause.
             Use this to represent other $orderby except 'Property,OpenProperty,$count, $it' orderBy expression.
-            Again, in the next major release, we don't need this class.
             </summary>
+            <remarks>
+            Again, in the next major release, we don't need this class.
+            Track on it at: https://github.com/OData/AspNetCoreOData/issues/1153
+            </remarks>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.OrderByClauseNode.#ctor(Microsoft.OData.UriParser.OrderByClause)">
             <summary>
@@ -10016,8 +10019,11 @@
         <member name="T:Microsoft.AspNetCore.OData.Query.OrderByNode">
             <summary>
             Represents a single order by expression in the $orderby clause.
-            saxu: Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
             </summary>
+            <remarks>
+            Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
+            Track on it at: https://github.com/OData/AspNetCoreOData/issues/1153
+            </remarks>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.OrderByNode.#ctor(Microsoft.OData.UriParser.OrderByDirection)">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -1321,6 +1321,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to OrderBy clause kind &apos;{0}&apos; is not valid. Only kind &apos;{1}&apos; is accepted..
+        /// </summary>
+        internal static string OrderByClauseInvalid {
+            get {
+                return ResourceManager.GetString("OrderByClauseInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Only ordering by properties is supported for non-primitive collections. Expressions are not supported..
         /// </summary>
         internal static string OrderByClauseNotSupported {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -453,6 +453,9 @@
   <data name="NotAllowedFunction" xml:space="preserve">
     <value>Function '{0}' is not allowed. To allow it, set the '{1}' property on EnableQueryAttribute or QueryValidationSettings.</value>
   </data>
+  <data name="OrderByClauseInvalid" xml:space="preserve">
+    <value>OrderBy clause kind '{0}' is not valid. Only kind '{1}' is accepted.</value>
+  </data>
   <data name="OrderByClauseNotSupported" xml:space="preserve">
     <value>Only ordering by properties is supported for non-primitive collections. Expressions are not supported.</value>
   </data>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1027,10 +1027,15 @@ Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions.Select.get -> string
 Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions.Skip.get -> string
 Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions.SkipToken.get -> string
 Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions.Top.get -> string
+Microsoft.AspNetCore.OData.Query.OrderByClauseNode
+Microsoft.AspNetCore.OData.Query.OrderByClauseNode.OrderByClause.get -> Microsoft.OData.UriParser.OrderByClause
+Microsoft.AspNetCore.OData.Query.OrderByClauseNode.OrderByClauseNode(Microsoft.OData.UriParser.OrderByClause orderByClause) -> void
 Microsoft.AspNetCore.OData.Query.OrderByCountNode
 Microsoft.AspNetCore.OData.Query.OrderByCountNode.OrderByClause.get -> Microsoft.OData.UriParser.OrderByClause
 Microsoft.AspNetCore.OData.Query.OrderByCountNode.OrderByCountNode(Microsoft.OData.UriParser.OrderByClause orderByClause) -> void
 Microsoft.AspNetCore.OData.Query.OrderByItNode
+Microsoft.AspNetCore.OData.Query.OrderByItNode.Name.get -> string
+Microsoft.AspNetCore.OData.Query.OrderByItNode.OrderByItNode(Microsoft.OData.UriParser.OrderByClause clause) -> void
 Microsoft.AspNetCore.OData.Query.OrderByItNode.OrderByItNode(Microsoft.OData.UriParser.OrderByDirection direction) -> void
 Microsoft.AspNetCore.OData.Query.OrderByNode
 Microsoft.AspNetCore.OData.Query.OrderByNode.Direction.get -> Microsoft.OData.UriParser.OrderByDirection
@@ -1178,6 +1183,12 @@ Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.MaxTop.set ->
 Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.ODataValidationSettings() -> void
 Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator
 Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.OrderByQueryValidator() -> void
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.IncrementNodeCount() -> void
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderBy.get -> Microsoft.AspNetCore.OData.Query.OrderByQueryOption
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderBy.set -> void
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderByNodeCount.get -> int
+Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext.OrderByValidatorContext() -> void
 Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext
 Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext.Context.get -> Microsoft.AspNetCore.OData.Query.ODataQueryContext
 Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext.Context.set -> void
@@ -1960,6 +1971,30 @@ virtual Microsoft.AspNetCore.OData.Query.Validator.FilterQueryValidator.Validate
 virtual Microsoft.AspNetCore.OData.Query.Validator.FilterQueryValidator.ValidateUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext validatorContext) -> void
 virtual Microsoft.AspNetCore.OData.Query.Validator.ODataQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.ODataQueryOptions options, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
 virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.OrderByQueryOption orderByOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateAllNode(Microsoft.OData.UriParser.AllNode allNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateAnyNode(Microsoft.OData.UriParser.AnyNode anyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateBinaryOperatorNode(Microsoft.OData.UriParser.BinaryOperatorNode binaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionComplexNode(Microsoft.OData.UriParser.CollectionComplexNode collectionComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionNode(Microsoft.OData.UriParser.CollectionNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionPropertyAccessNode(Microsoft.OData.UriParser.CollectionPropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCollectionResourceCastNode(Microsoft.OData.UriParser.CollectionResourceCastNode collectionResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateConstantNode(Microsoft.OData.UriParser.ConstantNode constantNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateConvertNode(Microsoft.OData.UriParser.ConvertNode convertNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateCountNode(Microsoft.OData.UriParser.CountNode countNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateInNode(Microsoft.OData.UriParser.InNode inNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateNavigationPropertyNode(Microsoft.OData.UriParser.CollectionNavigationNode collectionNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateNavigationPropertyNode(Microsoft.OData.UriParser.SingleNavigationNode singleNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateOrderBy(Microsoft.OData.UriParser.OrderByClause orderByClause, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateQueryNode(Microsoft.OData.UriParser.QueryNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateRangeVariable(Microsoft.OData.UriParser.RangeVariable rangeVariable, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleComplexNode(Microsoft.OData.UriParser.SingleComplexNode singleComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleResourceCastNode(Microsoft.OData.UriParser.SingleResourceCastNode singleResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleResourceFunctionCallNode(Microsoft.OData.UriParser.SingleResourceFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueFunctionCallNode(Microsoft.OData.UriParser.SingleValueFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueNode(Microsoft.OData.UriParser.SingleValueNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext, bool skipRangeVariable) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValueOpenPropertyNode(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openPropertyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateSingleValuePropertyAccessNode(Microsoft.OData.UriParser.SingleValuePropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator.ValidateUnaryOperatorNode(Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext) -> void
 virtual Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.SelectExpandQueryOption selectExpandQueryOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
 virtual Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator.ValidateExpandedCountSelectItem(Microsoft.OData.UriParser.ExpandedCountSelectItem expandCountItem, Microsoft.AspNetCore.OData.Query.Validator.SelectExpandValidatorContext validatorContext) -> void
 virtual Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator.ValidateExpandedNavigationSelectItem(Microsoft.OData.UriParser.ExpandedNavigationSelectItem expandItem, Microsoft.AspNetCore.OData.Query.Validator.SelectExpandValidatorContext validatorContext) -> void

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByClauseNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByClauseNode.cs
@@ -1,33 +1,29 @@
 //-----------------------------------------------------------------------------
-// <copyright file="OrderByCountNode.cs" company=".NET Foundation">
+// <copyright file="OrderByClauseNode.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //------------------------------------------------------------------------------
 
-using Microsoft.OData;
-using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Query
 {
     /// <summary>
-    /// Represents an order by <see cref="IEdmProperty"/> expression.
+    /// Represents the order by expression in the $orderby clause.
+    /// Use this to represent other $orderby except 'Property,OpenProperty,$count, $it' orderBy expression.
+    /// Again, in the next major release, we don't need this class.
     /// </summary>
-    public class OrderByCountNode : OrderByNode
+    public class OrderByClauseNode : OrderByNode
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OrderByCountNode"/> class.
+        /// Instantiates a new instance of <see cref="OrderByClauseNode"/> class.
         /// </summary>
-        /// <param name="orderByClause">The orderby clause representing property access.</param>
-        public OrderByCountNode(OrderByClause orderByClause)
+        /// <param name="orderByClause">The order by clause.</param>
+        public OrderByClauseNode(OrderByClause orderByClause)
             : base(orderByClause)
         {
             OrderByClause = orderByClause;
-            if (!(orderByClause.Expression is CountNode))
-            {
-                throw new ODataException(string.Format(SRResources.OrderByClauseInvalid, orderByClause.Expression.Kind, QueryNodeKind.Count));
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByClauseNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByClauseNode.cs
@@ -12,8 +12,11 @@ namespace Microsoft.AspNetCore.OData.Query
     /// <summary>
     /// Represents the order by expression in the $orderby clause.
     /// Use this to represent other $orderby except 'Property,OpenProperty,$count, $it' orderBy expression.
-    /// Again, in the next major release, we don't need this class.
     /// </summary>
+    /// <remarks>
+    /// Again, in the next major release, we don't need this class.
+    /// Track on it at: https://github.com/OData/AspNetCoreOData/issues/1153
+    /// </remarks>
     public class OrderByClauseNode : OrderByNode
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByItNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByItNode.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using Microsoft.OData;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Query
@@ -21,6 +22,39 @@ namespace Microsoft.AspNetCore.OData.Query
         public OrderByItNode(OrderByDirection direction)
             : base(direction)
         {
+            Name = "$it";
         }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="OrderByItNode"/> class.
+        /// </summary>
+        /// <param name="clause">The orderby clause.</param>
+        public OrderByItNode(OrderByClause clause)
+            : base(clause)
+        {
+            if (clause == null)
+            {
+                throw Error.ArgumentNull(nameof(clause));
+            }
+
+            if (clause.Expression is NonResourceRangeVariableReferenceNode nonResourceVarNode)
+            {
+                Name = nonResourceVarNode.Name;
+            }
+            else if (clause.Expression is ResourceRangeVariableReferenceNode resourceVarNode)
+            {
+                Name = resourceVarNode.Name;
+            }
+            else
+            {
+                throw new ODataException(string.Format(SRResources.OrderByClauseInvalid, clause.Expression.Kind,
+                    "NonResourceRangeVariableReferenceNode or ResourceRangeVariableReferenceNode"));
+            }
+        }
+
+        /// <summary>
+        /// Gets the range variable name
+        /// </summary>
+        public string Name { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByNode.cs
@@ -14,8 +14,11 @@ namespace Microsoft.AspNetCore.OData.Query
 {
     /// <summary>
     /// Represents a single order by expression in the $orderby clause.
-    /// saxu: Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
     /// </summary>
+    /// <remarks>
+    /// Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
+    /// Track on it at: https://github.com/OData/AspNetCoreOData/issues/1153
+    /// </remarks>
     public abstract class OrderByNode
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByNode.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.OData.Query
 {
     /// <summary>
     /// Represents a single order by expression in the $orderby clause.
+    /// saxu: Why do we need this class and its derived type? only fetch the PropertyPath? In the next major release, we can consider to remove all of these.
     /// </summary>
     public abstract class OrderByNode
     {
@@ -42,10 +43,6 @@ namespace Microsoft.AspNetCore.OData.Query
             PropertyPath = RestorePropertyPath(orderByClause.Expression);
         }
 
-        internal OrderByNode()
-        {
-        }
-
         /// <summary>
         /// Gets the <see cref="OrderByDirection"/> for the current node.
         /// </summary>
@@ -66,23 +63,24 @@ namespace Microsoft.AspNetCore.OData.Query
                 if (clause.Expression is CountNode)
                 {
                     result.Add(new OrderByCountNode(clause));
-                    continue;
                 }
-
-                if (clause.Expression is NonResourceRangeVariableReferenceNode ||
+                else if (clause.Expression is NonResourceRangeVariableReferenceNode ||
                     clause.Expression is ResourceRangeVariableReferenceNode)
                 {
-                    result.Add(new OrderByItNode(clause.Direction));
-                    continue;
+                    result.Add(new OrderByItNode(clause));
                 }
-
-                if (clause.Expression is SingleValueOpenPropertyAccessNode)
+                else if (clause.Expression is SingleValueOpenPropertyAccessNode)
                 {
                     result.Add(new OrderByOpenPropertyNode(clause));
                 }
-                else
+                else if(clause.Expression is SingleValuePropertyAccessNode)
                 {
                     result.Add(new OrderByPropertyNode(clause));
+                }
+                else
+                {
+                    // For other, let's create a wrapper. In next major release, we don't need this wrapper.
+                    result.Add(new OrderByClauseNode(clause));
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByOpenPropertyNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByOpenPropertyNode.cs
@@ -27,8 +27,7 @@ namespace Microsoft.AspNetCore.OData.Query
             var openPropertyExpression = orderByClause.Expression as SingleValueOpenPropertyAccessNode;
             if (openPropertyExpression == null)
             {
-                // TODO: need refactor the error message
-                throw new ODataException(SRResources.OrderByClauseNotSupported);
+                throw new ODataException(string.Format(SRResources.OrderByClauseInvalid, orderByClause.Expression.Kind, QueryNodeKind.SingleValueOpenPropertyAccess));
             }
 
             PropertyName = openPropertyExpression.Name;

--- a/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByPropertyNode.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Nodes/OrderByPropertyNode.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.OData.Query
             SingleValuePropertyAccessNode propertyExpression = orderByClause.Expression as SingleValuePropertyAccessNode;
             if (propertyExpression == null)
             {
-                throw new ODataException(SRResources.OrderByClauseNotSupported);
+                throw new ODataException(string.Format(SRResources.OrderByClauseInvalid, orderByClause.Expression.Kind, QueryNodeKind.SingleValuePropertyAccess));
             }
             else
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
@@ -259,11 +259,7 @@ namespace Microsoft.AspNetCore.OData.Query
 
             foreach (OrderByNode node in nodes)
             {
-                OrderByPropertyNode propertyNode = node as OrderByPropertyNode;
-                OrderByOpenPropertyNode openPropertyNode = node as OrderByOpenPropertyNode;
-                OrderByCountNode countNode = node as OrderByCountNode;
-
-                if (propertyNode != null)
+                if (node is OrderByPropertyNode propertyNode)
                 {
                     // Use autonomy class to achieve value equality for HasSet.
                     var edmPropertyWithPath = new { propertyNode.Property, propertyNode.PropertyPath };
@@ -289,7 +285,7 @@ namespace Microsoft.AspNetCore.OData.Query
 
                     alreadyOrdered = true;
                 }
-                else if (openPropertyNode != null)
+                else if (node is OrderByOpenPropertyNode openPropertyNode)
                 {
                     // This check prevents queries with duplicate properties (e.g. $orderby=Id,Id,Id,Id...) from causing stack overflows
                     if (openPropertiesSoFar.Contains(openPropertyNode.PropertyName))
@@ -302,10 +298,15 @@ namespace Microsoft.AspNetCore.OData.Query
                     querySoFar = AddOrderByQueryForProperty(binder, openPropertyNode.OrderByClause, querySoFar, binderContext, alreadyOrdered);
                     alreadyOrdered = true;
                 }
-                else if (countNode != null)
+                else if (node is OrderByCountNode countNode)
                 {
                     Contract.Assert(countNode.OrderByClause != null);
                     querySoFar = AddOrderByQueryForProperty(binder, countNode.OrderByClause, querySoFar, binderContext, alreadyOrdered);
+                    alreadyOrdered = true;
+                }
+                else if (node is OrderByClauseNode clauseNode)
+                {
+                    querySoFar = AddOrderByQueryForProperty(binder, clauseNode.OrderByClause, querySoFar, binderContext, alreadyOrdered);
                     alreadyOrdered = true;
                 }
                 else

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByModelLimitationsValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByModelLimitationsValidator.cs
@@ -135,6 +135,21 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
             return null;
         }
 
+        public override SingleValueNode Visit(SingleValueFunctionCallNode nodeIn)
+        {
+            foreach (var parameter in nodeIn.Parameters)
+            {
+                parameter.Accept(this);
+            }
+
+            if (nodeIn.Source != null)
+            {
+                return nodeIn.Source.Accept(this);
+            }
+
+            return null;
+        }
+
         private static string GetPropertyName(SingleValueNode node)
         {
             if (node.Kind == QueryNodeKind.SingleNavigationNode)

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
         }
 
         /// <summary>
-        /// override this method to restrict the binary operators inside the $orderby query.
+        /// Override this method to restrict the binary operators inside the $orderby query.
         /// That includes all the logical operators except 'not' and all math operators.
         /// </summary>
         /// <param name="binaryOperatorNode">The binary operator node to validate.</param>

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
         /// <summary>
         /// The recursive method that validate most of the query node type is of CollectionNode type.
         /// </summary>
-        /// <param name="node">The single value node.</param>
+        /// <param name="node">The collection value node.</param>
         /// <param name="validatorContext">The validator context.</param>
         protected virtual void ValidateCollectionNode(CollectionNode node, OrderByValidatorContext validatorContext)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByQueryValidator.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.OData;
+using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.Query.Validator
@@ -32,59 +34,607 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 throw Error.ArgumentNull("validationSettings");
             }
 
-            int nodeCount = 0;
-            for (OrderByClause clause = orderByOption.OrderByClause; clause != null; clause = clause.ThenBy)
+            OrderByValidatorContext validatorContext = new OrderByValidatorContext
             {
-                nodeCount++;
-                if (nodeCount > validationSettings.MaxOrderByNodeCount)
-                {
-                    throw new ODataException(Error.Format(SRResources.OrderByNodeCountExceeded,
-                        validationSettings.MaxOrderByNodeCount));
-                }
+                OrderBy = orderByOption,
+                Context = orderByOption.Context,
+                ValidationSettings = validationSettings,
+                Property = orderByOption.Context.TargetProperty,
+                StructuredType = orderByOption.Context.TargetStructuredType,
+                CurrentDepth = 0
+            };
+
+            OrderByClause clause = orderByOption.OrderByClause;
+            while (clause != null)
+            {
+                validatorContext.IncrementNodeCount();
+
+                ValidateOrderBy(clause, validatorContext);
+
+                clause = clause.ThenBy;
+            }
+        }
+
+        /// <summary>
+        /// Validates a <see cref="OrderByClause" />.
+        /// </summary>
+        /// <param name="orderByClause">The <see cref="OrderByClause" />.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateOrderBy(OrderByClause orderByClause, OrderByValidatorContext validatorContext)
+        {
+            if (orderByClause != null)
+            {
+                ValidateSingleValueNode(orderByClause.Expression, validatorContext, skipRangeVariable: false);
+            }
+        }
+
+        /// <summary>
+        /// Override this method if you want to visit each query node.
+        /// </summary>
+        /// <remarks>
+        /// <param name="node">The query node.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateQueryNode(QueryNode node, OrderByValidatorContext validatorContext)
+        {
+            if (node is SingleValueNode singleNode)
+            {
+                ValidateSingleValueNode(singleNode, validatorContext, skipRangeVariable: true);
+            }
+            else if (node is CollectionNode collectionNode)
+            {
+                ValidateCollectionNode(collectionNode, validatorContext);
+            }
+        }
+
+        /// <summary>
+        /// The recursive method that validate most of the SingleValueNode type.
+        /// </summary>
+        /// <param name="node">The single value node.</param>
+        /// <param name="validatorContext">The validator context.</param>
+        /// <param name="skipRangeVariable">The boolean value indicating skip the range variable validation. Typically, if it's 'Source' of a query node, we should skip it.</param>
+        protected virtual void ValidateSingleValueNode(SingleValueNode node, OrderByValidatorContext validatorContext, bool skipRangeVariable)
+        {
+            if (node == null)
+            {
+                return;
             }
 
-            bool enableOrderBy = orderByOption.Context.DefaultQueryConfigurations.EnableOrderBy;
-            OrderByModelLimitationsValidator validator = new OrderByModelLimitationsValidator(orderByOption.Context, enableOrderBy);
-            bool explicitAllowedProperties = validationSettings.AllowedOrderByProperties.Count > 0;
-
-            foreach (OrderByNode node in orderByOption.OrderByNodes)
+            switch (node.Kind)
             {
-                string propertyName = null;
-                OrderByPropertyNode propertyNode = node as OrderByPropertyNode;
-                if (propertyNode != null)
-                {
-                    propertyName = propertyNode.Property.Name;
-                    bool isValidPath = !validator.TryValidate(propertyNode.OrderByClause, explicitAllowedProperties);
-                    if (propertyName != null && isValidPath && explicitAllowedProperties)
+                case QueryNodeKind.BinaryOperator:
+                    ValidateBinaryOperatorNode(node as BinaryOperatorNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.Constant:
+                    ValidateConstantNode(node as ConstantNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.Convert:
+                    ValidateConvertNode(node as ConvertNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.Count:
+                    ValidateCountNode(node as CountNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.ResourceRangeVariableReference:
+                    if (!skipRangeVariable)
                     {
-                        // Explicit allowed properties were specified, but this one isn't within the list of allowed 
-                        // properties.
-                        if (!IsAllowed(validationSettings, propertyName))
-                        {
-                            throw new ODataException(Error.Format(SRResources.NotAllowedOrderByProperty, propertyName,
-                                "AllowedOrderByProperties"));
-                        }
+                        ValidateRangeVariable((node as ResourceRangeVariableReferenceNode).RangeVariable, validatorContext);
                     }
-                    else if (propertyName != null)
+                    break;
+
+                case QueryNodeKind.NonResourceRangeVariableReference:
+                    if (!skipRangeVariable)
                     {
-                        // The property wasn't limited but it wasn't contained in the set of explicitly allowed 
-                        // properties.
-                        if (!IsAllowed(validationSettings, propertyName))
-                        {
-                            throw new ODataException(Error.Format(SRResources.NotAllowedOrderByProperty, propertyName,
-                                "AllowedOrderByProperties"));
-                        }
+                        ValidateRangeVariable((node as NonResourceRangeVariableReferenceNode).RangeVariable, validatorContext);
+                    }
+                    break;
+
+                case QueryNodeKind.SingleValuePropertyAccess:
+                    ValidateSingleValuePropertyAccessNode(node as SingleValuePropertyAccessNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleComplexNode:
+                    ValidateSingleComplexNode(node as SingleComplexNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.UnaryOperator:
+                    ValidateUnaryOperatorNode(node as UnaryOperatorNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleValueFunctionCall:
+                    ValidateSingleValueFunctionCallNode(node as SingleValueFunctionCallNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleResourceFunctionCall:
+                    ValidateSingleResourceFunctionCallNode((SingleResourceFunctionCallNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleNavigationNode:
+                    ValidateNavigationPropertyNode((SingleNavigationNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleResourceCast:
+                    ValidateSingleResourceCastNode(node as SingleResourceCastNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.Any:
+                    ValidateAnyNode(node as AnyNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.All:
+                    ValidateAllNode(node as AllNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.In:
+                    ValidateInNode(node as InNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.SingleValueOpenPropertyAccess:
+                    ValidateSingleValueOpenPropertyNode(node as SingleValueOpenPropertyAccessNode, validatorContext);
+                    break;
+
+                case QueryNodeKind.NamedFunctionParameter:
+                case QueryNodeKind.ParameterAlias:
+                case QueryNodeKind.EntitySet:
+                case QueryNodeKind.KeyLookup:
+                case QueryNodeKind.SearchTerm:
+                default:
+                    // No default validation logic for others.
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Override this method to restrict the dynamic property inside the $orderby query.
+        /// </summary>
+        /// <param name="openPropertyNode">The in operator node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleValueOpenPropertyNode(SingleValueOpenPropertyAccessNode openPropertyNode, OrderByValidatorContext validatorContext)
+        {
+            // No default validation logic here.
+        }
+
+        /// <summary>
+        /// Override this method to restrict the 'in' operator in the $orderby query.
+        /// </summary>
+        /// <param name="inNode">The in operator node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateInNode(InNode inNode, OrderByValidatorContext validatorContext)
+        {
+            ValidateQueryNode(inNode?.Left, validatorContext);
+            ValidateQueryNode(inNode?.Right, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to restrict the 'constant' inside the $orderby query.
+        /// </summary>
+        /// <param name="constantNode">The constant node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateConstantNode(ConstantNode constantNode, OrderByValidatorContext validatorContext)
+        {
+            // No default validation logic here.
+        }
+
+        /// <summary>
+        /// Override this method to restrict the 'cast' inside the $orderby query.
+        /// </summary>
+        /// <param name="convertNode">The convert node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateConvertNode(ConvertNode convertNode, OrderByValidatorContext validatorContext)
+        {
+            // Validate child nodes but not the ConvertNode itself.
+            ValidateQueryNode(convertNode?.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to restrict the '$count' inside the $orderBy query.
+        /// </summary>
+        /// <param name="countNode">The count node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateCountNode(CountNode countNode, OrderByValidatorContext validatorContext)
+        {
+            ValidateQueryNode(countNode?.Source, validatorContext);
+
+            if (countNode?.FilterClause != null)
+            {
+                ValidateQueryNode(countNode.FilterClause.Expression, validatorContext);
+            }
+
+            if (countNode?.SearchClause != null)
+            {
+                ValidateQueryNode(countNode.SearchClause.Expression, validatorContext);
+            }
+        }
+
+        /// <summary>
+        /// override this method to restrict the binary operators inside the $orderby query.
+        /// That includes all the logical operators except 'not' and all math operators.
+        /// </summary>
+        /// <param name="binaryOperatorNode">The binary operator node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateBinaryOperatorNode(BinaryOperatorNode binaryOperatorNode, OrderByValidatorContext validatorContext)
+        {
+            // recursion case goes here
+            ValidateQueryNode(binaryOperatorNode?.Left, validatorContext);
+            ValidateQueryNode(binaryOperatorNode?.Right, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate the parameter used in the $orderby query.
+        /// </summary>
+        /// <param name="rangeVariable">The range variable node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateRangeVariable(RangeVariable rangeVariable, OrderByValidatorContext validatorContext)
+        {
+            if (rangeVariable != null)
+            {
+                string variableName = rangeVariable.Name;
+                if (!IsAllowed(validatorContext.ValidationSettings, variableName))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotAllowedOrderByProperty, variableName, "AllowedOrderByProperties"));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Override this method to validate property accessors.
+        /// </summary>
+        /// <param name="propertyAccessNode">The single value property access node.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleValuePropertyAccessNode(SingleValuePropertyAccessNode propertyAccessNode, OrderByValidatorContext validatorContext)
+        {
+            if (propertyAccessNode == null || validatorContext == null)
+            {
+                return;
+            }
+
+            IEdmModel model = validatorContext.Model;
+            bool enableOrderBy = validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy;
+            IEdmProperty property = propertyAccessNode.Property;
+
+            // Check whether the property is sortable.
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                bool notSortable = false;
+                if (propertyAccessNode.Source != null)
+                {
+                    if (propertyAccessNode.Source.Kind == QueryNodeKind.SingleNavigationNode)
+                    {
+                        SingleNavigationNode singleNavigationNode = propertyAccessNode.Source as SingleNavigationNode;
+                        notSortable = EdmHelpers.IsNotSortable(property, singleNavigationNode.NavigationProperty, singleNavigationNode.NavigationProperty.ToEntityType(), model, enableOrderBy);
+                    }
+                    else if (propertyAccessNode.Source.Kind == QueryNodeKind.SingleComplexNode)
+                    {
+                        SingleComplexNode singleComplexNode = propertyAccessNode.Source as SingleComplexNode;
+                        notSortable = EdmHelpers.IsNotSortable(property, singleComplexNode.Property, property.DeclaringType, model, enableOrderBy);
+                    }
+                    else
+                    {
+                        notSortable = EdmHelpers.IsNotSortable(property, validatorContext.Property, validatorContext.StructuredType, model, enableOrderBy);
                     }
                 }
-                else
+
+                if (notSortable)
                 {
-                    propertyName = "$it";
-                    if (!IsAllowed(validationSettings, propertyName))
-                    {
-                        throw new ODataException(Error.Format(SRResources.NotAllowedOrderByProperty, propertyName,
-                            "AllowedOrderByProperties"));
-                    }
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, property.Name));
                 }
+            }
+            else
+            {
+                ValidatePropertyAllowed(property.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(propertyAccessNode.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate Function calls, such as 'length', 'year', etc.
+        /// </summary>
+        /// <param name="node">The single value function call node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleValueFunctionCallNode(SingleValueFunctionCallNode node, OrderByValidatorContext validatorContext)
+        {
+            if (node == null || validatorContext == null)
+            {
+                return;
+            }
+
+            QueryValidatorHelpers.ValidateFunction(node, validatorContext.ValidationSettings);
+
+            foreach (QueryNode argumentNode in node.Parameters)
+            {
+                ValidateQueryNode(argumentNode, validatorContext);
+            }
+        }
+
+        /// <summary>
+        /// Override this method to validate single complex property accessors.
+        /// </summary>
+        /// <param name="singleComplexNode">The single complex node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleComplexNode(SingleComplexNode singleComplexNode, OrderByValidatorContext validatorContext)
+        {
+            if (singleComplexNode == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Check whether the property is sortable.
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                IEdmProperty property = singleComplexNode.Property;
+                if (EdmHelpers.IsNotSortable(property,
+                    validatorContext.Property,
+                    validatorContext.StructuredType,
+                    validatorContext.Model,
+                    validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, property.Name));
+                }
+            }
+            else
+            {
+                ValidatePropertyAllowed(singleComplexNode.Property.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(singleComplexNode.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate single resource function calls.
+        /// </summary>
+        /// <param name="node">The node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleResourceFunctionCallNode(SingleResourceFunctionCallNode node, OrderByValidatorContext validatorContext)
+        {
+            if (node == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Ideally, we should validate the function call name here.
+            // But, there's no validation setting for SingleResourceFunctionCall. So, let's skip the name validation
+            // Customer can override this method to add name validation.
+
+            foreach (QueryNode argumentNode in node.Parameters)
+            {
+                ValidateQueryNode(argumentNode, validatorContext);
+            }
+        }
+
+        /// <summary>
+        /// Override this method if you want to validate casts on single resource.
+        /// </summary>
+        /// <param name="singleResourceCastNode">The single resource cast node.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateSingleResourceCastNode(SingleResourceCastNode singleResourceCastNode, OrderByValidatorContext validatorContext)
+        {
+            ValidateQueryNode(singleResourceCastNode?.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate the Not operator.
+        /// </summary>
+        /// <remarks>
+        /// <param name="unaryOperatorNode">The unary operator node.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateUnaryOperatorNode(UnaryOperatorNode unaryOperatorNode, OrderByValidatorContext validatorContext)
+        {
+            // no default validation here
+        }
+
+        /// <summary>
+        /// Override this method for the collection value navigation property node.
+        /// </summary>
+        /// <param name="collectionNavigation">The source node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateNavigationPropertyNode(CollectionNavigationNode collectionNavigation, OrderByValidatorContext validatorContext)
+        {
+            if (collectionNavigation == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Check whether the property is not sortable
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                if (EdmHelpers.IsNotSortable(collectionNavigation.NavigationProperty,
+                validatorContext.Property,
+                validatorContext.StructuredType,
+                validatorContext.Model,
+                validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, collectionNavigation.NavigationProperty.Name));
+                }
+            }
+            else
+            {
+                ValidatePropertyAllowed(collectionNavigation.NavigationProperty.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(collectionNavigation.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method for the single value navigation property node.
+        /// </summary>
+        /// <param name="singleNavigation">The source node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateNavigationPropertyNode(SingleNavigationNode singleNavigation, OrderByValidatorContext validatorContext)
+        {
+            if (singleNavigation == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Check whether the property is not sortable
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                if (EdmHelpers.IsNotSortable(singleNavigation.NavigationProperty,
+                validatorContext.Property,
+                validatorContext.StructuredType,
+                validatorContext.Model,
+                validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, singleNavigation.NavigationProperty.Name));
+                }
+            }
+            else
+            {
+                ValidatePropertyAllowed(singleNavigation.NavigationProperty.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(singleNavigation.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to restrict the 'all' query inside the $orderby query.
+        /// </summary>
+        /// <param name="allNode">The all node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateAllNode(AllNode allNode, OrderByValidatorContext validatorContext)
+        {
+            // no default validation here
+        }
+
+        /// <summary>
+        /// Override this method to restrict the 'any' query inside the $orderby query.
+        /// </summary>
+        /// <param name="anyNode">The any node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateAnyNode(AnyNode anyNode, OrderByValidatorContext validatorContext)
+        {
+            // no default validation here
+        }
+
+        /// <summary>
+        /// The recursive method that validate most of the query node type is of CollectionNode type.
+        /// </summary>
+        /// <param name="node">The single value node.</param>
+        /// <param name="validatorContext">The validator context.</param>
+        protected virtual void ValidateCollectionNode(CollectionNode node, OrderByValidatorContext validatorContext)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            switch (node.Kind)
+            {
+                case QueryNodeKind.CollectionPropertyAccess:
+                    ValidateCollectionPropertyAccessNode((CollectionPropertyAccessNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.CollectionComplexNode:
+                    ValidateCollectionComplexNode((CollectionComplexNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.CollectionNavigationNode:
+                    ValidateNavigationPropertyNode((CollectionNavigationNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.CollectionResourceCast:
+                    ValidateCollectionResourceCastNode((CollectionResourceCastNode)node, validatorContext);
+                    break;
+
+                case QueryNodeKind.CollectionFunctionCall:
+                case QueryNodeKind.CollectionResourceFunctionCall:
+                case QueryNodeKind.CollectionOpenPropertyAccess:
+                default:
+                    // by default no validation for them.
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Override this method if you want to validate on resource collections cast node.
+        /// </summary>
+        /// <param name="collectionResourceCastNode">The collection resource cast node.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateCollectionResourceCastNode(CollectionResourceCastNode collectionResourceCastNode, OrderByValidatorContext validatorContext)
+        {
+            ValidateQueryNode(collectionResourceCastNode?.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate collection property accessors.
+        /// </summary>
+        /// <param name="propertyAccessNode">The collection property access node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateCollectionPropertyAccessNode(CollectionPropertyAccessNode propertyAccessNode, OrderByValidatorContext validatorContext)
+        {
+            if (propertyAccessNode == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Check whether the property is sortable.
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                IEdmProperty property = propertyAccessNode.Property;
+                if (EdmHelpers.IsNotSortable(property,
+                    validatorContext.Property,
+                    validatorContext.StructuredType,
+                    validatorContext.Model,
+                    validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, property.Name));
+                }
+            }
+            else
+            {
+                ValidatePropertyAllowed(propertyAccessNode.Property.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(propertyAccessNode.Source, validatorContext);
+        }
+
+        /// <summary>
+        /// Override this method to validate collection complex property accessors.
+        /// </summary>
+        /// <param name="collectionComplexNode">The collection complex node to validate.</param>
+        /// <param name="validatorContext">The validation context.</param>
+        protected virtual void ValidateCollectionComplexNode(CollectionComplexNode collectionComplexNode, OrderByValidatorContext validatorContext)
+        {
+            if (collectionComplexNode == null || validatorContext == null)
+            {
+                return;
+            }
+
+            // Check whether the property is sortable.
+            if (validatorContext.ValidationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                IEdmProperty property = collectionComplexNode.Property;
+                if (EdmHelpers.IsNotSortable(property, validatorContext.Property,
+                    validatorContext.StructuredType,
+                    validatorContext.Model,
+                    validatorContext.Context.DefaultQueryConfigurations.EnableOrderBy))
+                {
+                    throw new ODataException(Error.Format(SRResources.NotSortablePropertyUsedInOrderBy, property.Name));
+                }
+            }
+            else
+            {
+                ValidatePropertyAllowed(collectionComplexNode.Property.Name, validatorContext.ValidationSettings);
+            }
+
+            ValidateQueryNode(collectionComplexNode.Source, validatorContext);
+        }
+
+        private static void ValidatePropertyAllowed(string propertyName, ODataValidationSettings validationSettings)
+        {
+            // An empty collection means client can order the queryable result by any properties
+            if (validationSettings.AllowedOrderByProperties.Count == 0)
+            {
+                return;
+            }
+
+            // Then if the property name is not set in the collection, it means client can't order by it.
+            if (!validationSettings.AllowedOrderByProperties.Contains(propertyName))
+            {
+                throw new ODataException(Error.Format(SRResources.NotAllowedOrderByProperty, propertyName, "AllowedOrderByProperties"));
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByValidatorContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/OrderByValidatorContext.cs
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------------
+// <copyright file="OrderByValidatorContext.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData;
+
+namespace Microsoft.AspNetCore.OData.Query.Validator
+{
+    /// <summary>
+    /// The metadata context for $orderby validator.
+    /// </summary>
+    public class OrderByValidatorContext : QueryValidatorContext
+    {
+        private int _orderByNodeCount = 0;
+
+        /// <summary>
+        /// The top level $orderby query option.
+        /// </summary>
+        public OrderByQueryOption OrderBy { get; set; }
+
+        /// <summary>
+        /// Gets current orderby node count.
+        /// </summary>
+        public int OrderByNodeCount => _orderByNodeCount;
+
+        /// <summary>
+        /// Increment orderby node count.
+        /// </summary>
+        /// <exception cref="ODataException">Throw OData exception.</exception>
+        public void IncrementNodeCount()
+        {
+            ++_orderByNodeCount;
+
+            if (_orderByNodeCount > ValidationSettings.MaxOrderByNodeCount)
+            {
+                throw new ODataException(Error.Format(SRResources.OrderByNodeCountExceeded, ValidationSettings.MaxOrderByNodeCount));
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
         public IEdmProperty Property { get; set; }
 
         /// <summary>
-        /// The applied strutured type.
+        /// The applied structured type.
         /// </summary>
         public IEdmStructuredType StructuredType { get; set; }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorHelpers.cs
@@ -1,0 +1,142 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidatorHelpers.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNetCore.OData.Query.Validator
+{
+    /// <summary>
+    /// Helper methods for validation.
+    /// </summary>
+    internal class QueryValidatorHelpers
+    {
+        /// <summary>
+        /// Validates a single value function call.
+        /// </summary>
+        /// <param name="functionCallNode">The function name.</param>
+        /// <param name="settings">The validation settings.</param>
+        public static void ValidateFunction(SingleValueFunctionCallNode functionCallNode, ODataValidationSettings settings)
+        {
+            if (functionCallNode == null)
+            {
+                throw Error.ArgumentNull(nameof(functionCallNode));
+            }
+
+            if (settings == null)
+            {
+                throw Error.ArgumentNull(nameof(settings));
+            }
+
+            string functionName = functionCallNode.Name;
+
+            AllowedFunctions convertedFunction = ToODataFunction(functionName);
+            if (convertedFunction != AllowedFunctions.None &&
+                (settings.AllowedFunctions & convertedFunction) != convertedFunction)
+            {
+                // this means the given function is not allowed
+                throw new ODataException(Error.Format(SRResources.NotAllowedFunction, functionName, "AllowedFunctions"));
+            }
+        }
+
+        private static AllowedFunctions ToODataFunction(string functionName)
+        {
+            AllowedFunctions result = AllowedFunctions.None;
+            switch (functionName)
+            {
+                case "any":
+                    result = AllowedFunctions.Any;
+                    break;
+                case "all":
+                    result = AllowedFunctions.All;
+                    break;
+                case "cast":
+                    result = AllowedFunctions.Cast;
+                    break;
+                case ClrCanonicalFunctions.CeilingFunctionName:
+                    result = AllowedFunctions.Ceiling;
+                    break;
+                case ClrCanonicalFunctions.ConcatFunctionName:
+                    result = AllowedFunctions.Concat;
+                    break;
+                case ClrCanonicalFunctions.ContainsFunctionName:
+                    result = AllowedFunctions.Contains;
+                    break;
+                case ClrCanonicalFunctions.DayFunctionName:
+                    result = AllowedFunctions.Day;
+                    break;
+                case ClrCanonicalFunctions.EndswithFunctionName:
+                    result = AllowedFunctions.EndsWith;
+                    break;
+                case ClrCanonicalFunctions.FloorFunctionName:
+                    result = AllowedFunctions.Floor;
+                    break;
+                case ClrCanonicalFunctions.HourFunctionName:
+                    result = AllowedFunctions.Hour;
+                    break;
+                case ClrCanonicalFunctions.IndexofFunctionName:
+                    result = AllowedFunctions.IndexOf;
+                    break;
+                case "isof":
+                    result = AllowedFunctions.IsOf;
+                    break;
+                case ClrCanonicalFunctions.LengthFunctionName:
+                    result = AllowedFunctions.Length;
+                    break;
+                case ClrCanonicalFunctions.MatchesPatternFunctionName:
+                    result = AllowedFunctions.MatchesPattern;
+                    break;
+                case ClrCanonicalFunctions.MinuteFunctionName:
+                    result = AllowedFunctions.Minute;
+                    break;
+                case ClrCanonicalFunctions.MonthFunctionName:
+                    result = AllowedFunctions.Month;
+                    break;
+                case ClrCanonicalFunctions.RoundFunctionName:
+                    result = AllowedFunctions.Round;
+                    break;
+                case ClrCanonicalFunctions.SecondFunctionName:
+                    result = AllowedFunctions.Second;
+                    break;
+                case ClrCanonicalFunctions.StartswithFunctionName:
+                    result = AllowedFunctions.StartsWith;
+                    break;
+                case ClrCanonicalFunctions.SubstringFunctionName:
+                    result = AllowedFunctions.Substring;
+                    break;
+                case ClrCanonicalFunctions.TolowerFunctionName:
+                    result = AllowedFunctions.ToLower;
+                    break;
+                case ClrCanonicalFunctions.ToupperFunctionName:
+                    result = AllowedFunctions.ToUpper;
+                    break;
+                case ClrCanonicalFunctions.TrimFunctionName:
+                    result = AllowedFunctions.Trim;
+                    break;
+                case ClrCanonicalFunctions.YearFunctionName:
+                    result = AllowedFunctions.Year;
+                    break;
+                case ClrCanonicalFunctions.DateFunctionName:
+                    result = AllowedFunctions.Date;
+                    break;
+                case ClrCanonicalFunctions.TimeFunctionName:
+                    result = AllowedFunctions.Time;
+                    break;
+                case ClrCanonicalFunctions.FractionalSecondsFunctionName:
+                    result = AllowedFunctions.FractionalSeconds;
+                    break;
+                default:
+                    // Originally, we think it should never be here.
+                    // But, ODL supports the customized function, if we are here, it might mean it's a customized function.
+                    // Since we don't have configuration for customized function, let's return the 'None'.
+                    break;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/QueryValidatorHelpers.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.OData.Query.Validator
                 case ClrCanonicalFunctions.IndexofFunctionName:
                     result = AllowedFunctions.IndexOf;
                     break;
-                case "isof":
+                case ClrCanonicalFunctions.IsofFunctionName:
                     result = AllowedFunctions.IsOf;
                     break;
                 case ClrCanonicalFunctions.LengthFunctionName:

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
@@ -1,0 +1,252 @@
+//-----------------------------------------------------------------------------
+// <copyright file="OrderByAdvancedTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.ODataOrderByTest
+{
+    public class OrderByAdvancedTest : WebApiTestBase<OrderByAdvancedTest>
+    {
+        public OrderByAdvancedTest(WebApiTestFixture<OrderByAdvancedTest> fixture)
+            :base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            IEdmModel edmModel = GetEdmModel();
+
+            services.ConfigureControllers(typeof(StudentsController));
+
+            services.AddControllers().AddOData(opt =>
+                opt.Count().Filter().OrderBy().Expand().Select().AddRouteComponents("odata", edmModel));
+        }
+
+        public static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<OrderByStudent>("Students");
+            return builder.GetEdmModel();
+        }
+
+        [Theory]
+        [InlineData("$orderby=name", new[] { 2, 1, 6, 5, 3, 4 }, new[] { "a1", "A1", "Ab", "AB", "bb", "Bc" })]
+        [InlineData("$orderby=tolower(name)", new[] { 1, 2, 5, 6, 3, 4 }, new[] { "A1", "a1", "AB", "Ab", "bb", "Bc" })]
+        [InlineData("$orderby=toupper(name)", new[] { 1, 2, 5, 6, 3, 4 }, new[] { "A1", "a1", "AB", "Ab", "bb", "Bc" })]
+        public async Task DollarOrderBy_UsingAdvanced_BuiltInStringFunctions(string orderBy, int[] ids, string[] names)
+        {
+            // Arrange
+            string queryUrl = $"odata/students?{orderBy}&$select=id,name";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            JObject payloadBody = await response.Content.ReadAsObject<JObject>();
+            (int[] actualIds, string[] actualNames) = GetIds(payloadBody, "Name");
+
+            Assert.True(ids.SequenceEqual(actualIds));
+            Assert.True(names.SequenceEqual(actualNames));
+        }
+
+        [Theory]
+        [InlineData("$orderby=birthday", new[] { 2, 3, 1, 6, 5, 4 }, new[] { "1908", "1987", "2011", "2019", "2019", "2023" })]
+        [InlineData("$orderby=year(birthday)", new[] { 2, 3, 1, 5, 6, 4 },new[] { "1908", "1987", "2011", "2019", "2019", "2023" })] // Be noted: #5 goes before #6
+        [InlineData("$orderby=month(birthday)", new[] { 1, 6, 4, 5, 3, 2 }, new[] { "2011", "2019", "2023", "2019", "1987", "1908" })]
+        public async Task DollarOrderBy_UsingAdvanced_BuiltInDateFunctions(string orderBy, int[] ids, string[] birthdays)
+        {
+            // Arrange
+            string queryUrl = $"odata/students?{orderBy}&$select=id,year&$compute=year(birthday) as year";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            JObject payloadBody = await response.Content.ReadAsObject<JObject>();
+            (int[] actualIds, string[] actualBirthdays) = GetIds(payloadBody, "year");
+
+            Assert.True(ids.SequenceEqual(actualIds));
+            Assert.True(birthdays.SequenceEqual(actualBirthdays));
+        }
+
+        [Fact]
+        public async Task DollarOrderBy_UsingDollarCount()
+        {
+            // Arrange
+            string queryUrl = $"odata/students?$orderby=Grades/$count&$select=id,number&$compute=Grades/$count as number";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            JObject payloadBody = await response.Content.ReadAsObject<JObject>();
+            (int[] actualIds, string[] actualNumbers) = GetIds(payloadBody, "number");
+
+            Assert.True(new int[] { 2, 5, 1, 4, 3, 6 }.SequenceEqual(actualIds));
+            Assert.True(new int[] { 1, 1, 3, 3, 4, 5 }.SequenceEqual(actualNumbers.Select(a => int.Parse(a))));
+        }
+
+        private static (int[], string[]) GetIds(JObject payload, string propertyName)
+        {
+            JArray value = payload["value"] as JArray;
+            Assert.NotNull(value);
+
+            int[] ids = new int[value.Count()];
+            string[] properties = new string[value.Count()];
+            for (int i = 0; i < value.Count(); i++)
+            {
+                JObject item = value[i] as JObject;
+                ids[i] = (int)item["Id"];
+                properties[i] = (string)item[propertyName];
+            }
+
+            return (ids, properties);
+        }
+
+        [Fact]
+        public async Task DollarOrderBy_UsingPropertyPath()
+        {
+            // Arrange
+            string queryUrl = $"odata/students?$orderby=location/city&$select=id,location/city";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal("{\"value\":[" +
+                "{\"Id\":3,\"Location\":{\"City\":\"Avat\"}}," +
+                "{\"Id\":4,\"Location\":{\"City\":\"Aveneve\"}}," +
+                "{\"Id\":5,\"Location\":{\"City\":\"Ces\"}}," +
+                "{\"Id\":1,\"Location\":{\"City\":\"Cesar\"}}," +
+                "{\"Id\":6,\"Location\":{\"City\":\"Claire\"}}," +
+                "{\"Id\":2,\"Location\":{\"City\":\"Debra\"}}" +
+              "]}", payloadBody);
+        }
+
+        [Fact]
+        public async Task DollarOrderBy_UsingPropertyPath_WithBuiltInStringFunction()
+        {
+            // Arrange
+            string queryUrl = $"odata/students?$orderby=tolower(substring(location/city,1,2))&$select=id,location/city,t&$compute=tolower(substring(location/city,1,2)) as t";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal("{\"value\":[" +
+                "{\"Id\":2,\"t\":\"eb\",\"Location\":{\"City\":\"Debra\"}}," +
+                "{\"Id\":1,\"t\":\"es\",\"Location\":{\"City\":\"Cesar\"}}," +
+                "{\"Id\":5,\"t\":\"es\",\"Location\":{\"City\":\"Ces\"}}," +
+                "{\"Id\":6,\"t\":\"la\",\"Location\":{\"City\":\"Claire\"}}," +
+                "{\"Id\":3,\"t\":\"va\",\"Location\":{\"City\":\"Avat\"}}," +
+                "{\"Id\":4,\"t\":\"ve\",\"Location\":{\"City\":\"Aveneve\"}}" +
+              "]}", payloadBody);
+        }
+
+        [Fact]
+        public async Task DollarOrderBy_UsingDollarThisWithinDollarSelect_OnCollection()
+        {
+            // Arrange
+            string queryUrl = "odata/students/6?$select=Grades($orderby=$this)";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            // Origin is : 9, 8, 7, 1, 2
+            Assert.Equal("{\"Grades\":[1,2,7,8,9]}", payloadBody);
+        }
+
+
+        [Fact]
+        public async Task DollarOrderBy_UsingDollarThis_OnCollection()
+        {
+            // Arrange
+            string queryUrl = "odata/students/6/Grades?$orderby=$it";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = CreateClient();
+            HttpResponseMessage response;
+
+            // Act
+            response = await client.SendAsync(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            string payloadBody = await response.Content.ReadAsStringAsync();
+
+            // Origin is : 9, 8, 7, 1, 2
+            Assert.Equal("{\"Grades\":[1,2,7,8,9]}", payloadBody);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ODataOrderByTest
             string payloadBody = await response.Content.ReadAsStringAsync();
 
             // Origin is : 9, 8, 7, 1, 2
-            Assert.Equal("{\"Grades\":[1,2,7,8,9]}", payloadBody);
+            Assert.Equal("{\"value\":[1,2,7,8,9]}", payloadBody);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByAdvancedTest.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ODataOrderByTest
 
 
         [Fact]
-        public async Task DollarOrderBy_UsingDollarThis_OnCollection()
+        public async Task DollarOrderBy_UsingDollarIt_OnCollection()
         {
             // Arrange
             string queryUrl = "odata/students/6/Grades?$orderby=$it";

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByController.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -100,6 +101,48 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ODataOrderByTest
         public IActionResult GetItemsWithoutColumn()
         {
             return Ok(_itemWithoutColumns);
+        }
+    }
+
+    public class StudentsController : ODataController
+    {
+        private static IList<OrderByStudent> _students = new List<OrderByStudent>
+        {
+            new OrderByStudent { Id = 1, Name = "A1", Birthday = new DateTimeOffset(2011, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 1, 2 ,3 }, Location = new OrderByAddress{ City = "Cesar", ZipCode = "98" } },
+
+            new OrderByStudent { Id = 2, Name = "a1", Birthday = new DateTimeOffset(1908, 11, 21, 5, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 8 }, Location = new OrderByAddress{ City = "Debra", ZipCode = "1807" } },
+
+            new OrderByStudent { Id = 3, Name = "bb", Birthday = new DateTimeOffset(1987, 9, 11, 1, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 5, 6, 8, 9 }, Location = new OrderByAddress{ City = "Avat", ZipCode = "98087" } },
+
+            new OrderByStudent { Id = 4, Name = "Bc", Birthday = new DateTimeOffset(2023, 3, 4, 1, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 4, 5, 6 }, Location = new OrderByAddress{ City = "Aveneve", ZipCode = "89" } },
+
+            new OrderByStudent { Id = 5, Name = "AB", Birthday = new DateTimeOffset(2019, 6, 7, 1, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 0 }, Location = new OrderByAddress{ City = "Ces", ZipCode = "11" } },
+
+            new OrderByStudent { Id = 6, Name = "Ab", Birthday = new DateTimeOffset(2019, 2, 18, 1, 1, 1, TimeSpan.Zero),
+                Grades = new List<int>{ 9, 8, 7, 1, 2 }, Location = new OrderByAddress{ City = "Claire", ZipCode = "56" } }
+        };
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(_students);
+        }
+
+        [EnableQuery]
+        public IActionResult Get(int key)
+        {
+            return Ok(_students.FirstOrDefault(c => c.Id == key));
+        }
+
+        [EnableQuery]
+        public IActionResult GetGrades(int key)
+        {
+            return Ok(_students.FirstOrDefault(c => c.Id == key).Grades);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ODataOrderByTest/OrderByDataModel.cs
@@ -5,6 +5,9 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -79,4 +82,27 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ODataOrderByTest
         Three,
         Four
     }
+
+    #region Advanced $orderby
+
+    public class OrderByStudent
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTimeOffset Birthday { get; set; }
+
+        public IList<int> Grades { get; set; }
+
+        public OrderByAddress Location { get; set; }
+    }
+
+    public class OrderByAddress
+    {
+        public string City { get; set; }
+
+        public string ZipCode { get; set; }
+    }
+    #endregion
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -1471,6 +1471,12 @@ public class Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions {
 	string Top  { public get; }
 }
 
+public class Microsoft.AspNetCore.OData.Query.OrderByClauseNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
+	public OrderByClauseNode (Microsoft.OData.UriParser.OrderByClause orderByClause)
+
+	Microsoft.OData.UriParser.OrderByClause OrderByClause  { public get; }
+}
+
 public class Microsoft.AspNetCore.OData.Query.OrderByCountNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
 	public OrderByCountNode (Microsoft.OData.UriParser.OrderByClause orderByClause)
 
@@ -1478,7 +1484,10 @@ public class Microsoft.AspNetCore.OData.Query.OrderByCountNode : Microsoft.AspNe
 }
 
 public class Microsoft.AspNetCore.OData.Query.OrderByItNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
+	public OrderByItNode (Microsoft.OData.UriParser.OrderByClause clause)
 	public OrderByItNode (Microsoft.OData.UriParser.OrderByDirection direction)
+
+	string Name  { public get; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.OrderByOpenPropertyNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
@@ -3052,6 +3061,39 @@ public class Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator : 
 	public OrderByQueryValidator ()
 
 	public virtual void Validate (Microsoft.AspNetCore.OData.Query.OrderByQueryOption orderByOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings)
+	protected virtual void ValidateAllNode (Microsoft.OData.UriParser.AllNode allNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateAnyNode (Microsoft.OData.UriParser.AnyNode anyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateBinaryOperatorNode (Microsoft.OData.UriParser.BinaryOperatorNode binaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionComplexNode (Microsoft.OData.UriParser.CollectionComplexNode collectionComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionNode (Microsoft.OData.UriParser.CollectionNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionPropertyAccessNode (Microsoft.OData.UriParser.CollectionPropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionResourceCastNode (Microsoft.OData.UriParser.CollectionResourceCastNode collectionResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateConstantNode (Microsoft.OData.UriParser.ConstantNode constantNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateConvertNode (Microsoft.OData.UriParser.ConvertNode convertNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCountNode (Microsoft.OData.UriParser.CountNode countNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateInNode (Microsoft.OData.UriParser.InNode inNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateNavigationPropertyNode (Microsoft.OData.UriParser.CollectionNavigationNode collectionNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateNavigationPropertyNode (Microsoft.OData.UriParser.SingleNavigationNode singleNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateOrderBy (Microsoft.OData.UriParser.OrderByClause orderByClause, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateQueryNode (Microsoft.OData.UriParser.QueryNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateRangeVariable (Microsoft.OData.UriParser.RangeVariable rangeVariable, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleComplexNode (Microsoft.OData.UriParser.SingleComplexNode singleComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleResourceCastNode (Microsoft.OData.UriParser.SingleResourceCastNode singleResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValueFunctionCallNode (Microsoft.OData.UriParser.SingleValueFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValueNode (Microsoft.OData.UriParser.SingleValueNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext, bool skipRangeVariable)
+	protected virtual void ValidateSingleValueOpenPropertyNode (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openPropertyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValuePropertyAccessNode (Microsoft.OData.UriParser.SingleValuePropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext : Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext {
+	public OrderByValidatorContext ()
+
+	Microsoft.AspNetCore.OData.Query.OrderByQueryOption OrderBy  { public get; public set; }
+	int OrderByNodeCount  { public get; }
+
+	public void IncrementNodeCount ()
 }
 
 public class Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator : ISelectExpandQueryValidator {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -1471,6 +1471,12 @@ public class Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions {
 	string Top  { public get; }
 }
 
+public class Microsoft.AspNetCore.OData.Query.OrderByClauseNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
+	public OrderByClauseNode (Microsoft.OData.UriParser.OrderByClause orderByClause)
+
+	Microsoft.OData.UriParser.OrderByClause OrderByClause  { public get; }
+}
+
 public class Microsoft.AspNetCore.OData.Query.OrderByCountNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
 	public OrderByCountNode (Microsoft.OData.UriParser.OrderByClause orderByClause)
 
@@ -1478,7 +1484,10 @@ public class Microsoft.AspNetCore.OData.Query.OrderByCountNode : Microsoft.AspNe
 }
 
 public class Microsoft.AspNetCore.OData.Query.OrderByItNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
+	public OrderByItNode (Microsoft.OData.UriParser.OrderByClause clause)
 	public OrderByItNode (Microsoft.OData.UriParser.OrderByDirection direction)
+
+	string Name  { public get; }
 }
 
 public class Microsoft.AspNetCore.OData.Query.OrderByOpenPropertyNode : Microsoft.AspNetCore.OData.Query.OrderByNode {
@@ -3052,6 +3061,39 @@ public class Microsoft.AspNetCore.OData.Query.Validator.OrderByQueryValidator : 
 	public OrderByQueryValidator ()
 
 	public virtual void Validate (Microsoft.AspNetCore.OData.Query.OrderByQueryOption orderByOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings)
+	protected virtual void ValidateAllNode (Microsoft.OData.UriParser.AllNode allNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateAnyNode (Microsoft.OData.UriParser.AnyNode anyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateBinaryOperatorNode (Microsoft.OData.UriParser.BinaryOperatorNode binaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionComplexNode (Microsoft.OData.UriParser.CollectionComplexNode collectionComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionNode (Microsoft.OData.UriParser.CollectionNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionPropertyAccessNode (Microsoft.OData.UriParser.CollectionPropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCollectionResourceCastNode (Microsoft.OData.UriParser.CollectionResourceCastNode collectionResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateConstantNode (Microsoft.OData.UriParser.ConstantNode constantNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateConvertNode (Microsoft.OData.UriParser.ConvertNode convertNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateCountNode (Microsoft.OData.UriParser.CountNode countNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateInNode (Microsoft.OData.UriParser.InNode inNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateNavigationPropertyNode (Microsoft.OData.UriParser.CollectionNavigationNode collectionNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateNavigationPropertyNode (Microsoft.OData.UriParser.SingleNavigationNode singleNavigation, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateOrderBy (Microsoft.OData.UriParser.OrderByClause orderByClause, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateQueryNode (Microsoft.OData.UriParser.QueryNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateRangeVariable (Microsoft.OData.UriParser.RangeVariable rangeVariable, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleComplexNode (Microsoft.OData.UriParser.SingleComplexNode singleComplexNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleResourceCastNode (Microsoft.OData.UriParser.SingleResourceCastNode singleResourceCastNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValueFunctionCallNode (Microsoft.OData.UriParser.SingleValueFunctionCallNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValueNode (Microsoft.OData.UriParser.SingleValueNode node, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext, bool skipRangeVariable)
+	protected virtual void ValidateSingleValueOpenPropertyNode (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openPropertyNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateSingleValuePropertyAccessNode (Microsoft.OData.UriParser.SingleValuePropertyAccessNode propertyAccessNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+	protected virtual void ValidateUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode, Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext validatorContext)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Validator.OrderByValidatorContext : Microsoft.AspNetCore.OData.Query.Validator.QueryValidatorContext {
+	public OrderByValidatorContext ()
+
+	Microsoft.AspNetCore.OData.Query.OrderByQueryOption OrderBy  { public get; public set; }
+	int OrderByNodeCount  { public get; }
+
+	public void IncrementNodeCount ()
 }
 
 public class Microsoft.AspNetCore.OData.Query.Validator.SelectExpandQueryValidator : ISelectExpandQueryValidator {

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Nodes/OrderByClauseNodeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Nodes/OrderByClauseNodeTests.cs
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------------
+// <copyright file="OrderByClauseNodeTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Tests.Commons;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Query
+{
+    public class OrderByClauseNodeTests
+    {
+        [Fact]
+        public void CtorOrderByClauseNode_ThrowsArgumentNull_OrderByClause()
+        {
+            // Arrange & Act & Assert
+            ExceptionAssert.ThrowsArgumentNull(() => new OrderByClauseNode(null), "orderByClause");
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Nodes/OrderByOpenPropertyNodeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Nodes/OrderByOpenPropertyNodeTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
 
             // Act & Assert
             ExceptionAssert.Throws<ODataException>(() => new OrderByOpenPropertyNode(orderBy),
-                "Only ordering by properties is supported for non-primitive collections. Expressions are not supported.");
+                "OrderBy clause kind 'None' is not valid. Only kind 'SingleValueOpenPropertyAccess' is accepted.");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionTests.cs
@@ -715,7 +715,9 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
             IEdmModel model = GetEdmModel(c => c.CustomerId);
             HttpRequest request = RequestFactory.Create(HttpMethods.Get, "http://server/service/Customers?$orderby=CustomerId,Name");
 
-            var options = new ODataQueryOptions(new ODataQueryContext(model, typeof(Customer)), request);
+            ODataQueryContext queryContext = new ODataQueryContext(model, typeof(Customer));
+            queryContext.DefaultQueryConfigurations.EnableOrderBy = true;
+            var options = new ODataQueryOptions(queryContext, request);
             ODataValidationSettings validationSettings = new ODataValidationSettings { MaxOrderByNodeCount = 1 };
 
             // Act & Assert

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/OrderByQueryOptionTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/OrderByQueryOptionTest.cs
@@ -306,14 +306,15 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
 
         [Theory]
         [InlineData("SharePrice add 1")]
-        public void OrderBy_Throws_For_Expressions(string orderByQuery)
+        [InlineData("tolower(Name)")]
+        public void OrderBy_Works_For_Expressions(string orderByQuery)
         {
             var model = new ODataModelBuilder().Add_Customer_EntityType_With_Address().Add_Customers_EntitySet().GetEdmModel();
             var orderByOption = new OrderByQueryOption(orderByQuery, new ODataQueryContext(model, typeof(Customer)));
 
-            ExceptionAssert.Throws<ODataException>(
-                () => orderByOption.OrderByNodes.Count(),
-                "Only ordering by properties is supported for non-primitive collections. Expressions are not supported.");
+            var nodes = orderByOption.OrderByNodes;
+            OrderByNode orderByNode = Assert.Single(nodes);
+            OrderByClauseNode clauseNode = Assert.IsType<OrderByClauseNode>(orderByNode);
         }
 
         //[Fact]
@@ -678,16 +679,16 @@ namespace Microsoft.AspNetCore.OData.Tests.Query
         }
 
         [Fact]
-        public void OrderBy_Throws_ParameterAliasNotFound()
+        public void OrderBy_Works_ParameterAlias()
         {
             // Arrange
             var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
             var orderByOption = new OrderByQueryOption("@p", new ODataQueryContext(model, typeof(Customer)));
 
             // Act & Assert
-            ExceptionAssert.Throws<ODataException>(
-                () => orderByOption.OrderByNodes,
-                "Only ordering by properties is supported for non-primitive collections. Expressions are not supported.");
+            var nodes = orderByOption.OrderByNodes;
+            OrderByNode orderByNode = Assert.Single(nodes);
+            OrderByClauseNode clauseNode = Assert.IsType<OrderByClauseNode>(orderByNode);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/OrderByQueryValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Validator/OrderByQueryValidatorTest.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
-using Microsoft.OData.ModelBuilder.Config;
 using Microsoft.OData.UriParser;
 using Xunit;
 
@@ -255,6 +254,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Validator
             ODataQueryContext context = new ODataQueryContext(model, edmType);
             OrderByQueryOption option = new OrderByQueryOption("ComplexProperty/Value", context);
             ODataValidationSettings settings = new ODataValidationSettings();
+            settings.AllowedOrderByProperties.Add("ComplexProperty");
             settings.AllowedOrderByProperties.Add("Value");
 
             // Act & Assert


### PR DESCRIPTION
Fixes #1126

Support odata query expression in $orderby. For example:

$orderby=tolower(name)
$orderby=year(Birthday)
....