### PR TITLE
Fix/datetime filter fix

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -101,8 +101,9 @@ internal static class EdmPrimitiveHelper
             }
             else if (type == typeof(DateTime))
             {
-                if (value is DateTimeOffset dateTimeOffsetValue)
+                if (value is DateTimeOffset)
                 {
+                    DateTimeOffset dateTimeOffsetValue = (DateTimeOffset)value;
                     TimeZoneInfo timeZone = timeZoneInfo ?? TimeZoneInfo.Local;
                     dateTimeOffsetValue = TimeZoneInfo.ConvertTime(dateTimeOffsetValue, timeZone);
                     return DateTime.SpecifyKind(dateTimeOffsetValue.DateTime, DateTimeKind.Utc);

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -105,8 +105,12 @@ internal static class EdmPrimitiveHelper
                 {
                     DateTimeOffset dateTimeOffsetValue = (DateTimeOffset)value;
                     TimeZoneInfo timeZone = timeZoneInfo ?? TimeZoneInfo.Local;
+
                     dateTimeOffsetValue = TimeZoneInfo.ConvertTime(dateTimeOffsetValue, timeZone);
-                    return DateTime.SpecifyKind(dateTimeOffsetValue.DateTime, DateTimeKind.Utc);
+
+                    var dateTimeKind = GetTargetDateTimeKind(timeZone);
+
+                    return DateTime.SpecifyKind(dateTimeOffsetValue.DateTime, dateTimeKind);
                 }
 
                 if (value is Date)
@@ -182,5 +186,16 @@ internal static class EdmPrimitiveHelper
                 }
             }
         }
+    }
+
+    private static DateTimeKind GetTargetDateTimeKind(TimeZoneInfo timeZone)
+    {
+        if (timeZone.Equals(TimeZoneInfo.Local))
+            return DateTimeKind.Local;
+
+        if (timeZone.Equals(TimeZoneInfo.Utc))
+            return DateTimeKind.Utc;
+
+        return DateTimeKind.Unspecified;
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -101,12 +101,11 @@ internal static class EdmPrimitiveHelper
             }
             else if (type == typeof(DateTime))
             {
-                if (value is DateTimeOffset)
+                if (value is DateTimeOffset dateTimeOffsetValue)
                 {
-                    DateTimeOffset dateTimeOffsetValue = (DateTimeOffset)value;
                     TimeZoneInfo timeZone = timeZoneInfo ?? TimeZoneInfo.Local;
                     dateTimeOffsetValue = TimeZoneInfo.ConvertTime(dateTimeOffsetValue, timeZone);
-                    return dateTimeOffsetValue.DateTime;
+                    return DateTime.SpecifyKind(dateTimeOffsetValue.DateTime, DateTimeKind.Utc);
                 }
 
                 if (value is Date)

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -190,11 +190,11 @@ internal static class EdmPrimitiveHelper
 
     private static DateTimeKind GetTargetDateTimeKind(TimeZoneInfo timeZone)
     {
-        if (timeZone.Equals(TimeZoneInfo.Local))
-            return DateTimeKind.Local;
-
         if (timeZone.Equals(TimeZoneInfo.Utc))
             return DateTimeKind.Utc;
+
+        if (timeZone.Equals(TimeZoneInfo.Local))
+            return DateTimeKind.Local;
 
         return DateTimeKind.Unspecified;
     }

--- a/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmPrimitiveHelper.cs
@@ -108,7 +108,7 @@ internal static class EdmPrimitiveHelper
 
                     dateTimeOffsetValue = TimeZoneInfo.ConvertTime(dateTimeOffsetValue, timeZone);
 
-                    var dateTimeKind = GetTargetDateTimeKind(timeZone);
+                    DateTimeKind dateTimeKind = GetTargetDateTimeKind(timeZone);
 
                     return DateTime.SpecifyKind(dateTimeOffsetValue.DateTime, dateTimeKind);
                 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayWithEfTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayWithEfTest.cs
@@ -189,6 +189,7 @@ public class DateAndTimeOfDayWithEfTest : WebApiTestBase<DateAndTimeOfDayWithEfT
     [InlineData("?$filter=PublishDay ne 2016-03-22", "1,3,4,5")]
     [InlineData("?$filter=PublishDay lt 2016-03-22", "4")]
     [InlineData("?$filter=EndTime ne null", "1,3,5")]
+    [InlineData($"?$filter=LastAction eq {DateAndTimeOfDayWithEfTestConstants.DefaultLastActionValue}", "1,2,3,4,5")]
     // [InlineData("?$filter=CreatedTime eq 04:03:05.0790000", "4")] // EFCore could not be translated.
     // [InlineData("?$filter=hour(EndTime) eq 11", "1")] // EFCore could not be translated.
     // [InlineData("?$filter=minute(EndTime) eq 06", "3")] // EFCore could not be translated.
@@ -308,7 +309,9 @@ public class DateAndTimeOfDayModelsController : ODataController
 
     public DateAndTimeOfDayModelsController(EfDateAndTimeOfDayModelContext context)
     {
+        context.Database.EnsureDeleted();
         context.Database.EnsureCreated();
+
         if (!context.DateTimes.Any())
         {
             DateTime dt = new DateTime(2015, 12, 22);
@@ -318,6 +321,7 @@ public class DateAndTimeOfDayModelsController : ODataController
                 {
                    // Id = i,
                     Birthday = dt.AddYears(i),
+                    LastAction = DateTime.Parse(DateAndTimeOfDayWithEfTestConstants.DefaultLastActionValue),
                     EndDay = dt.AddDays(i),
                     DeliverDay = i % 2 == 0 ? (DateTime?)null : dt.AddYears(5 - i),
                     PublishDay = i % 2 != 0 ? (DateTime?)null : dt.AddMonths(5 - i),
@@ -355,7 +359,7 @@ public class DateAndTimeOfDayModelsController : ODataController
         return Ok(dtm);
     }
 
-    public IActionResult Post([FromBody]DateAndTimeOfDayModel dt)
+    public IActionResult Post([FromBody] DateAndTimeOfDayModel dt)
     {
         Assert.NotNull(dt);
 
@@ -367,7 +371,7 @@ public class DateAndTimeOfDayModelsController : ODataController
         return Created(dt);
     }
 
-    public IActionResult Put(int key, [FromBody]Delta<DateAndTimeOfDayModel> dt)
+    public IActionResult Put(int key, [FromBody] Delta<DateAndTimeOfDayModel> dt)
     {
         Assert.Equal(new[] { "Birthday", "CreatedTime" }, dt.GetChangedPropertyNames());
 
@@ -411,6 +415,9 @@ public class DateAndTimeOfDayModel
     [Column(TypeName = "date")]
     public DateTime Birthday { get; set; }
 
+    [Column(TypeName = "datetime")]
+    public DateTime LastAction { get; set; }
+
     [Column(TypeName = "DaTe")]
     public DateTime? PublishDay { get; set; }
 
@@ -425,4 +432,9 @@ public class DateAndTimeOfDayModel
     public TimeSpan? EndTime { get; set; }
 
     public TimeSpan ResumeTime { get; set; } // will use the Fluent API
+}
+
+internal static class DateAndTimeOfDayWithEfTestConstants
+{
+    internal const string DefaultLastActionValue = "2024-11-27T15:06:35Z";
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayWithEfTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayWithEfTest.cs
@@ -189,7 +189,6 @@ public class DateAndTimeOfDayWithEfTest : WebApiTestBase<DateAndTimeOfDayWithEfT
     [InlineData("?$filter=PublishDay ne 2016-03-22", "1,3,4,5")]
     [InlineData("?$filter=PublishDay lt 2016-03-22", "4")]
     [InlineData("?$filter=EndTime ne null", "1,3,5")]
-    [InlineData($"?$filter=LastAction eq {DateAndTimeOfDayWithEfTestConstants.DefaultLastActionValue}", "1,2,3,4,5")]
     // [InlineData("?$filter=CreatedTime eq 04:03:05.0790000", "4")] // EFCore could not be translated.
     // [InlineData("?$filter=hour(EndTime) eq 11", "1")] // EFCore could not be translated.
     // [InlineData("?$filter=minute(EndTime) eq 06", "3")] // EFCore could not be translated.
@@ -309,9 +308,7 @@ public class DateAndTimeOfDayModelsController : ODataController
 
     public DateAndTimeOfDayModelsController(EfDateAndTimeOfDayModelContext context)
     {
-        context.Database.EnsureDeleted();
         context.Database.EnsureCreated();
-
         if (!context.DateTimes.Any())
         {
             DateTime dt = new DateTime(2015, 12, 22);
@@ -321,7 +318,6 @@ public class DateAndTimeOfDayModelsController : ODataController
                 {
                    // Id = i,
                     Birthday = dt.AddYears(i),
-                    LastAction = DateTime.Parse(DateAndTimeOfDayWithEfTestConstants.DefaultLastActionValue),
                     EndDay = dt.AddDays(i),
                     DeliverDay = i % 2 == 0 ? (DateTime?)null : dt.AddYears(5 - i),
                     PublishDay = i % 2 != 0 ? (DateTime?)null : dt.AddMonths(5 - i),
@@ -359,7 +355,7 @@ public class DateAndTimeOfDayModelsController : ODataController
         return Ok(dtm);
     }
 
-    public IActionResult Post([FromBody] DateAndTimeOfDayModel dt)
+    public IActionResult Post([FromBody]DateAndTimeOfDayModel dt)
     {
         Assert.NotNull(dt);
 
@@ -371,7 +367,7 @@ public class DateAndTimeOfDayModelsController : ODataController
         return Created(dt);
     }
 
-    public IActionResult Put(int key, [FromBody] Delta<DateAndTimeOfDayModel> dt)
+    public IActionResult Put(int key, [FromBody]Delta<DateAndTimeOfDayModel> dt)
     {
         Assert.Equal(new[] { "Birthday", "CreatedTime" }, dt.GetChangedPropertyNames());
 
@@ -415,9 +411,6 @@ public class DateAndTimeOfDayModel
     [Column(TypeName = "date")]
     public DateTime Birthday { get; set; }
 
-    [Column(TypeName = "datetime")]
-    public DateTime LastAction { get; set; }
-
     [Column(TypeName = "DaTe")]
     public DateTime? PublishDay { get; set; }
 
@@ -432,9 +425,4 @@ public class DateAndTimeOfDayModel
     public TimeSpan? EndTime { get; set; }
 
     public TimeSpan ResumeTime { get; set; } // will use the Fluent API
-}
-
-internal static class DateAndTimeOfDayWithEfTestConstants
-{
-    internal const string DefaultLastActionValue = "2024-11-27T15:06:35Z";
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -154,6 +154,8 @@ public class EdmPrimitiveHelperTests
         //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
         //and do not accept Local and Unspecified in the new versions of the framework
 
+        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
+
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -128,11 +128,6 @@ public class EdmPrimitiveHelperTests
     [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
     public void ConvertDateTimeValue_ImplicitKind(DateTimeOffset valueToConvert)
     {
-        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
-        //and do not accept Local and Unspecified in the new versions of the framework
-
-        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
-
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
 
@@ -145,11 +140,6 @@ public class EdmPrimitiveHelperTests
     [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
     public void ConvertDateTimeValue_ExplicitLocalKind(DateTimeOffset valueToConvert)
     {
-        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
-        //and do not accept Local and Unspecified in the new versions of the framework
-
-        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
-
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime), TimeZoneInfo.Local);
 
@@ -162,11 +152,6 @@ public class EdmPrimitiveHelperTests
     [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
     public void ConvertDateTimeValue_ExplicitUtcKind(DateTimeOffset valueToConvert)
     {
-        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
-        //and do not accept Local and Unspecified in the new versions of the framework
-
-        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
-
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime), TimeZoneInfo.Utc);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -94,7 +94,7 @@ public class EdmPrimitiveHelperTests
 
     [Theory]
     [MemberData(nameof(ConvertPrimitiveValue_NonStandardPrimitives_Data))]
-    [MemberData(nameof(ConvertPrimitiveValue_NonStandardPrimitives_ExtraData))] 
+    [MemberData(nameof(ConvertPrimitiveValue_NonStandardPrimitives_ExtraData))]
     public void ConvertPrimitiveValue_NonStandardPrimitives(object valueToConvert, object result, Type conversionType)
     {
         // Arrange & Act
@@ -145,5 +145,21 @@ public class EdmPrimitiveHelperTests
         ExceptionAssert.Throws<ValidationException>(
             () => EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, conversionType),
             exception);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
+    public void ConvertDateTimeValue_ExplicitUtc(DateTimeOffset valueToConvert)
+    {
+        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
+        //and do not accept Local and Unspecified in the new versions of the framework
+
+        // Arrange & Act
+        object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
+
+        // Assert
+        DateTime dt = Assert.IsType<DateTime>(actual);
+        Assert.Equal(valueToConvert.LocalDateTime, dt);
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -126,6 +126,23 @@ public class EdmPrimitiveHelperTests
 
     [Theory]
     [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
+    public void ConvertDateTimeValue_ExplicitUtc(DateTimeOffset valueToConvert)
+    {
+        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
+        //and do not accept Local and Unspecified in the new versions of the framework
+
+        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
+
+        // Arrange & Act
+        object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
+
+        // Assert
+        DateTime dt = Assert.IsType<DateTime>(actual);
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
     public void ConvertDateTimeValue_NonStandardPrimitives_CustomTimeZoneInfo(DateTimeOffset valueToConvert)
     {
         // Arrange & Act
@@ -145,23 +162,5 @@ public class EdmPrimitiveHelperTests
         ExceptionAssert.Throws<ValidationException>(
             () => EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, conversionType),
             exception);
-    }
-
-    [Theory]
-    [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
-    public void ConvertDateTimeValue_ExplicitUtc(DateTimeOffset valueToConvert)
-    {
-        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
-        //and do not accept Local and Unspecified in the new versions of the framework
-
-        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
-
-        // Arrange & Act
-        object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
-
-        // Assert
-        DateTime dt = Assert.IsType<DateTime>(actual);
-        Assert.Equal(valueToConvert.LocalDateTime, dt);
-        Assert.Equal(DateTimeKind.Utc, dt.Kind);
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -143,9 +143,14 @@ public class EdmPrimitiveHelperTests
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime), TimeZoneInfo.Local);
 
+        //if server local time is UTC, then expect Utc Kind
+        DateTimeKind expectedTimeKind = TimeZoneInfo.Local.Equals(TimeZoneInfo.Utc)
+            ? DateTimeKind.Utc
+            : DateTimeKind.Local;
+
         // Assert
         DateTime dt = Assert.IsType<DateTime>(actual);
-        Assert.Equal(DateTimeKind.Local, dt.Kind);
+        Assert.Equal(expectedTimeKind, dt.Kind);
     }
 
     [Theory]

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -131,6 +131,11 @@ public class EdmPrimitiveHelperTests
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
 
+        //if server local time is UTC, then expect Utc Kind
+        DateTimeKind expectedTimeKind = TimeZoneInfo.Local.Equals(TimeZoneInfo.Utc)
+            ? DateTimeKind.Utc
+            : DateTimeKind.Local;
+
         // Assert
         DateTime dt = Assert.IsType<DateTime>(actual);
         Assert.Equal(DateTimeKind.Local, dt.Kind);

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -138,7 +138,7 @@ public class EdmPrimitiveHelperTests
 
         // Assert
         DateTime dt = Assert.IsType<DateTime>(actual);
-        Assert.Equal(DateTimeKind.Local, dt.Kind);
+        Assert.Equal(expectedTimeKind, dt.Kind);
     }
 
     [Theory]

--- a/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Edm/EdmPrimitiveHelperTests.cs
@@ -126,7 +126,7 @@ public class EdmPrimitiveHelperTests
 
     [Theory]
     [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
-    public void ConvertDateTimeValue_ExplicitUtc(DateTimeOffset valueToConvert)
+    public void ConvertDateTimeValue_ImplicitKind(DateTimeOffset valueToConvert)
     {
         //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
         //and do not accept Local and Unspecified in the new versions of the framework
@@ -135,6 +135,40 @@ public class EdmPrimitiveHelperTests
 
         // Arrange & Act
         object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime));
+
+        // Assert
+        DateTime dt = Assert.IsType<DateTime>(actual);
+        Assert.Equal(DateTimeKind.Local, dt.Kind);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
+    public void ConvertDateTimeValue_ExplicitLocalKind(DateTimeOffset valueToConvert)
+    {
+        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
+        //and do not accept Local and Unspecified in the new versions of the framework
+
+        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
+
+        // Arrange & Act
+        object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime), TimeZoneInfo.Local);
+
+        // Assert
+        DateTime dt = Assert.IsType<DateTime>(actual);
+        Assert.Equal(DateTimeKind.Local, dt.Kind);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertDateTime_NonStandardPrimitives_Data))]
+    public void ConvertDateTimeValue_ExplicitUtcKind(DateTimeOffset valueToConvert)
+    {
+        //Some databases (for example, Npgsql) require an explicit indication of Kind = Utc
+        //and do not accept Local and Unspecified in the new versions of the framework
+
+        //example: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported
+
+        // Arrange & Act
+        object actual = EdmPrimitiveHelper.ConvertPrimitiveValue(valueToConvert, typeof(DateTime), TimeZoneInfo.Utc);
 
         // Assert
         DateTime dt = Assert.IsType<DateTime>(actual);


### PR DESCRIPTION
fix error:
Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported

also:
Fixes https://github.com/OData/AspNetCoreOData/issues/1223
Fixes https://github.com/OData/AspNetCoreOData/pull/1033
Fixes https://github.com/OData/AspNetCoreOData/issues/378