### PR TITLE
Add OrderByDescending while looping prefixes in FindRelatedODataPrefix

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.OData.Routing.Conventions
             // In order to avoiding ambiguous, let's compare non-empty route prefix first,
             // If no match, then compare empty route prefix.
             string emptyPrefix = null;
-            foreach (var prefix in prefixes)
+            foreach (var prefix in prefixes.OrderByDescending(p => p))
             {
                 if (string.IsNullOrEmpty(prefix))
                 {


### PR DESCRIPTION
Examples: two routes named api/v1/session and api/v1/sessionitem. 

If session is registered in AddRouteComponents before sessionitem, this last one won't be added due the StartsWith comparison, causing unexpected results. 

This happens with any similar situation. Sorting the prefixes in descending order while looping them, will cause always the "most composed" route to be added independently of their registration order, avoiding hours of debugging and investigation, since there's no explicit documentation about this, and in some cases the registration may be generated by an sdk or other tool, that may invalidate the manual fix to switch the order, like was my case.