### PR TITLE
Update ODL versions to 8.0.0-rc.1

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -877,8 +877,8 @@ namespace Microsoft.AspNetCore.OData.Formatter.Deserialization
             }
             else
             {
-                IDictionary<string, ODataProperty> newPropertiesDic = resourceWrapper.Resource.Properties.ToDictionary(p => p.Name, p => p);
-                foreach (ODataProperty key in keys)
+                IDictionary<string, ODataPropertyInfo> newPropertiesDic = resourceWrapper.Resource.Properties.ToDictionary(p => p.Name, p => p);
+                foreach (ODataPropertyInfo key in keys)
                 {
                     // Logic: if we have the key property, try to keep the key property and get rid of the key value from ID.
                     // Need to double confirm whether it is the right logic?

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -28,13 +28,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.ModelBuilder" Version="1.0.9" />
-    <PackageReference Include="Microsoft.OData.Core" Version="8.0.0-preview.3" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="8.0.0-preview.3" />
+    <PackageReference Include="Microsoft.OData.Core" Version="8.0.0-rc.1" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="8.0.0-rc.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Spatial" Version="8.0.0-preview.3" />
+    <PackageReference Include="Microsoft.Spatial" Version="8.0.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -1009,30 +1009,30 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Assert.Equal(6, resource.Properties.Count());
 
             // Verify the declared properties
-            ODataProperty street = Assert.Single(resource.Properties.Where(p => p.Name == "CustomerId"));
+            ODataProperty street = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "CustomerId"));
             Assert.Equal(991, street.Value);
 
-            ODataProperty city = Assert.Single(resource.Properties.Where(p => p.Name == "Name"));
+            ODataProperty city = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "Name"));
             Assert.Equal("Name #991", city.Value);
 
             // Verify the nested open complex property
             Assert.Empty(resource.Properties.Where(p => p.Name == "Address"));
 
             // Verify the dynamic properties
-            ODataProperty enumProperty = Assert.Single(resource.Properties.Where(p => p.Name == "EnumProperty"));
+            ODataProperty enumProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "EnumProperty"));
             ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(enumProperty.Value);
             Assert.Equal("Fourth", enumValue.Value);
             Assert.Equal("Default.SimpleEnum", enumValue.TypeName);
 
-            ODataProperty guidProperty = Assert.Single(resource.Properties.Where(p => p.Name == "GuidProperty"));
+            ODataProperty guidProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "GuidProperty"));
             Assert.Equal(new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"), guidProperty.Value);
 
-            ODataProperty listProperty = Assert.Single(resource.Properties.Where(p => p.Name == "ListProperty"));
+            ODataProperty listProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "ListProperty"));
             ODataCollectionValue collectionValue = Assert.IsType<ODataCollectionValue>(listProperty.Value);
             Assert.Equal(new List<int> { 5, 4, 3, 2, 1 }, collectionValue.Items.OfType<int>().ToList());
             Assert.Equal("Collection(Edm.Int32)", collectionValue.TypeName);
 
-            ODataProperty dateTimeProperty = Assert.Single(resource.Properties.Where(p => p.Name == "DateTimeProperty"));
+            ODataProperty dateTimeProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "DateTimeProperty"));
             Assert.Equal(new DateTimeOffset(dateTime), dateTimeProperty.Value);
         }
 
@@ -1101,20 +1101,20 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Assert.Equal(4, resource.Properties.Count());
 
             // Verify the declared properties
-            ODataProperty street = Assert.Single(resource.Properties.Where(p => p.Name == "CustomerId"));
+            ODataProperty street = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "CustomerId"));
             Assert.Equal(991, street.Value);
 
-            ODataProperty city = Assert.Single(resource.Properties.Where(p => p.Name == "Name"));
+            ODataProperty city = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "Name"));
             Assert.Equal("Name #991", city.Value);
 
             // Verify the nested open complex property
             Assert.Empty(resource.Properties.Where(p => p.Name == "Address"));
 
             // Verify the dynamic properties
-            ODataProperty guidProperty = Assert.Single(resource.Properties.Where(p => p.Name == "GuidProperty"));
+            ODataProperty guidProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "GuidProperty"));
             Assert.Equal(new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"), guidProperty.Value);
 
-            ODataProperty nullProperty = resource.Properties.Single(p => p.Name == "NullProperty");
+            ODataProperty nullProperty = resource.Properties.OfType<ODataProperty>().Single(p => p.Name == "NullProperty");
             Assert.Null(nullProperty.Value);
         }
 
@@ -1183,7 +1183,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Assert.Equal(3, resource.Properties.Count());
 
             // Verify properties with empty names are ignored
-            ODataProperty emptyProperty = resource.Properties.SingleOrDefault(p => p.Name == "");
+            ODataProperty emptyProperty = resource.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "");
             Assert.Null(emptyProperty);
         }
 
@@ -2333,7 +2333,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
 
                     // Assert
                     stream.Position = 0;
-                    using (StreamReader reader = new StreamReader(stream))
+                    using (StreamReader reader = new StreamReader(stream, leaveOpen: true))
                     {
                         string response = reader.ReadToEnd();
                         Assert.Contains(@"""ProductID"":1", response);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -1009,30 +1009,30 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Assert.Equal(6, resource.Properties.Count());
 
             // Verify the declared properties
-            ODataProperty street = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "CustomerId"));
+            ODataProperty street = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "CustomerId")));
             Assert.Equal(991, street.Value);
 
-            ODataProperty city = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "Name"));
+            ODataProperty city = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "Name")));
             Assert.Equal("Name #991", city.Value);
 
             // Verify the nested open complex property
             Assert.Empty(resource.Properties.Where(p => p.Name == "Address"));
 
             // Verify the dynamic properties
-            ODataProperty enumProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "EnumProperty"));
+            ODataProperty enumProperty = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "EnumProperty")));
             ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(enumProperty.Value);
             Assert.Equal("Fourth", enumValue.Value);
             Assert.Equal("Default.SimpleEnum", enumValue.TypeName);
 
-            ODataProperty guidProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "GuidProperty"));
+            ODataProperty guidProperty = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "GuidProperty")));
             Assert.Equal(new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"), guidProperty.Value);
 
-            ODataProperty listProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "ListProperty"));
+            ODataProperty listProperty = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "ListProperty")));
             ODataCollectionValue collectionValue = Assert.IsType<ODataCollectionValue>(listProperty.Value);
             Assert.Equal(new List<int> { 5, 4, 3, 2, 1 }, collectionValue.Items.OfType<int>().ToList());
             Assert.Equal("Collection(Edm.Int32)", collectionValue.TypeName);
 
-            ODataProperty dateTimeProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "DateTimeProperty"));
+            ODataProperty dateTimeProperty = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "DateTimeProperty")));
             Assert.Equal(new DateTimeOffset(dateTime), dateTimeProperty.Value);
         }
 
@@ -1101,17 +1101,17 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Serialization
             Assert.Equal(4, resource.Properties.Count());
 
             // Verify the declared properties
-            ODataProperty street = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "CustomerId"));
+            ODataProperty street = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "CustomerId")));
             Assert.Equal(991, street.Value);
 
-            ODataProperty city = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "Name"));
+            ODataProperty city = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "Name")));
             Assert.Equal("Name #991", city.Value);
 
             // Verify the nested open complex property
             Assert.Empty(resource.Properties.Where(p => p.Name == "Address"));
 
             // Verify the dynamic properties
-            ODataProperty guidProperty = Assert.Single(resource.Properties.OfType<ODataProperty>().Where(p => p.Name == "GuidProperty"));
+            ODataProperty guidProperty = Assert.IsType<ODataProperty>(Assert.Single(resource.Properties.Where(p => p.Name == "GuidProperty")));
             Assert.Equal(new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"), guidProperty.Value);
 
             ODataProperty nullProperty = resource.Properties.OfType<ODataProperty>().Single(p => p.Name == "NullProperty");

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             Assert.NotNull(item);
             ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
 
-            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties.OfType<ODataProperty>());
+            ODataProperty property = Assert.IsType<ODataProperty>(Assert.Single(resourceWrapper.Resource.Properties));
             // Declared property with 'Edm.Int32'
             Assert.Equal("ID", property.Name);
             Assert.Equal(17, property.Value);
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             Assert.NotNull(item);
             ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
 
-            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties.OfType<ODataProperty>());
+            ODataProperty property = Assert.IsType<ODataProperty>(Assert.Single(resourceWrapper.Resource.Properties));
             // Declared property with 'Edm.Int32'
             Assert.Equal("ID", property.Name);
             Assert.Equal(17, property.Value);
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                     Assert.Equal("NS.Info", p.Resource.TypeName);
 
                     Assert.Empty(p.NestedResourceInfos);
-                    ODataProperty property = Assert.Single(p.Resource.Properties.OfType<ODataProperty>());
+                    ODataProperty property = Assert.IsType<ODataProperty>(Assert.Single(p.Resource.Properties));
                     Assert.Equal("Key1", property.Name);
                     Assert.Equal("Value1", property.Value);
                 },

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.Untyped.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
             Assert.Empty(resourceWrapper.NestedResourceInfos);
 
-            Assert.Collection(resourceWrapper.Resource.Properties,
+            Assert.Collection(resourceWrapper.Resource.Properties.OfType<ODataProperty>(),
                 p =>
                 {
                     // Declared property with 'Edm.Int32'
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             Assert.NotNull(item);
             ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
 
-            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties);
+            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties.OfType<ODataProperty>());
             // Declared property with 'Edm.Int32'
             Assert.Equal("ID", property.Name);
             Assert.Equal(17, property.Value);
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                 Assert.Equal(n, p.NestedResourceInfo.Name);
                 ODataResourceWrapper nestedResourceWrapper = Assert.IsType<ODataResourceWrapper>(Assert.Single(p.NestedItems));
                 Assert.Empty(nestedResourceWrapper.NestedResourceInfos);
-                Assert.Collection(nestedResourceWrapper.Resource.Properties,
+                Assert.Collection(nestedResourceWrapper.Resource.Properties.OfType<ODataProperty>(),
                     p =>
                     {
                         Assert.Equal("Key1", p.Name);
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             Assert.NotNull(item);
             ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(item);
 
-            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties);
+            ODataProperty property = Assert.Single(resourceWrapper.Resource.Properties.OfType<ODataProperty>());
             // Declared property with 'Edm.Int32'
             Assert.Equal("ID", property.Name);
             Assert.Equal(17, property.Value);
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                     {
                         Assert.Empty(p.NestedResourceInfos);
                         Assert.NotNull(p.Resource);
-                        Assert.Collection(p.Resource.Properties,
+                        Assert.Collection(p.Resource.Properties.OfType<ODataProperty>(),
                             p =>
                             {
                                 Assert.Equal("Key1", p.Name);
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                         ODataResourceWrapper resourceWrapper = Assert.IsType<ODataResourceWrapper>(p);
                         Assert.Empty(resourceWrapper.NestedResourceInfos);
                         Assert.NotNull(resourceWrapper.Resource);
-                        Assert.Collection(resourceWrapper.Resource.Properties,
+                        Assert.Collection(resourceWrapper.Resource.Properties.OfType<ODataProperty>(),
                             p =>
                             {
                                 Assert.Equal("Key1", p.Name);
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                     Assert.Equal("NS.Info", p.Resource.TypeName);
 
                     Assert.Empty(p.NestedResourceInfos);
-                    ODataProperty property = Assert.Single(p.Resource.Properties);
+                    ODataProperty property = Assert.Single(p.Resource.Properties.OfType<ODataProperty>());
                     Assert.Equal("Key1", property.Name);
                     Assert.Equal("Value1", property.Value);
                 },

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Wrapper/ODataReaderExtensionsTests.cs
@@ -189,12 +189,12 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                 r =>
                 {
                     Assert.Equal("NS.Order", r.Resource.TypeName);
-                    Assert.Equal(82, r.Resource.Properties.First(p => p.Name == "Price").Value);
+                    Assert.Equal(82, r.Resource.Properties.OfType<ODataProperty>().First(p => p.Name == "Price").Value);
                 },
                 r =>
                 {
                     Assert.Equal("NS.VipOrder", r.Resource.TypeName);
-                    Assert.Equal("abc@efg.com", r.Resource.Properties.First(p => p.Name == "Email").Value);
+                    Assert.Equal("abc@efg.com", r.Resource.Properties.OfType<ODataProperty>().First(p => p.Name == "Email").Value);
                 });
         }
 
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
 
             ODataResourceWrapper resource2 = Assert.IsType<ODataResourceWrapper>(ordersDeltaResourceSet.DeltaItems.ElementAt(1));
             Assert.Equal("NS.VipOrder", resource2.Resource.TypeName);
-            Assert.Collection(resource2.Resource.Properties,
+            Assert.Collection(resource2.Resource.Properties.OfType<ODataProperty>(),
                 p =>
                 {
                     Assert.Equal("OrderId", p.Name);
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                     // 1) Resource
                     ODataResourceWrapper resource1 = Assert.IsType<ODataResourceWrapper>(e);
                     Assert.Equal("Customers(42)", resource1.Resource.Id.OriginalString);
-                    Assert.Equal("Sammy", resource1.Resource.Properties.First(p => p.Name == "Name").Value);
+                    Assert.Equal("Sammy", resource1.Resource.Properties.OfType<ODataProperty>().First(p => p.Name == "Name").Value);
                 },
                 e =>
                 {
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
                     // 4) Resource
                     ODataResourceWrapper resource2 = Assert.IsType<ODataResourceWrapper>(e);
                     Assert.Equal("Orders(10643)", resource2.Resource.Id.OriginalString);
-                    Assert.Equal(82, resource2.Resource.Properties.First(p => p.Name == "Price").Value);
+                    Assert.Equal(82, resource2.Resource.Properties.OfType<ODataProperty>().First(p => p.Name == "Price").Value);
                 },
                 e =>
                 {
@@ -418,7 +418,7 @@ namespace Microsoft.AspNetCore.OData.Tests.Formatter.Wrapper
             ODataDeletedResource innerDeletedResource = Assert.IsType<ODataDeletedResource>(orderResource.Resource);
             Assert.Equal(DeltaDeletedEntryReason.Deleted, innerDeletedResource.Reason);
 
-            ODataProperty property = Assert.Single(innerDeletedResource.Properties);
+            ODataProperty property = Assert.Single(innerDeletedResource.Properties.OfType<ODataProperty>());
             Assert.Equal("OrderId", property.Name);
             Assert.Equal(10, property.Value);
         }

--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -4,12 +4,12 @@
     <VersionMajor Condition="'$(VersionMajor)' == ''">9</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
     <VersionBuild Condition="'$(VersionBuild)' == ''">0</VersionBuild>
-    <VersionRelease Condition="'$(VersionRelease)' == ''">preview.2</VersionRelease>
+    <VersionRelease Condition="'$(VersionRelease)' == ''">rc.1</VersionRelease>
   </PropertyGroup>
   
     <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
-    <ODataLibPackageDependency>[8.0.0-preview.3, 9.0.0)</ODataLibPackageDependency>
+    <ODataLibPackageDependency>[8.0.0-rc.1, 9.0.0)</ODataLibPackageDependency>
     <ODataModelBuilderPackageDependency>[1.0.9, 2.0.0)</ODataModelBuilderPackageDependency>
   </PropertyGroup>
 


### PR DESCRIPTION
Updated the ODL version to `8.0.0-rc.1`. Since `8.0.0-rc.1` had some breaking changes, I've also made some updates like: 

1. Updating `ODataResource.Properties` to a collection of `ODataPropertyInfo`