### PR TITLE
Fixes #1336 : Regressions from refacturing from extension method EntityType() to EntityType property bug

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/ContainmentPathBuilder.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/ContainmentPathBuilder.cs
@@ -171,7 +171,7 @@ internal class ContainmentPathBuilder
         NavigationPropertySegment navigationPropertySegment = segment as NavigationPropertySegment;
         if (navigationPropertySegment != null)
         {
-            return navigationPropertySegment.NavigationSource.EntityType;
+            return navigationPropertySegment.NavigationSource?.EntityType;
         }
 
         return null;

--- a/src/Microsoft.AspNetCore.OData/Formatter/LinkGenerationHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/LinkGenerationHelpers.cs
@@ -39,7 +39,7 @@ public static class LinkGenerationHelpers
 
         IList<ODataPathSegment> idLinkPathSegments = resourceContext.GenerateBaseODataPathSegments();
 
-        bool isSameType = resourceContext.StructuredType == resourceContext.NavigationSource.EntityType;
+        bool isSameType = resourceContext.StructuredType == resourceContext.NavigationSource?.EntityType;
         if (includeCast && !isSameType)
         {
             idLinkPathSegments.Add(new TypeSegment(resourceContext.StructuredType, navigationSource: null));
@@ -257,7 +257,7 @@ public static class LinkGenerationHelpers
         IList<ODataPathSegment> actionPathSegments = resourceContext.GenerateBaseODataPathSegments();
 
         // generate link with cast if the navigation source doesn't match the entity type the action is bound to.
-        if (resourceContext.NavigationSource.EntityType != bindingParameterType.Definition)
+        if (resourceContext.NavigationSource?.EntityType != bindingParameterType.Definition)
         {
             actionPathSegments.Add(new TypeSegment((IEdmEntityType)bindingParameterType.Definition, null));
             // entity set can be null
@@ -305,7 +305,7 @@ public static class LinkGenerationHelpers
         IList<ODataPathSegment> functionPathSegments = resourceContext.GenerateBaseODataPathSegments();
 
         // generate link with cast if the navigation source type doesn't match the entity type the function is bound to.
-        if (resourceContext.NavigationSource.EntityType != bindingParameterType.Definition)
+        if (resourceContext.NavigationSource?.EntityType != bindingParameterType.Definition)
         {
             functionPathSegments.Add(new TypeSegment(bindingParameterType.Definition, null));
         }

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -454,7 +454,7 @@ public class SelectExpandQueryOption
                 }
 
                 GetAutoSelectExpandItems(
-                    currentEdmNavigationSource.EntityType,
+                    currentEdmNavigationSource?.EntityType,
                     model,
                     item.NavigationSource,
                     true,
@@ -577,7 +577,7 @@ public class SelectExpandQueryOption
         SelectExpandClause selectExpandClause = null;
         bool levelsEncounteredInInnerExpand = false;
         bool isMaxLevelInInnerExpand = false;
-        var entityType = expandItem.NavigationSource.EntityType;
+        var entityType = expandItem.NavigationSource?.EntityType; // the navigation source could be null.
         IEdmNavigationProperty navigationProperty =
             (expandItem.PathToNavigationProperty.LastSegment as NavigationPropertySegment).NavigationProperty;
         ModelBoundQuerySettings nestQuerySettings = Context.Model.GetModelBoundQuerySettings(navigationProperty, navigationProperty.ToEntityType());


### PR DESCRIPTION
Fixes #1336 : Regressions from refacturing from extension method EntityType() to EntityType property bug
If the navigation source is null, it throws nullreference exception. Change it to test the null first, then call the EntityType property.