### PR TITLE
Add dynamic properties support for any, all and in operators

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -7703,6 +7703,11 @@
               Looks up a localized string similar to The type &apos;{0}&apos; must be an enum or Nullable&lt;T&gt; where T is an enum type..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.TypeMustBeOpenType">
+            <summary>
+              Looks up a localized string similar to The type &apos;{0}&apos; must be an open type. The dynamic properties container property is only expected on open types..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.TypeMustBeRelated">
             <summary>
               Looks up a localized string similar to The type &apos;{0}&apos; does not inherit from and is not a base type of &apos;{1}&apos;..
@@ -9236,6 +9241,15 @@
             <param name="context">The query binder context.</param>
             <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindCollectionOpenPropertyAccessNode(Microsoft.OData.UriParser.CollectionOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Binds a <see cref="T:Microsoft.OData.UriParser.CollectionPropertyAccessNode"/> to create a LINQ <see cref="T:System.Linq.Expressions.Expression"/> that
+            represents the semantics of the <see cref="T:Microsoft.OData.UriParser.CollectionPropertyAccessNode"/>.
+            </summary>
+            <param name="openPropertyAccessNode">The query node to bind.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindDynamicPropertyAccessQueryNode(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>
             Binds a <see cref="T:Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode"/> to create a LINQ <see cref="T:System.Linq.Expressions.Expression"/> that
@@ -9397,11 +9411,11 @@
             <param name="context">The query binder context.</param>
             <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.GetDynamicPropertyContainer(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.GetDynamicPropertyContainer(Microsoft.OData.UriParser.SingleValueNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>
             Gets property for dynamic properties dictionary.
             </summary>
-            <param name="openNode"></param>
+            <param name="sourceNode">The source node.</param>
             <param name="context">The query binder context.</param>
             <returns>Returns CLR property for dynamic properties container.</returns>
         </member>
@@ -9412,6 +9426,15 @@
             <param name="propertyPath">The property path.</param>
             <param name="context">The query binder context.</param>
             <returns>Returns null if no aggregations were used so far</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindPropertyAccessExpression(Microsoft.OData.UriParser.SingleValueNode,System.Reflection.PropertyInfo,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Binds property to the source node.
+            </summary>
+            <param name="sourceNode">The source node.</param>
+            <param name="prop">The property.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.ApplyNullPropagationForFilterBody(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -1798,6 +1798,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type &apos;{0}&apos; must be an open type. The dynamic properties container property is only expected on open types..
+        /// </summary>
+        internal static string TypeMustBeOpenType {
+            get {
+                return ResourceManager.GetString("TypeMustBeOpenType", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; does not inherit from and is not a base type of &apos;{1}&apos;..
         /// </summary>
         internal static string TypeMustBeRelated {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -186,6 +186,9 @@
   <data name="TypeMustBeEnumOrNullableEnum" xml:space="preserve">
     <value>The type '{0}' must be an enum or Nullable&lt;T&gt; where T is an enum type.</value>
   </data>
+  <data name="TypeMustBeOpenType" xml:space="preserve">
+    <value>The type '{0}' must be an open type. The dynamic properties container property is only expected on open types.</value>
+  </data>
   <data name="EdmTypeNotSupported" xml:space="preserve">
     <value>{0} is not a supported EDM type.</value>
   </data>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-﻿
+﻿static Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.GetDynamicPropertyContainer(Microsoft.OData.UriParser.SingleValueNode source, Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext context) -> System.Reflection.PropertyInfo
+virtual Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindCollectionOpenPropertyAccessNode(Microsoft.OData.UriParser.CollectionOpenPropertyAccessNode openPropertyAccessNode, Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext context) -> System.Linq.Expressions.Expression

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -97,6 +97,9 @@ public abstract partial class QueryBinder
             case QueryNodeKind.CollectionPropertyAccess:
                 return BindCollectionPropertyAccessNode(node as CollectionPropertyAccessNode, context);
 
+            case QueryNodeKind.CollectionOpenPropertyAccess:
+                return BindCollectionOpenPropertyAccessNode(node as CollectionOpenPropertyAccessNode, context);
+
             case QueryNodeKind.CollectionComplexNode:
                 return BindCollectionComplexNode(node as CollectionComplexNode, context);
 
@@ -108,7 +111,6 @@ public abstract partial class QueryBinder
 
             case QueryNodeKind.CollectionFunctionCall:
             case QueryNodeKind.CollectionResourceFunctionCall:
-            case QueryNodeKind.CollectionOpenPropertyAccess:
             default:
                 throw Error.NotSupported(SRResources.QueryNodeBindingNotSupported, node.Kind, typeof(QueryBinder).Name);
         }
@@ -277,6 +279,76 @@ public abstract partial class QueryBinder
     }
 
     /// <summary>
+    /// Binds a <see cref="CollectionPropertyAccessNode"/> to create a LINQ <see cref="Expression"/> that
+    /// represents the semantics of the <see cref="CollectionPropertyAccessNode"/>.
+    /// </summary>
+    /// <param name="openPropertyAccessNode">The query node to bind.</param>
+    /// <param name="context">The query binder context.</param>
+    /// <returns>The LINQ <see cref="Expression"/> created.</returns>
+    public virtual Expression BindCollectionOpenPropertyAccessNode(CollectionOpenPropertyAccessNode openPropertyAccessNode, QueryBinderContext context)
+    {
+        CheckArgumentNull(openPropertyAccessNode, context);
+
+        if (context.ElementClrType.IsDynamicTypeWrapper())
+        {
+            return GetFlattenedPropertyExpression(openPropertyAccessNode.Name, context) ?? Expression.Property(
+                Bind(openPropertyAccessNode.Source, context), openPropertyAccessNode.Name);
+        }
+
+        if (context.ComputedProperties.TryGetValue(openPropertyAccessNode.Name, out ComputeExpression computedProperty))
+        {
+            return Bind(computedProperty.Expression, context);
+        }
+
+        PropertyInfo containerProperty = GetDynamicPropertyContainer(openPropertyAccessNode.Source, context);
+
+        Expression containerPropertyAccessExpression = BindPropertyAccessExpression(openPropertyAccessNode.Source, containerProperty, context);
+
+        IndexExpression readDictionaryIndexerExpression = Expression.Property(containerPropertyAccessExpression,
+            DictionaryStringObjectIndexerName, Expression.Constant(openPropertyAccessNode.Name));
+
+        // Check if value from dictionary is IEnumerable
+        Expression enumerableCheckExpression = Expression.TypeIs(readDictionaryIndexerExpression, typeof(IEnumerable));
+
+        // Cast to IEnumerable - if check passes
+        Expression castToEnumerableExpression = Expression.Convert(readDictionaryIndexerExpression, typeof(IEnumerable));
+
+        // Method call expression for ((IEnumerable)value).Cast<object>()
+        MethodCallExpression castMethodCallExpression = Expression.Call(
+            ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(typeof(object)),
+            castToEnumerableExpression);
+
+        // Return null if not IEnumerable
+        Expression defaultNullExpression = Expression.Convert(Expression.Constant(null), typeof(IEnumerable<object>));
+
+        // Conditional expression to return 'null' if value is not IEnumerable, else perform Cast<object>()
+        Expression conditionalCastExpression = Expression.Condition(
+            enumerableCheckExpression,
+            castMethodCallExpression,
+            defaultNullExpression);
+
+        Expression containsKeyExpression = Expression.Call(containerPropertyAccessExpression,
+            containerPropertyAccessExpression.Type.GetMethod("ContainsKey"), Expression.Constant(openPropertyAccessNode.Name));
+
+        if (context.QuerySettings.HandleNullPropagation == HandleNullPropagationOption.True)
+        {
+            var dynamicDictIsNotNull = Expression.NotEqual(containerPropertyAccessExpression, Expression.Constant(null));
+            var dynamicDictIsNotNullAndContainsKey = Expression.AndAlso(dynamicDictIsNotNull, containsKeyExpression);
+            return Expression.Condition(
+                dynamicDictIsNotNullAndContainsKey,
+                conditionalCastExpression,
+                defaultNullExpression);
+        }
+        else
+        {
+            return Expression.Condition(
+                containsKeyExpression,
+                conditionalCastExpression,
+                defaultNullExpression);
+        }
+    }
+
+    /// <summary>
     /// Binds a <see cref="SingleValueOpenPropertyAccessNode"/> to create a LINQ <see cref="Expression"/> that
     /// represents the semantics of the <see cref="SingleValueOpenPropertyAccessNode"/>.
     /// </summary>
@@ -297,9 +369,9 @@ public abstract partial class QueryBinder
             return Bind(computedProperty.Expression, context);
         }
 
-        PropertyInfo prop = GetDynamicPropertyContainer(openNode, context);
+        PropertyInfo prop = GetDynamicPropertyContainer(openNode.Source, context);
 
-        var propertyAccessExpression = BindPropertyAccessExpression(openNode, prop, context);
+        var propertyAccessExpression = BindPropertyAccessExpression(openNode.Source, prop, context);
         var readDictionaryIndexerExpression = Expression.Property(propertyAccessExpression,
             DictionaryStringObjectIndexerName, Expression.Constant(openNode.Name));
         var containsKeyExpression = Expression.Call(propertyAccessExpression,
@@ -978,14 +1050,14 @@ public abstract partial class QueryBinder
     /// <summary>
     /// Gets property for dynamic properties dictionary.
     /// </summary>
-    /// <param name="openNode"></param>
+    /// <param name="sourceNode">The source node.</param>
     /// <param name="context">The query binder context.</param>
     /// <returns>Returns CLR property for dynamic properties container.</returns>
-    protected static PropertyInfo GetDynamicPropertyContainer(SingleValueOpenPropertyAccessNode openNode, QueryBinderContext context)
+    protected static PropertyInfo GetDynamicPropertyContainer(SingleValueNode sourceNode, QueryBinderContext context)
     {
-        if (openNode == null)
+        if (sourceNode == null)
         {
-            throw Error.ArgumentNull(nameof(openNode));
+            throw Error.ArgumentNull(nameof(sourceNode));
         }
 
         if (context == null)
@@ -994,7 +1066,7 @@ public abstract partial class QueryBinder
         }
 
         IEdmStructuredType edmStructuredType;
-        IEdmTypeReference edmTypeReference = openNode.Source.TypeReference;
+        IEdmTypeReference edmTypeReference = sourceNode.TypeReference;
         if (edmTypeReference.IsEntity())
         {
             edmStructuredType = edmTypeReference.AsEntity().EntityDefinition();
@@ -1005,7 +1077,12 @@ public abstract partial class QueryBinder
         }
         else
         {
-            throw Error.NotSupported(SRResources.QueryNodeBindingNotSupported, openNode.Kind, typeof(QueryBinder).Name);
+            throw Error.NotSupported(SRResources.QueryNodeBindingNotSupported, sourceNode.Kind, typeof(QueryBinder).Name);
+        }
+
+        if (!edmStructuredType.IsOpen)
+        {
+            throw Error.NotSupported(SRResources.TypeMustBeOpenType, edmStructuredType.FullTypeName());
         }
 
         return context.Model.GetDynamicPropertyDictionary(edmStructuredType);
@@ -1322,6 +1399,11 @@ public abstract partial class QueryBinder
             constantType = Nullable.GetUnderlyingType(constantType) ?? constantType;
         }
 
+        if (edmTypeReference != null && edmTypeReference.IsUntyped())
+        {
+            constantType = typeof(object);
+        }
+
         return constantType;
     }
 
@@ -1409,10 +1491,19 @@ public abstract partial class QueryBinder
         }
     }
 
-    private Expression BindPropertyAccessExpression(SingleValueOpenPropertyAccessNode openNode, PropertyInfo prop, QueryBinderContext context)
+    /// <summary>
+    /// Binds property to the source node.
+    /// </summary>
+    /// <param name="sourceNode">The source node.</param>
+    /// <param name="prop">The property.</param>
+    /// <param name="context">The query binder context.</param>
+    /// <returns>The LINQ <see cref="Expression"/> created.</returns>
+    private Expression BindPropertyAccessExpression(SingleValueNode sourceNode, PropertyInfo prop, QueryBinderContext context)
     {
-        var source = Bind(openNode.Source, context);
+        Expression source = Bind(sourceNode, context);
+
         Expression propertyAccessExpression;
+
         if (context.QuerySettings.HandleNullPropagation == HandleNullPropagationOption.True &&
             ExpressionBinderHelper.IsNullable(source.Type) && source != context.CurrentParameter)
         {
@@ -1422,6 +1513,7 @@ public abstract partial class QueryBinder
         {
             propertyAccessExpression = Expression.Property(source, prop.Name);
         }
+
         return propertyAccessExpression;
     }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinderContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinderContext.cs
@@ -235,7 +235,18 @@ public class QueryBinderContext
                 }
             }
 
-            ParameterExpression parameter = Expression.Parameter(Model.GetClrType(edmTypeReference, AssembliesResolver), rangeVariable.Name);
+            Type clrType = null;
+            if (edmTypeReference != null)
+            {
+                clrType = Model.GetClrType(edmTypeReference, AssembliesResolver);
+            }
+            else
+            {
+                // Edm type reference will be null in a dynamic property scenario
+                clrType = typeof(object);
+            }
+
+            ParameterExpression parameter = Expression.Parameter(clrType, rangeVariable.Name);
             Contract.Assert(lambdaIt == null, "There can be only one parameter in an Any/All lambda");
             lambdaIt = parameter;
 

--- a/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Validator/FilterQueryValidator.cs
@@ -617,6 +617,10 @@ public class FilterQueryValidator : IFilterQueryValidator
                 ValidateCollectionPropertyAccessNode(propertyAccessNode, validatorContext);
                 break;
 
+            case QueryNodeKind.CollectionOpenPropertyAccess:
+                // No identified validations for collection-valued open property yet
+                break;
+
             case QueryNodeKind.CollectionComplexNode:
                 CollectionComplexNode collectionComplexNode = node as CollectionComplexNode;
                 ValidateCollectionComplexNode(collectionComplexNode, validatorContext);
@@ -633,7 +637,6 @@ public class FilterQueryValidator : IFilterQueryValidator
 
             case QueryNodeKind.CollectionFunctionCall:
             case QueryNodeKind.CollectionResourceFunctionCall:
-            case QueryNodeKind.CollectionOpenPropertyAccess:
             // Unused or have unknown uses.
             default:
                 throw Error.NotSupported(SRResources.QueryNodeValidationNotSupported, node.Kind, typeof(FilterQueryValidator).Name);


### PR DESCRIPTION
Add dynamic properties support for `any`, `all` and `in` operators.

Implements support for the following expressions
- `$filter=DynamicSingleValuedProperty in ('a','b','c')`
- `$filter=DynamicCollectionValuedProperty/any(d:d eq 4)`
- `$filter=DynamicCollectionValuedProperty/all(d: d gt 2)`

Closes https://github.com/OData/odata.net/issues/3059