### PR TITLE
Fixes #1332: Deep Comparison for Array-based Concurrency tokens.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ETag.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ETag.cs
@@ -136,7 +136,11 @@ namespace Microsoft.AspNetCore.OData.Query
                 Expression value = itemValue != null
                     ? LinqParameterContainer.Parameterize(itemValue.GetType(), itemValue)
                     : Expression.Constant(value: null);
-                BinaryExpression equal = Expression.Equal(name, value);
+                Expression equal;
+                if (itemValue != null && itemValue.GetType().IsArray)
+                    equal = ExpressionHelpers.SequenceEquals(name, value);
+                else
+                    equal = Expression.Equal(name, value);
                 where = where == null ? equal : Expression.AndAlso(where, equal);
             }
 

--- a/src/Microsoft.AspNetCore.OData/Query/ETag.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ETag.cs
@@ -133,14 +133,27 @@ namespace Microsoft.AspNetCore.OData.Query
             {
                 MemberExpression name = Expression.Property(param, item.Key);
                 object itemValue = item.Value;
-                Expression value = itemValue != null
-                    ? LinqParameterContainer.Parameterize(itemValue.GetType(), itemValue)
-                    : Expression.Constant(value: null);
+                
                 Expression equal;
-                if (itemValue != null && itemValue.GetType().IsArray)
-                    equal = ExpressionHelpers.SequenceEquals(name, value);
+                if (itemValue != null)
+                {
+                    Type itemType = itemValue.GetType();
+                    Expression value = LinqParameterContainer.Parameterize(itemType, itemValue);
+                    if (itemType.IsArray)
+                    {
+                        equal = ExpressionHelpers.SequenceEquals(name, value);
+                    }
+                    else
+                    {
+                        equal = Expression.Equal(name, value);
+                    }
+                }
                 else
+                {
+                    Expression value = Expression.Constant(value: null);
                     equal = Expression.Equal(name, value);
+                }
+                
                 where = where == null ? equal : Expression.AndAlso(where, equal);
             }
 

--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -284,5 +284,14 @@ namespace Microsoft.AspNetCore.OData.Query
             MemberExpression propertyAccess = Expression.Property(odataItParameter, propertyName);
             return Expression.Lambda(propertyAccess, odataItParameter);
         }
+
+        public static Expression SequenceEquals(Expression left, Expression right)
+        {
+            MethodInfo sequenceEqualMethod = typeof(Enumerable)
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .First(m => m.Name == "SequenceEqual" && m.GetParameters().Length == 2)
+                .MakeGenericMethod(right.Type.GetElementType());
+            return Expression.Call(sequenceEqualMethod, left, right);
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             SingletonConfiguration<ETagsCustomer> eTagsCustomerSingleton = builder.Singleton<ETagsCustomer>("ETagsDerivedCustomersSingleton");
             eTagsCustomerSingleton.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
             eTagsCustomerSingleton.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
-            eTagsCustomersSet.EntityType.Ignore(d=>d.RowVersion);
+            eTagsCustomersSet.EntityType.Ignore(d => d.RowVersion);
             return builder.GetEdmModel();
         }
 
@@ -61,8 +61,8 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             EntitySetConfiguration<ETagsDerivedCustomer> eTagsDerivedCustomersSet = builder.EntitySet<ETagsDerivedCustomer>("ETagsDerivedCustomers");
             eTagsDerivedCustomersSet.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
             eTagsDerivedCustomersSet.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
-            eTagsDerivedCustomersSet.EntityType.Ignore(d=>d.RowVersion);
-            eTagsCustomersSet.EntityType.Ignore(d=>d.RowVersion);
+            eTagsDerivedCustomersSet.EntityType.Ignore(d => d.RowVersion);
+            eTagsCustomersSet.EntityType.Ignore(d => d.RowVersion);
             return builder.GetEdmModel();
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             SingletonConfiguration<ETagsCustomer> eTagsCustomerSingleton = builder.Singleton<ETagsCustomer>("ETagsDerivedCustomersSingleton");
             eTagsCustomerSingleton.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
             eTagsCustomerSingleton.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+            eTagsCustomersSet.EntityType.Ignore(d=>d.RowVersion);
             return builder.GetEdmModel();
         }
 
@@ -60,6 +61,8 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             EntitySetConfiguration<ETagsDerivedCustomer> eTagsDerivedCustomersSet = builder.EntitySet<ETagsDerivedCustomer>("ETagsDerivedCustomers");
             eTagsDerivedCustomersSet.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
             eTagsDerivedCustomersSet.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+            eTagsDerivedCustomersSet.EntityType.Ignore(d=>d.RowVersion);
+            eTagsCustomersSet.EntityType.Ignore(d=>d.RowVersion);
             return builder.GetEdmModel();
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             customer.UlongProperty = eTagsCustomer.UlongProperty;
             customer.GuidProperty = eTagsCustomer.GuidProperty;
             customer.DateTimeOffsetProperty = eTagsCustomer.DateTimeOffsetProperty;
-
+            customer.RowVersion[7]++;
             return Ok(customer);
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
            
             ETagsCustomer customer = appliedCustomers.Single();
             patch.Patch(customer);
-
+            customer.RowVersion[7]++;
             return Ok(customer);
         }
     }
@@ -188,6 +188,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
                 ShortProperty = (short)(Int16.MaxValue - i),
                 DoubleProperty = 2.0 * (i + 1),
                 Notes = Enumerable.Range(0, i + 1).Select(j => "This is note " + (i * 10 + j)).ToList(),
+                RowVersion = new byte[] { 0, 0, 0, 0, 0, 0, 16, 28 },
                 RelatedCustomer = new ETagsCustomer
                 {
                     Id = i + 1,

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
@@ -41,5 +41,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
         public ETagsCustomer RelatedCustomer { get; set; }
         [Contained]
         public ETagsCustomer ContainedCustomer { get; set; }
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsOtherTypesTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsOtherTypesTest.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
             customer.Property(c => c.DoubleProperty).IsConcurrencyToken();
             customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+            customer.Ignore(c => c.RowVersion);
             return builder.GetEdmModel();
         }
 
@@ -53,6 +54,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             var builder = new ODataConventionModelBuilder();
             var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
             customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+            customer.Ignore(c => c.RowVersion);
             customer.Property(c => c.ShortProperty).IsConcurrencyToken();
             return builder.GetEdmModel();
         }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             eTagsCustomers.Property(c => c.Id).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.Name).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.BoolProperty).IsConcurrencyToken();
-            eTagsCustomers.Property(c => c.ByteProperty).IsConcurrencyToken();.
+            eTagsCustomers.Property(c => c.ByteProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.CharProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DecimalProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DoubleProperty).IsConcurrencyToken();

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             eTagsCustomers.Property(c => c.UlongProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.GuidProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DateTimeOffsetProperty).IsConcurrencyToken();
+            eTagsCustomers.Ignore(d=>d.RowVersion);
             return builder.GetEdmModel();
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             eTagsCustomers.Property(c => c.Id).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.Name).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.BoolProperty).IsConcurrencyToken();
-            eTagsCustomers.Property(c => c.ByteProperty).IsConcurrencyToken();
+            eTagsCustomers.Property(c => c.ByteProperty).IsConcurrencyToken();.
             eTagsCustomers.Property(c => c.CharProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DecimalProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DoubleProperty).IsConcurrencyToken();
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags
             eTagsCustomers.Property(c => c.UlongProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.GuidProperty).IsConcurrencyToken();
             eTagsCustomers.Property(c => c.DateTimeOffsetProperty).IsConcurrencyToken();
-            eTagsCustomers.Ignore(d=>d.RowVersion);
+            eTagsCustomers.Ignore(d => d.RowVersion);
             return builder.GetEdmModel();
         }
 


### PR DESCRIPTION
Fixes #1332

A popular convention today for concurrency check fields is to use a `byte[]` field called `RowVersion` with a `Timestamp` or `ConcurrencyCheck` attribute.

However, when using such a field, the `queryOptions.ifNoneMatch.ApplyTo` call was having absolutely no effect. That's because `ApplyTo` was internally using `Expression.Equal` which is perfect for value types but doesn't fare very well against reference types or particularly Arrays.

I fixed this by adding a case for arrays that, through a helper method, generates an expression that performs a deep comparison.