### PR TITLE
Fixes #1212: Link generation with string key and back slash in the key value

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Common/StringExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/StringExtensions.cs
@@ -28,6 +28,21 @@ namespace Microsoft.AspNetCore.OData.Common
         }
 
         /// <summary>
+        /// Escape Uri string for '/'
+        /// </summary>
+        /// <param name="uriString">The Uri string.</param>
+        /// <returns>Escaped back slash Uri string.</returns>
+        public static string EscapeBackSlashUriString(this string uriString)
+        {
+            if (uriString == null)
+            {
+                return null;
+            }
+
+            return uriString.Replace("/", "%2F");
+        }
+
+        /// <summary>
         /// Normalize the http method.
         /// </summary>
         /// <param name="method">The http method.</param>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1055,6 +1055,13 @@
             <param name="uriString">The Uri string.</param>
             <returns>Unescaped back slash Uri string.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.StringExtensions.EscapeBackSlashUriString(System.String)">
+            <summary>
+            Escape Uri string for '/'
+            </summary>
+            <param name="uriString">The Uri string.</param>
+            <returns>Escaped back slash Uri string.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.StringExtensions.NormalizeHttpMethod(System.String)">
             <summary>
             Normalize the http method.
@@ -1101,6 +1108,20 @@
             </summary>
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.DateOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeOnly(System.Type)">
+            <summary>
+            Determine if a type is a <see cref="T:System.TimeOnly"/>.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a TimeOnly; false otherwise.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
@@ -15564,22 +15585,6 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate" /> class.
             </summary>
-            <param name="segment">The value segment.</param>
-        </member>
-        <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">
-            <summary>
-            Gets the value segment.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.GetTemplates(Microsoft.AspNetCore.OData.Routing.ODataRouteOptions)">
-            <inheritdoc />
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.TryTranslate(Microsoft.AspNetCore.OData.Routing.Template.ODataTemplateTranslateContext)">
-            <inheritdoc />
-        </member>
-    </members>
-</doc>
-ummary>
             <param name="segment">The value segment.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Routing.Template.ValueSegmentTemplate.Segment">

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataPathSegmentHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataPathSegmentHandler.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using Microsoft.AspNetCore.OData.Common;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -305,6 +306,7 @@ namespace Microsoft.AspNetCore.OData.Routing
                 return string.Empty;
             }
 
+            // only one key
             if (keyValuePairs.Count < 2)
             {
                 var keyValue = keyValuePairs.First();
@@ -316,16 +318,17 @@ namespace Microsoft.AspNetCore.OData.Routing
                     return string.Join(
                         ",",
                         keyValuePairs.Select(keyValuePair =>
-                            TranslateNode(keyValuePair.Value)).ToArray());
+                            TranslateNode(keyValuePair.Value).EscapeBackSlashUriString()).ToArray());
                 }
             }
 
+            // composite keys or alternate key(s)
             return string.Join(
                 ",",
                 keyValuePairs.Select(keyValuePair =>
                     (keyValuePair.Key +
                      "=" +
-                     TranslateNode(keyValuePair.Value))).ToArray());
+                     TranslateNode(keyValuePair.Value).EscapeBackSlashUriString())).ToArray());
         }
 
         internal static string TranslateNode(object node)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Regressions/LocationHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Regressions/LocationHeaderTests.cs
@@ -1,0 +1,134 @@
+//-----------------------------------------------------------------------------
+// <copyright file="LocationHeaderTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Regressions
+{
+    public class LocationHeaderTests : WebApiTestBase<LocationHeaderTests>
+    {
+        public LocationHeaderTests(WebApiTestFixture<LocationHeaderTests> fixture)
+            : base(fixture)
+        {
+        }
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            IEdmModel edmModel = GetEdmModel();
+            services.ConfigureControllers(typeof(HandleController));
+            services.AddControllers().AddOData(opt => opt.AddRouteComponents("location", edmModel));
+        }
+
+        [Fact]
+        public async Task CreateCustomerWithSingleKey_ReturnsCorrectLocationHeaderEscapedUri()
+        {
+            // Arrange
+            string payload = @"{""Name"":""abc""}";
+            var postContent = new StringContent(payload);
+            postContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            postContent.Headers.ContentLength = payload.Length;
+
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.PostAsync("location/customers", postContent);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            Assert.True(response.Headers.Contains("Location"), "The response should contain Header 'Location'");
+
+            string locationHeader = response.Headers.GetValues("Location").Single();
+
+            Assert.Equal("http://localhost/location/Customers('abc%2F$+%2F-8')", locationHeader);
+        }
+
+        [Fact]
+        public async Task CreateOrderWithCompositeKey_ReturnsCorrectLocationHeaderEscapedUri()
+        {
+            // Arrange
+            string payload = @"{""Title"":""xzy""}";
+            var postContent = new StringContent(payload);
+            postContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            postContent.Headers.ContentLength = payload.Length;
+
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.PostAsync("location/orders", postContent);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            Assert.True(response.Headers.Contains("Location"), "The response should contain Header 'Location'");
+
+            string locationHeader = response.Headers.GetValues("Location").Single();
+
+            Assert.Equal("http://localhost/location/Orders(Id1='xzy%2F',Id2='%2Fxzy')", locationHeader);
+        }
+
+        public static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<LocCustomer>("Customers");
+            builder.EntitySet<LocOrder>("Orders");
+            return builder.GetEdmModel();
+        }
+    }
+
+    public class HandleController : ODataController
+    {
+        [HttpPost("location/customers")]
+        public IActionResult CreateCustomer([FromBody]LocCustomer customer)
+        {
+            customer.Id = $"{customer.Name}/$+/-8"; // insert slash middle
+            return Created(customer);
+        }
+
+        [HttpPost("location/orders")]
+        public IActionResult CreateOrder([FromBody] LocOrder order)
+        {
+            order.Id1 = $"{order.Title}/"; // append slash at end
+            order.Id2 = $"/{order.Title}"; // insert slash at beginning
+            return Created(order);
+        }
+    }
+
+    public class LocCustomer
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class LocOrder
+    {
+        [Key]
+        public string Id1 { get; set; }
+
+        [Key]
+        public string Id2 { get; set; }
+
+        public string Title { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Routing/ODataPathSegmentHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Routing/ODataPathSegmentHandlerTests.cs
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing
             // Arrange
             EdmEntityType entityType = new EdmEntityType("NS", "Entity");
             IEdmStructuralProperty key1 = entityType.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false));
-            IEdmStructuralProperty key2 = entityType.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false));
+            IEdmStructuralProperty key2 = entityType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
 
             entityType.AddKeys(key1, key2);
             IEnumerable<KeyValuePair<string, object>> keys = new KeyValuePair<string, object>[]
@@ -388,6 +388,28 @@ namespace Microsoft.AspNetCore.OData.Tests.Routing
 
             // Assert
             Assert.Equal("Id=4,Name='abc'", actual);
+        }
+
+        [Fact]
+        public void ConvertKeysToString_ConvertKeysValues_ShouldEscapeUriString()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Entity");
+            IEdmStructuralProperty key1 = entityType.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false));
+            IEdmStructuralProperty key2 = entityType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+
+            entityType.AddKeys(key1, key2);
+            IEnumerable<KeyValuePair<string, object>> keys = new KeyValuePair<string, object>[]
+            {
+                KeyValuePair.Create("Id", (object)4),
+                KeyValuePair.Create("Name", (object)"2425/&Foo")
+            };
+
+            // Act
+            string actual = ODataPathSegmentHandler.ConvertKeysToString(keys, entityType);
+
+            // Assert
+            Assert.Equal("Id=4,Name='2425%2F&Foo'", actual);
         }
 
         [Fact]


### PR DESCRIPTION
fixes #1212 

When a key value contains back slah '/', the link generated should escape this character. 