### PR TITLE
Set capacity for TruncatedCollection(IQueryable, int, boolean) overload

### DIFF
--- a/sample/BenchmarkServer/Controllers/ProductsController.cs
+++ b/sample/BenchmarkServer/Controllers/ProductsController.cs
@@ -68,7 +68,7 @@ namespace ODataPerformanceProfile.Controllers
         }
 
         [HttpGet]
-        [EnableQuery]
+        [EnableQuery(PageSize = 3000)]
         public IActionResult Get()
         {
             return Ok(products);

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -29,8 +29,10 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         /// <param name="source">The collection to be truncated.</param>
         /// <param name="pageSize">The page size.</param>
         public TruncatedCollection(IEnumerable<T> source, int pageSize)
-            : base(source.Take(checked(pageSize + 1)))
+            : base(checked(pageSize + 1))
         {
+            var items = source.Take(checked(pageSize + 1));
+            AddRange(items);
             Initialize(pageSize);
         }
 
@@ -54,8 +56,10 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         // NOTE: The queryable version calls Queryable.Take which actually gets translated to the backend query where as 
         // the enumerable version just enumerates and is inefficient.
         public TruncatedCollection(IQueryable<T> source, int pageSize, bool parameterize)
-            : base(Take(source, pageSize, parameterize))
+            : base(checked(pageSize + 1))
         {
+            var items = Take(source, pageSize, parameterize);
+            AddRange(items);
             Initialize(pageSize);
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -85,6 +85,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
             {
                 AddRange(source);
             }
+
             if (pageSize > 0)
             {
                 Initialize(pageSize);

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
     {
         // The default capacity of the list.
         // https://github.com/microsoft/referencesource/blob/master/mscorlib/system/collections/generic/list.cs#L38
-        private const int defaultCapacity = 4;
+        private const int DefaultCapacity = 4;
         private const int MinPageSize = 1;
 
         private bool _isTruncated;
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         public TruncatedCollection(IEnumerable<T> source, int pageSize, long? totalCount)
             : base(pageSize > 0
                 ? checked(pageSize + 1)
-                : (totalCount > 0 ? (totalCount < int.MaxValue ? (int)totalCount : int.MaxValue) : defaultCapacity))
+                : (totalCount > 0 ? (totalCount < int.MaxValue ? (int)totalCount : int.MaxValue) : DefaultCapacity))
         {
             if (pageSize > 0)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         /// <param name="totalCount">The total count.</param>
         // NOTE: The queryable version calls Queryable.Take which actually gets translated to the backend query where as 
         // the enumerable version just enumerates and is inefficient.
-        [Obsolete("should not used should be removed in the next major version")]
+        [Obsolete("should not be used, will be marked internal in the next major version")]
         public TruncatedCollection(IQueryable<T> source, int pageSize, long? totalCount) : this(source, pageSize,
             totalCount, false)
         {
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         /// <param name="parameterize">Flag indicating whether constants should be parameterized</param>
         // NOTE: The queryable version calls Queryable.Take which actually gets translated to the backend query where as 
         // the enumerable version just enumerates and is inefficient.
-        [Obsolete("should not be used should be removed in the next major version")]
+        [Obsolete("should not be used, will be marked internal in the next major version")]
         public TruncatedCollection(IQueryable<T> source, int pageSize, long? totalCount, bool parameterize)
             : base(pageSize > 0 ? Take(source, pageSize, parameterize) : source)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
     public class TruncatedCollection<T> : List<T>, ITruncatedCollection, IEnumerable<T>, ICountOptionCollection
     {
         // The default capacity of the list.
-        // https://github.com/microsoft/referencesource/blob/master/mscorlib/system/collections/generic/list.cs#L38
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs#L23
         private const int DefaultCapacity = 4;
         private const int MinPageSize = 1;
 

--- a/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Container/TruncatedCollectionOfT.cs
@@ -88,7 +88,9 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         /// <param name="totalCount">The total count.</param>
         // NOTE: The queryable version calls Queryable.Take which actually gets translated to the backend query where as 
         // the enumerable version just enumerates and is inefficient.
-        public TruncatedCollection(IQueryable<T> source, int pageSize, long? totalCount) : this(source, pageSize, totalCount, false)
+        [Obsolete("should not used should be removed in the next major version")]
+        public TruncatedCollection(IQueryable<T> source, int pageSize, long? totalCount) : this(source, pageSize,
+            totalCount, false)
         {
         }
 
@@ -101,6 +103,7 @@ namespace Microsoft.AspNetCore.OData.Query.Container
         /// <param name="parameterize">Flag indicating whether constants should be parameterized</param>
         // NOTE: The queryable version calls Queryable.Take which actually gets translated to the backend query where as 
         // the enumerable version just enumerates and is inefficient.
+        [Obsolete("should not be used should be removed in the next major version")]
         public TruncatedCollection(IQueryable<T> source, int pageSize, long? totalCount, bool parameterize)
             : base(pageSize > 0 ? Take(source, pageSize, parameterize) : source)
         {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.Net6.bsl
@@ -2746,7 +2746,14 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize)
 	public TruncatedCollection`1 (IEnumerable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount)
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, bool parameterize)
+	[
+	ObsoleteAttribute(),
+	]
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount)
+
+	[
+	ObsoleteAttribute(),
+	]
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount, bool parameterize)
 
 	bool IsTruncated  { public virtual get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.NetCore31.bsl
@@ -2746,7 +2746,14 @@ public class Microsoft.AspNetCore.OData.Query.Container.TruncatedCollection`1 : 
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize)
 	public TruncatedCollection`1 (IEnumerable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount)
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, bool parameterize)
+	[
+	ObsoleteAttribute(),
+	]
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount)
+
+	[
+	ObsoleteAttribute(),
+	]
 	public TruncatedCollection`1 (IQueryable`1 source, int pageSize, System.Nullable`1[[System.Int64]] totalCount, bool parameterize)
 
 	bool IsTruncated  { public virtual get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Container/TruncatedCollectionOfTTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Container/TruncatedCollectionOfTTest.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using Microsoft.AspNetCore.OData.Query.Container;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using System.Collections.Generic;
@@ -50,6 +51,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Query.Container
         }
 
         [Fact]
+        [Obsolete]
         public void CtorTruncatedCollection_WithQueryable_SetsProperties()
         {
             // Arrange & Act


### PR DESCRIPTION
After profiling our service that uses AspNetCore.OData with a huge page size of 3000. I've noticed a lot of time is spent inside TruncatedCollection overload for IQueryable
<img width="1552" alt="image" src="https://github.com/OData/AspNetCoreOData/assets/10225385/29be798c-62ea-429c-85f5-fa0382d1a05b">

Since it uses List as a base class current initialization will resize quite a few times before reaching the page size. This PR attempts to fix this for some of the overloads were size of the page is known

fixes #1185 