### PR TITLE
Add .NET Core SDK 8.x to Pipeline for release8.x branch

### DIFF
--- a/pipelines/azure_pipelines.yml
+++ b/pipelines/azure_pipelines.yml
@@ -64,6 +64,11 @@ extends:
           inputs:
             version: 6.x
             includePreviewVersions: true
+        - task: UseDotNet@2
+          displayName: Use .NET Core sdk 8.x
+          inputs:
+            version: 8.x
+            includePreviewVersions: true
         - task: DotNetCoreCLI@2
           displayName: build Microsoft.AspNetCore.OData
           inputs:

--- a/pipelines/azure_pipelines_nightly.yml
+++ b/pipelines/azure_pipelines_nightly.yml
@@ -80,6 +80,11 @@ extends:
           inputs:
             version: 6.x
             includePreviewVersions: true
+        - task: UseDotNet@2
+          displayName: Use .NET Core sdk 8.x
+          inputs:
+            version: 8.x
+            includePreviewVersions: true
         - task: DotNetCoreCLI@2
           displayName: Build Microsoft.AspNetCore.OData
           inputs:


### PR DESCRIPTION
This pull request adds a new task to the pipeline to use the .NET Core SDK version 8.x. The task configuration includes the following:

```yaml
  - task: UseDotNet@2
      displayName: Use .NET Core sdk 8.x
      inputs:
        version: 8.x
        includePreviewVersions: true
```

This update ensures that the pipeline can support .NET Core 8.x changes.