### PR TITLE
Optimize `ODataPathExtensions.GetNavigationSource`

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/ODataPathExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataPathExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.OData.Routing
                 throw Error.ArgumentNull(nameof(path));
             }
 
-            for (int i = path.Count - 1; i > -1; --i)
+            for (int i = path.Count - 1; i >= 0; --i)
             {
                 ODataPathSegment segment = path[i];
                 if (segment is EntitySetSegment entitySetSegment)
@@ -126,7 +126,6 @@ namespace Microsoft.AspNetCore.OData.Routing
                 }
 
                 return null;
-
             }
 
             return null;

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataPathExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataPathExtensions.cs
@@ -77,9 +77,59 @@ namespace Microsoft.AspNetCore.OData.Routing
                 throw Error.ArgumentNull(nameof(path));
             }
 
-            ODataPathNavigationSourceHandler handler = new ODataPathNavigationSourceHandler();
-            path.WalkWith(handler);
-            return handler.NavigationSource;
+            for (int i = path.Count - 1; i > -1; --i)
+            {
+                ODataPathSegment segment = path[i];
+                if (segment is EntitySetSegment entitySetSegment)
+                {
+                    return entitySetSegment.EntitySet;
+                }
+
+                if (segment is KeySegment keySegment)
+                {
+                    return keySegment.NavigationSource;
+                }
+
+                if (segment is NavigationPropertyLinkSegment navigationPropertyLinkSegment)
+                {
+                    return navigationPropertyLinkSegment.NavigationSource;
+                }
+
+                if (segment is NavigationPropertySegment navigationPropertySegment)
+                {
+                    return navigationPropertySegment.NavigationSource;
+                }
+
+                if (segment is OperationImportSegment operationImportSegment)
+                {
+                    return operationImportSegment.EntitySet;
+                }
+
+                if (segment is OperationSegment operationSegment)
+                {
+                    return operationSegment.EntitySet;
+                }
+
+                if (segment is SingletonSegment singleton)
+                {
+                    return singleton.Singleton;
+                }
+
+                if (segment is TypeSegment typeSegment)
+                {
+                    return typeSegment.NavigationSource;
+                }
+
+                if (segment is PropertySegment)
+                {
+                    continue;
+                }
+
+                return null;
+
+            }
+
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Fix #1118 

Replaces the use of `ODataPathNavigationSourceHandler` in `ODataPath.GetNavigationSource` extension method with a simpler reverse loop of the path.

With `ODataPathNavigationSourceHandler`
- a new instance of the handler is allocated
- all the segments of the path are visited
- a `List<string>` is created and populated with the string representation of each path segment. This list is used to generate a string representation of the path via a `Path` property. But this property is not needed to determine the navigation source (it's also not used by existing code).

The new implementation scans the path segments from the end and stops as soon as it finds the navigation source because only the last navigation source in the path matters.

The `ODataPathNavigationSourceHandler` is public so I kept it to avoid breaking changes.

**Before**

![image](https://github.com/OData/AspNetCoreOData/assets/8460169/6e3047d0-004d-44e7-9733-596135044e22)


**After**

![image](https://github.com/OData/AspNetCoreOData/assets/8460169/541bd542-997f-411e-991c-29051b509ef5)
