### PR TITLE
Fixes #1250: Enable query options on untyped properties

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
@@ -200,6 +200,16 @@ namespace Microsoft.AspNetCore.OData.Edm
                 case EdmTypeKind.TypeDefinition:
                     return new EdmTypeDefinitionReference((IEdmTypeDefinition)edmType, isNullable);
 
+                case EdmTypeKind.Untyped:
+                    if (isNullable)
+                    {
+                        return EdmUntypedStructuredTypeReference.NullableTypeReference;
+                    }
+                    else
+                    {
+                        return EdmUntypedStructuredTypeReference.NonNullableTypeReference;
+                    }
+
                 default:
                     throw Error.NotSupported(SRResources.EdmTypeNotSupported, edmType.ToTraceString());
             }

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/DefaultODataTypeMapperTests.cs
@@ -330,6 +330,30 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
             Assert.Same(typeof(MyColor), clrType);
         }
 
+
+        [Fact]
+        public void GetClrType_WorksAsExpected_ForUntypedType()
+        {
+            // 1) Arrange : using primitive untyped
+            IEdmType untypedType = EdmCoreModel.Instance.GetUntypedType();
+
+            // 1) Act & Assert
+            Type clrType = _mapper.GetClrType(EdmModel, untypedType, true, null);
+            Assert.Same(typeof(object), clrType);
+
+            clrType = _mapper.GetClrType(EdmModel, untypedType, false, null);
+            Assert.Same(typeof(object), clrType);
+
+            // 2) Arrange : using structured untyped
+            untypedType = EdmUntypedStructuredType.Instance;
+
+            // 2) Act & Assert
+            clrType = _mapper.GetClrType(EdmModel, untypedType, true, null);
+            Assert.Same(typeof(object), clrType);
+            clrType = _mapper.GetClrType(EdmModel, untypedType, false, null);
+            Assert.Same(typeof(object), clrType);
+        }
+
         #endregion
 
         #region GetEdmType
@@ -408,6 +432,14 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
             colorType = _mapper.GetEdmTypeReference(EdmModel, typeof(MyColor?));
             Assert.Same(expectedType, colorType.Definition);
             Assert.True(colorType.IsNullable);
+        }
+
+        [Fact]
+        public void GetEdmTypeReference_WorksAsExpected_FoUntypedTpe()
+        {
+            // Arrange & Act & Assert
+            IEdmTypeReference untyped = _mapper.GetEdmTypeReference(EdmModel, typeof(object));
+            Assert.Same(EdmUntypedStructuredType.Instance, untyped.Definition);
         }
         #endregion
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmHelpersTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmHelpersTests.cs
@@ -6,7 +6,6 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Data;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.AspNetCore.OData.Tests.Commons;
@@ -160,6 +159,8 @@ namespace Microsoft.AspNetCore.OData.Tests.Edm
                     { typeDefinition, false, typeof(IEdmTypeDefinitionReference) },
                     { entityReferenceType, true, typeof(IEdmEntityReferenceTypeReference) },
                     { entityReferenceType, true, typeof(IEdmEntityReferenceTypeReference) },
+                    { EdmUntypedStructuredType.Instance, true, typeof(IEdmUntypedTypeReference) },
+                    { EdmUntypedStructuredType.Instance, false, typeof(IEdmUntypedTypeReference) }
                 };
             }
         }


### PR DESCRIPTION
Treat the System.Object as EdmUntypedStructuredType
Treat EdmUntypedStructuredType as System.Object
Add test to cover the $filter, $select on untyped properties
Not covered the $orderby on untyped properties