### PR TITLE
Add dynamic single-valued property support for filter expressions

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -7703,6 +7703,11 @@
               Looks up a localized string similar to The type &apos;{0}&apos; must be an enum or Nullable&lt;T&gt; where T is an enum type..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.TypeMustBeOpenType">
+            <summary>
+              Looks up a localized string similar to The type &apos;{0}&apos; must be an open type. The dynamic properties container property is only expected on open types..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.TypeMustBeRelated">
             <summary>
               Looks up a localized string similar to The type &apos;{0}&apos; does not inherit from and is not a base type of &apos;{1}&apos;..
@@ -9401,7 +9406,7 @@
             <summary>
             Gets property for dynamic properties dictionary.
             </summary>
-            <param name="openNode"></param>
+            <param name="openNode">The single-valued open property access node.</param>
             <param name="context">The query binder context.</param>
             <returns>Returns CLR property for dynamic properties container.</returns>
         </member>
@@ -9413,11 +9418,63 @@
             <param name="context">The query binder context.</param>
             <returns>Returns null if no aggregations were used so far</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindPropertyAccessExpression(Microsoft.OData.UriParser.SingleValueNode,System.Reflection.PropertyInfo,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Binds property to the source node.
+            </summary>
+            <param name="sourceNode">The source node.</param>
+            <param name="prop">The property.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.GetDynamicPropertyContainer(Microsoft.OData.Edm.IEdmTypeReference,Microsoft.OData.UriParser.QueryNodeKind,Microsoft.OData.Edm.IEdmModel)">
+            <summary>
+            Gets property for dynamic properties dictionary.
+            </summary>
+            <param name="edmTypeReference">The Edm type reference.</param>
+            <param name="queryNodeKind">Query node kind.</param>
+            <param name="model">The Edm model.</param>
+            <returns>Returns CLR property for dynamic properties container.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.ApplyNullPropagationForFilterBody(System.Linq.Expressions.Expression,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>
             Apply null propagation for filter body.
             </summary>
             <param name="body">The body.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindDynamicPropertyAccessExpression(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Binds dynamic property to the source node.
+            </summary>
+            <param name="openNode">The query node to bind.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.CreateDynamicPropertyAccessExpression(System.Linq.Expressions.Expression,System.String,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Creates an expression for retrieving a dynamic property from the dynamic properties container property.
+            </summary>
+            <param name="dynamicPropertiesContainerExpr">The dynamic properties container property access expression.</param>
+            <param name="propertyName">The dynamic property name.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.BindNestedDynamicPropertyAccessExpression(Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Binds nested dynamic property to the source node.
+            </summary>
+            <param name="openNode">The query node to bind.</param>
+            <param name="context">The query binder context.</param>
+            <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.CreateNestedDynamicPropertyAccessExpression(System.Linq.Expressions.Expression,Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
+            <summary>
+            Creates an expression for retrieving a nested dynamic property.
+            </summary>
+            <param name="sourceExpr">The source expression.</param>
+            <param name="openNode">The query node to bind.</param>
             <param name="context">The query binder context.</param>
             <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -1798,6 +1798,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type &apos;{0}&apos; must be an open type. The dynamic properties container property is only expected on open types..
+        /// </summary>
+        internal static string TypeMustBeOpenType {
+            get {
+                return ResourceManager.GetString("TypeMustBeOpenType", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; does not inherit from and is not a base type of &apos;{1}&apos;..
         /// </summary>
         internal static string TypeMustBeRelated {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -745,4 +745,7 @@
     <value>Unable to identify a unique property named '{0}'.</value>
     <comment>{0} = Property Name</comment>
   </data>
+  <data name="TypeMustBeOpenType" xml:space="preserve">
+    <value>The type '{0}' must be an open type. The dynamic properties container property is only expected on open types.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -24,7 +24,6 @@ using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
-using Microsoft.VisualBasic;
 
 namespace Microsoft.AspNetCore.OData.Query.Expressions;
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterController.cs
@@ -20,3 +20,21 @@ public class PeopleController : ODataController
         return Ok(DollarFilterDataSource.People);
     }
 }
+
+public class VendorsController : ODataController
+{
+    [EnableQuery]
+    public ActionResult<IEnumerable<Vendor>> Get()
+    {
+        return DollarFilterDataSource.Vendors;
+    }
+}
+
+public class BadVendorsController : ODataController
+{
+    [EnableQuery]
+    public ActionResult<IEnumerable<Vendor>> Get()
+    {
+        return DollarFilterDataSource.BadVendors;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterDataModel.cs
@@ -5,10 +5,43 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter;
 
 public class Person
 {
     public int Id { get; set; }
     public string SSN { get; set; }
+}
+
+public class Vendor
+{
+    public int Id { get; set; }
+    public VendorAddress DeclaredSingleValuedProperty { get; set; }
+    public int DeclaredPrimitiveProperty { get; set; }
+    public Dictionary<string, object> DynamicProperties { get; set; }
+}
+
+public class VendorAddress
+{
+    public string Street { get; set; }
+    public VendorCity City { get; set; }
+    public Dictionary<string, object> DynamicProperties { get; set; }
+}
+
+public class VendorCity
+{
+    public string Name { get; set; }
+    public Dictionary<string, object> DynamicProperties { get; set; }
+}
+
+public class NonOpenVendorAddress
+{
+    public string Street { get; set; }
+}
+
+public class NotInModelVendorAddress
+{
+    public string Street { get; set; }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterDataSource.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter;
 public class DollarFilterDataSource
 {
     private static IList<Person> people;
+    private static List<Vendor> vendors;
+    private static List<Vendor> badVendors;
 
     static DollarFilterDataSource()
     {
@@ -22,7 +24,191 @@ public class DollarFilterDataSource
             new Person { Id = 3, SSN = "xyz'" },
             new Person { Id = 4, SSN = "'pqr'" }
         };
+
+        #region Vendors
+
+        vendors = new List<Vendor>
+            {
+                new Vendor
+                {
+                    Id = 1,
+                    DeclaredPrimitiveProperty = 19,
+                    DeclaredSingleValuedProperty = new VendorAddress
+                    {
+                        Street = "Bourbon Street",
+                        City = new VendorCity
+                        {
+                            Name = "New Orleans",
+                            DynamicProperties = new Dictionary<string, object>
+                            {
+                                { "State", "Louisiana" }
+                            }
+                        },
+                        DynamicProperties = new Dictionary<string, object>
+                        {
+                            { "ZipCode", "25810" }
+                        }
+                    },
+                    DynamicProperties = new Dictionary<string, object>
+                    {
+                        { "DynamicPrimitiveProperty", 19 },
+                        {
+                            "DynamicSingleValuedProperty",
+                            new VendorAddress
+                            {
+                                Street = "Bourbon Street",
+                                City = new VendorCity
+                                {
+                                    Name = "New Orleans",
+                                    DynamicProperties = new Dictionary<string, object>
+                                    {
+                                        { "State", "Louisiana" }
+                                    }
+                                },
+                                DynamicProperties = new Dictionary<string, object>
+                                {
+                                    { "ZipCode", "25810" }
+                                }
+                            }
+                        }
+                    }
+                },
+                new Vendor
+                {
+                    Id = 2,
+                    DeclaredPrimitiveProperty = 13,
+                    DeclaredSingleValuedProperty = new VendorAddress
+                    {
+                        Street = "Ocean Drive",
+                        City = new VendorCity
+                        {
+                            Name = "Miami",
+                            DynamicProperties = new Dictionary<string, object>
+                            {
+                                { "State", "Florida" }
+                            }
+                        },
+                        DynamicProperties = new Dictionary<string, object>
+                        {
+                            { "ZipCode", "73857" }
+                        }
+                    },
+                    DynamicProperties = new Dictionary<string, object>
+                    {
+                        { "DynamicPrimitiveProperty", 13 },
+                        {
+                            "DynamicSingleValuedProperty",
+                            new VendorAddress
+                            {
+                                Street = "Ocean Drive",
+                                City = new VendorCity
+                                {
+                                    Name = "Miami",
+                                    DynamicProperties = new Dictionary<string, object>
+                                    {
+                                        { "State", "Florida" }
+                                    }
+                                },
+                                DynamicProperties = new Dictionary<string, object>
+                                {
+                                    { "ZipCode", "73857" }
+                                }
+                            }
+                        }
+                    }
+                },
+                new Vendor
+                {
+                    Id = 3,
+                    DeclaredPrimitiveProperty = 17,
+                    DeclaredSingleValuedProperty = new VendorAddress
+                    {
+                        Street = "Canal Street",
+                        City = new VendorCity
+                        {
+                            Name = "New Orleans",
+                            DynamicProperties = new Dictionary<string, object>
+                            {
+                                { "State", "Louisiana" }
+                            }
+                        },
+                        DynamicProperties = new Dictionary<string, object>
+                        {
+                            { "ZipCode", "11065" }
+                        }
+                    },
+                    DynamicProperties = new Dictionary<string, object>
+                    {
+                        { "DynamicPrimitiveProperty", 17 },
+                        {
+                            "DynamicSingleValuedProperty",
+                            new VendorAddress
+                            {
+                                Street = "Canal Street",
+                                City = new VendorCity
+                                {
+                                    Name = "New Orleans",
+                                    DynamicProperties = new Dictionary<string, object>
+                                    {
+                                        { "State", "Louisiana" }
+                                    }
+                                },
+                                DynamicProperties = new Dictionary<string, object>
+                                {
+                                    { "ZipCode", "11065" }
+                                }
+                            }
+                        }                    }
+                }
+            };
+
+        #endregion Vendors
+
+        #region Bad Vendors
+
+        badVendors = new List<Vendor>
+        {
+            new Vendor
+            {
+                Id = 1,
+                DynamicProperties = new Dictionary<string, object>
+                {
+                    {
+                        "WarehouseAddress",
+                        new NonOpenVendorAddress
+                        {
+                            Street = "Madero Street"
+                        }
+                    },
+                    {
+                        "Foo",
+                        "Bar"
+                    },
+                    {
+                        "NotInModelAddress",
+                        new NotInModelVendorAddress
+                        {
+                            Street = "No Way"
+                        }
+                    },
+                    {
+                        "ContainerPropertyNullAddress",
+                        new VendorAddress
+                        {
+                            Street = "Genova Street",
+                            DynamicProperties = null
+                        }
+                    }
+                }
+            }
+        };
+
+        #endregion Bad Vendors
     }
 
     public static IList<Person> People => people;
+
+    public static List<Vendor> Vendors => vendors;
+
+    public static List<Vendor> BadVendors => badVendors;
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterEdmModel.cs
@@ -16,6 +16,11 @@ public class DollarFilterEdmModel
     {
         var builder = new ODataConventionModelBuilder();
         builder.EntitySet<Person>("People");
+        builder.ComplexType<VendorAddress>();
+        builder.ComplexType<VendorCity>();
+        builder.ComplexType<NonOpenVendorAddress>();
+        builder.EntitySet<Vendor>("Vendors");
+        builder.EntitySet<Vendor>("BadVendors");
 
         return builder.GetEdmModel();
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarFilter/DollarFilterTests.cs
@@ -9,9 +9,12 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter;
@@ -27,7 +30,10 @@ public class DollarFilterTests : WebApiTestBase<DollarFilterTests>
     {
         IEdmModel model = DollarFilterEdmModel.GetEdmModel();
 
-        services.ConfigureControllers(typeof(PeopleController));
+        services.ConfigureControllers(
+            typeof(PeopleController),
+            typeof(VendorsController),
+            typeof(BadVendorsController));
 
         services.AddControllers().AddOData(opt =>
             opt.Filter().Select().AddRouteComponents("odata", model));
@@ -93,5 +99,203 @@ public class DollarFilterTests : WebApiTestBase<DollarFilterTests>
         var result = await response.Content.ReadAsStringAsync();
 
         Assert.EndsWith($"$metadata#People\",\"value\":{partialResult}}}", result);
+    }
+
+    [Theory]
+    [InlineData("Id eq 2")]
+    [InlineData("DeclaredPrimitiveProperty eq 13")]
+    [InlineData("DeclaredSingleValuedProperty/Street eq 'Ocean Drive'")]
+    [InlineData("DeclaredSingleValuedProperty/ZipCode eq '73857'")]
+    [InlineData("DeclaredSingleValuedProperty/City/Name eq 'Miami'")]
+    [InlineData("DeclaredSingleValuedProperty/City/State eq 'Florida'")]
+    [InlineData("DynamicPrimitiveProperty eq 13")]
+    [InlineData("DynamicSingleValuedProperty/Street eq 'Ocean Drive'")]
+    [InlineData("DynamicSingleValuedProperty/ZipCode eq '73857'")]
+    [InlineData("DynamicSingleValuedProperty/City/Name eq 'Miami'")]
+    [InlineData("DynamicSingleValuedProperty/City/State eq 'Florida'")]
+    public async Task TestDeclaredAndDynamicPropertiesInFilterExpressions(string filterExpr)
+    {
+        // Arrange
+        var queryUrl = $"odata/Vendors?$filter={filterExpr}";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        var result = await response.Content.ReadAsStringAsync();
+
+        Assert.EndsWith(
+            "$metadata#Vendors\"," +
+            "\"value\":[" +
+            "{\"Id\":2," +
+            "\"DeclaredPrimitiveProperty\":13," +
+            "\"DynamicPrimitiveProperty\":13," +
+            "\"DeclaredSingleValuedProperty\":{" +
+            "\"Street\":\"Ocean Drive\"," +
+            "\"ZipCode\":\"73857\",\"City\":{\"Name\":\"Miami\",\"State\":\"Florida\"}}," +
+            "\"DynamicSingleValuedProperty\":{" +
+            "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter.VendorAddress\"," +
+            "\"Street\":\"Ocean Drive\"," +
+            "\"ZipCode\":\"73857\"," +
+            "\"City\":{\"Name\":\"Miami\",\"State\":\"Florida\"}}}]}",
+            result);
+    }
+
+    [Theory]
+    [InlineData("Id in (1,3)")]
+    [InlineData("DeclaredPrimitiveProperty in (19,17)")]
+    [InlineData("DeclaredSingleValuedProperty/Street in ('Bourbon Street','Canal Street')")]
+    [InlineData("DeclaredSingleValuedProperty/ZipCode in ('25810','11065')")]
+    [InlineData("DeclaredSingleValuedProperty/City/Name eq 'New Orleans'")]
+    [InlineData("DeclaredSingleValuedProperty/City/State eq 'Louisiana'")]
+    [InlineData("DynamicPrimitiveProperty eq 19 or DynamicPrimitiveProperty eq 17")]
+    [InlineData("DynamicSingleValuedProperty/Street in ('Bourbon Street','Canal Street')")]
+    [InlineData("DynamicSingleValuedProperty/ZipCode in ('25810','11065')")]
+    [InlineData("DynamicSingleValuedProperty/City/Name eq 'New Orleans'")]
+    [InlineData("DynamicSingleValuedProperty/City/State eq 'Louisiana'")]
+    public async Task TestDeclaredAndDynamicPropertiesInFilterExpressionsReturningMultipleResources(string filterExpr)
+    {
+        // Arrange
+        var queryUrl = $"odata/Vendors?$filter={filterExpr}";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        var result = await response.Content.ReadAsStringAsync();
+
+        Assert.EndsWith(
+            "$metadata#Vendors\"," +
+            "\"value\":[" +
+            "{\"Id\":1," +
+            "\"DeclaredPrimitiveProperty\":19," +
+            "\"DynamicPrimitiveProperty\":19," +
+            "\"DeclaredSingleValuedProperty\":{" +
+            "\"Street\":\"Bourbon Street\"," +
+            "\"ZipCode\":\"25810\"," +
+            "\"City\":{\"Name\":\"New Orleans\",\"State\":\"Louisiana\"}}," +
+            "\"DynamicSingleValuedProperty\":{" +
+            "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter.VendorAddress\"," +
+            "\"Street\":\"Bourbon Street\"," +
+            "\"ZipCode\":\"25810\"," +
+            "\"City\":{\"Name\":\"New Orleans\",\"State\":\"Louisiana\"}}}," +
+            "{\"Id\":3," +
+            "\"DeclaredPrimitiveProperty\":17," +
+            "\"DynamicPrimitiveProperty\":17," +
+            "\"DeclaredSingleValuedProperty\":{" +
+            "\"Street\":\"Canal Street\"," +
+            "\"ZipCode\":\"11065\"," +
+            "\"City\":{\"Name\":\"New Orleans\",\"State\":\"Louisiana\"}}," +
+            "\"DynamicSingleValuedProperty\":{" +
+            "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.DollarFilter.VendorAddress\"," +
+            "\"Street\":\"Canal Street\"," +
+            "\"ZipCode\":\"11065\"," +
+            "\"City\":{\"Name\":\"New Orleans\",\"State\":\"Louisiana\"}}}]}",
+            result);
+    }
+
+    [Fact]
+    public async Task TestDynamicPropertySegmentAfterNonOpenDynamicProperty()
+    {
+        // Arrange
+        var queryUrl = $"odata/BadVendors?$filter=WarehouseAddress/City eq 'Mexico City'";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await client.SendAsync(request);
+        });
+
+        Assert.NotNull(exception);
+        var odataException = exception.InnerException?.InnerException;
+        Assert.NotNull(odataException);
+        Assert.Equal(string.Format(SRResources.TypeMustBeOpenType, typeof(NonOpenVendorAddress).FullName),
+            odataException.Message);
+    }
+
+    [Fact]
+    public async Task TestDynamicPropertySegmentAfterPrimitiveDynamicProperty()
+    {
+        // Arrange
+        var queryUrl = $"odata/BadVendors?$filter=Foo/City eq 'Mexico City'";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await client.SendAsync(request);
+        });
+
+        Assert.NotNull(exception);
+        var odataException = exception.InnerException?.InnerException;
+        Assert.NotNull(odataException);
+        Assert.Equal(string.Format(SRResources.QueryNodeBindingNotSupported, QueryNodeKind.SingleValueOpenPropertyAccess, typeof(QueryBinder).Name),
+            odataException.Message);
+    }
+
+    [Fact]
+    public async Task TestDynamicPropertySegmentOnResourceTypeNotInEdmModel()
+    {
+        // Arrange
+        var queryUrl = $"odata/BadVendors?$filter=NotInModelAddress/City eq 'Mexico City'";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await client.SendAsync(request);
+        });
+
+        Assert.NotNull(exception);
+        var odataException = exception.InnerException?.InnerException;
+        Assert.NotNull(odataException);
+        Assert.Equal(string.Format(SRResources.ResourceTypeNotInModel, typeof(NotInModelVendorAddress).FullName),
+            odataException.Message);
+    }
+
+    [Theory]
+    [InlineData("ContainerPropertyNullAddress/City eq 'Mexico City'")]
+    [InlineData("NonExistentDynamicProperty eq 404")]
+    public async Task TestNullPropagationForNullDynamicContainerProperty(string filterExpr)
+    {
+        // Arrange
+        var queryUrl = $"odata/BadVendors?$filter={filterExpr}";
+        var request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=minimal"));
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        var result = await response.Content.ReadAsStringAsync();
+        Assert.Equal(
+            "{\"@odata.context\":\"http://localhost/odata/$metadata#BadVendors\",\"value\":[]}",
+            result);
     }
 }


### PR DESCRIPTION
Add dynamic single-valued property support for filter expressions

Scenarios:
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty} eq {value}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DeclaredSingleValuedProperty}/{DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} eq {value}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty} eq {value}
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DynamicSingleValuedProperty}/{DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty} in {collection}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DeclaredSingleValuedProperty}/{DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty} in {collection}
- $filter={DeclaredSingleValuedProperty}/{DynamicSingleValuedProperty}/{DeclaredSingleValuedProperty} in {collection}