### PR TITLE
Fix UnicodeCharactersTest

### DIFF
--- a/test/Microsoft.AspNetCore.OData.Tests/Scenarios/UnicodeCharactersTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Scenarios/UnicodeCharactersTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Scenarios
         {
             // Arrange
             const string payload = "{" +
-                "\"LogonName\":\"Ärne Bjørn\"," +
-                "\"Email\":\"ärnebjørn@test.com\"" +
+                "\"LogonName\":\"Ã„rne BjÃ¸rn\"," +
+                "\"Email\":\"Ã¤rnebjÃ¸rn@test.com\"" +
                 "}";
 
             const string uri = "http://localhost/odata/UnicodeCharUsers";
@@ -53,8 +53,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Scenarios
         {
             // Arrange
             const string payload = "{" +
-                "\"LogonName\":\"Ärne Bjørn\"," +
-                "\"Email\":\"ärnebjørn@test.com\"" +
+                "\"LogonName\":\"Ã„rne BjÃ¸rn\"," +
+                "\"Email\":\"Ã¤rnebjÃ¸rn@test.com\"" +
                 "}";
 
             const string uri = "http://localhost/odata/UnicodeCharUsers";


### PR DESCRIPTION
By changing the UnicodeCharactersTests.cs encoding from ISO-8859-1 to UTF-8.

❌ Before this commit:

```
dotnet test --filter "FullyQualifiedName~UnicodeCharactersTest" --framework net6.0 test\Microsoft.AspNetCore.OData.Tests\Microsoft.AspNetCore.OData.Tests.csproj
  Determining projects to restore...
  All projects are up-to-date for restore.
  Microsoft.AspNetCore.OData -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.dll
  Microsoft.AspNetCore.OData.TestCommon -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.TestCommon.dll
  Microsoft.AspNetCore.OData.Tests -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.Tests.dll
Test run for C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.9.0 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:02.7831129]     Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey [FAIL]
[xUnit.net 00:00:02.8002771]     Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey_PreferNoContent [FAIL]
  Failed Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey [390 ms]
  Error Message:
   Assert.Equal() Failure
                                 ↓ (pos 42)
Expected: ···/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')
Actual:   ···/UnicodeCharUsers('%EF%BF%BDrne%20Bj%EF%BF%BDrn')
                                 ↑ (pos 42)
  Stack Trace:
     at Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey() in C:\Projects\GitHub\AspNetCoreOData\test\Microsoft.AspNetCore.OData.Tests\Scenarios\UnicodeCharactersTests.cs:line 48
--- End of stack trace from previous location ---
  Failed Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey_PreferNoContent [18 ms]
  Error Message:
   Assert.Equal() Failure
                                 ↓ (pos 42)
Expected: ···/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')
Actual:   ···/UnicodeCharUsers('%EF%BF%BDrne%20Bj%EF%BF%BDrn')
                                 ↑ (pos 42)
  Stack Trace:
     at Microsoft.AspNetCore.OData.Tests.Scenarios.UnicodeCharactersTest.PostEntity_WithUnicodeCharactersInKey_PreferNoContent() in C:\Projects\GitHub\AspNetCoreOData\test\Microsoft.AspNetCore.OData.Tests\Scenarios\UnicodeCharactersTests.cs:line 77
--- End of stack trace from previous location ---

Failed!  - Failed:     2, Passed:     0, Skipped:     0, Total:     2, Duration: 14 ms - Microsoft.AspNetCore.OData.Tests.dll (net6.0)
```

✔️ After this commit:
```
dotnet test --filter "FullyQualifiedName~UnicodeCharactersTest" --framework net6.0 test\Microsoft.AspNetCore.OData.Tests\Microsoft.AspNetCore.OData.Tests.csproj
  Determining projects to restore...
  All projects are up-to-date for restore.
  Microsoft.AspNetCore.OData -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.dll
  Microsoft.AspNetCore.OData.TestCommon -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.TestCommon.dll
  Microsoft.AspNetCore.OData.Tests -> C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.Tests.dll
Test run for C:\Projects\GitHub\AspNetCoreOData\bin\AnyCPU\Debug\net6.0\Microsoft.AspNetCore.OData.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.9.0 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 24 ms - Microsoft.AspNetCore.OData.Tests.dll (net6.0)
```