### PR TITLE
Read Type.GetGenericTypeDefinition just once in _isDeltaOfT

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
@@ -298,12 +298,12 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         {
             get
             {
-                if (_isDeltaOfT is not null)
+                if (_isDeltaOfT.HasValue)
                 {
                     return _isDeltaOfT.Value;
                 }
                 
-                if (Type is not { IsGenericType: true })
+                if (!(Type is { IsGenericType: true }))
                 {
                     _isDeltaOfT = false;
                     return _isDeltaOfT.Value;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
@@ -298,24 +298,21 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
         {
             get
             {
-                if (_isDeltaOfT == null)
+                if (_isDeltaOfT is not null)
                 {
-                    if (Type == null)
-                    {
-                        _isDeltaOfT = false;
-                    }
-                    else if (Type.IsGenericType)
-                    {
-                        var genericTypeDefinition = Type.GetGenericTypeDefinition();
-                        _isDeltaOfT = (genericTypeDefinition == typeof(Delta<>) ||
-                                       genericTypeDefinition == typeof(DeltaSet<>) ||
-                                       genericTypeDefinition == typeof(DeltaDeletedResource<>));
-                    }
-                    else
-                    {
-                        _isDeltaOfT = false;
-                    }
+                    return _isDeltaOfT.Value;
                 }
+                
+                if (Type is not { IsGenericType: true })
+                {
+                    _isDeltaOfT = false;
+                    return _isDeltaOfT.Value;
+                }
+
+                var genericTypeDefinition = Type.GetGenericTypeDefinition();
+                _isDeltaOfT = genericTypeDefinition == typeof(Delta<>) ||
+                              genericTypeDefinition == typeof(DeltaSet<>) ||
+                              genericTypeDefinition == typeof(DeltaDeletedResource<>);
 
                 return _isDeltaOfT.Value;
             }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataSerializerContext.cs
@@ -300,8 +300,21 @@ namespace Microsoft.AspNetCore.OData.Formatter.Serialization
             {
                 if (_isDeltaOfT == null)
                 {
-                    _isDeltaOfT = Type != null && Type.IsGenericType && (Type.GetGenericTypeDefinition() == typeof(Delta<>) ||
-                        Type.GetGenericTypeDefinition() == typeof(DeltaSet<>) || Type.GetGenericTypeDefinition() == typeof(DeltaDeletedResource<>));
+                    if (Type == null)
+                    {
+                        _isDeltaOfT = false;
+                    }
+                    else if (Type.IsGenericType)
+                    {
+                        var genericTypeDefinition = Type.GetGenericTypeDefinition();
+                        _isDeltaOfT = (genericTypeDefinition == typeof(Delta<>) ||
+                                       genericTypeDefinition == typeof(DeltaSet<>) ||
+                                       genericTypeDefinition == typeof(DeltaDeletedResource<>));
+                    }
+                    else
+                    {
+                        _isDeltaOfT = false;
+                    }
                 }
 
                 return _isDeltaOfT.Value;


### PR DESCRIPTION
Fix multiple calls to GetGenericTypeDefinition in [ODataSerializerContext.cs](https://github.com/OData/AspNetCoreOData/compare/main...senioroman4uk:senioroman4uk/fix-is-delta-of-t?expand=1#diff-732b595c31c0f7e9b97687d1ab7bce7d1f35d3fc2ce9adfcec3ef13e1d373b99)

fixes #1188 