### PR TITLE
update DI settings

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Abstracts/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Abstracts/ODataServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ internal static class ODataServiceCollectionExtensions
         // ReaderSettings and WriterSettings are registered as prototype services.
         // There will be a copy (if it is accessed) of each prototype for each request.
 #pragma warning disable CS0618 // ReadUntypedAsString is obsolete in ODL 8.
-        services.AddSingleton(new ODataMessageReaderSettings
+        services.AddScoped(sp => new ODataMessageReaderSettings
         {
             EnableMessageStreamDisposal = false,
             MessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue },
@@ -53,7 +53,7 @@ internal static class ODataServiceCollectionExtensions
         });
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        services.AddSingleton(new ODataMessageWriterSettings
+        services.AddScoped(sp => new ODataMessageWriterSettings
         {
             EnableMessageStreamDisposal = false,
             MessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue },

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -28,9 +28,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.ModelBuilder" Version="2.0.0" />
-    <PackageReference Include="Microsoft.OData.Core" Version="8.0.1" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Spatial" Version="8.0.1" />
+    <PackageReference Include="Microsoft.OData.Core" Version="8.0.2" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Spatial" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -9471,9 +9471,9 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.CreateDynamicPropertyAccessExpression(System.Linq.Expressions.Expression,System.String,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>
-            Creates an expression for retrieving a dynamic property from the dynamic properties container property.
+            Creates an expression for retrieving a dynamic property from the container property.
             </summary>
-            <param name="containerPropertyAccessExpr">The dynamic properties container property access expression.</param>
+            <param name="containerPropertyAccessExpr">The container property access expression.</param>
             <param name="propertyName">The dynamic property name.</param>
             <param name="context">The query binder context.</param>
             <returns>The LINQ <see cref="T:System.Linq.Expressions.Expression"/> created.</returns>
@@ -9522,7 +9522,7 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Expressions.QueryBinder.CreateNestedDynamicPropertyAccessExpression(System.Linq.Expressions.Expression,System.String,Microsoft.OData.UriParser.QueryNodeKind,Microsoft.AspNetCore.OData.Query.Expressions.QueryBinderContext)">
             <summary>
-            Creates an expression for retrieving a dynamic property from the dynamic properties container property.
+            Creates an expression for retrieving a dynamic property from the container property.
             </summary>
             <param name="sourceExpr">The source expression.</param>
             <param name="propertyName">The property name.</param>

--- a/test/Microsoft.AspNetCore.OData.Tests/Abstracts/DefaultContainerBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Abstracts/DefaultContainerBuilderTests.cs
@@ -136,6 +136,69 @@ public class DefaultContainerBuilderTests
         Assert.NotEqual(o11, o21);
     }
 
+    [Fact]
+    public void MessageReaderIsScoped()
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection();
+        services.AddDefaultWebApiServices();
+        IServiceProvider container = services.BuildServiceProvider();
+
+        // Act
+        IServiceProvider scopedContainer1 = container.GetRequiredService<IServiceScopeFactory>()
+            .CreateScope().ServiceProvider;
+        ODataMessageReaderSettings reader11 = scopedContainer1.GetService<ODataMessageReaderSettings>();
+        ODataMessageReaderSettings reader12 = scopedContainer1.GetService<ODataMessageReaderSettings>();
+
+        // Assert
+        Assert.NotNull(reader11);
+        Assert.NotNull(reader12);
+        Assert.Equal(reader11, reader12);
+
+        IServiceProvider scopedContainer2 = container.GetRequiredService<IServiceScopeFactory>()
+            .CreateScope().ServiceProvider;
+        ODataMessageReaderSettings reader21 = scopedContainer2.GetService<ODataMessageReaderSettings>();
+        ODataMessageReaderSettings reader22 = scopedContainer2.GetService<ODataMessageReaderSettings>();
+
+        Assert.NotNull(reader21);
+        Assert.NotNull(reader22);
+        Assert.Equal(reader21, reader22);
+
+        Assert.NotEqual(reader11, reader21);
+    }
+
+
+    [Fact]
+    public void MessageWriterIsScoped()
+    {
+        // Arrange
+        IServiceCollection services = new ServiceCollection();
+        services.AddDefaultWebApiServices();
+        IServiceProvider container = services.BuildServiceProvider();
+
+        // Act
+        IServiceProvider scopedContainer1 = container.GetRequiredService<IServiceScopeFactory>()
+            .CreateScope().ServiceProvider;
+        ODataMessageWriterSettings writer11 = scopedContainer1.GetService<ODataMessageWriterSettings>();
+        ODataMessageWriterSettings writer12 = scopedContainer1.GetService<ODataMessageWriterSettings>();
+
+        // Assert
+        Assert.NotNull(writer11);
+        Assert.NotNull(writer12);
+        Assert.Equal(writer11, writer12);
+
+        IServiceProvider scopedContainer2 = container.GetRequiredService<IServiceScopeFactory>()
+            .CreateScope().ServiceProvider;
+        ODataMessageWriterSettings writer21 = scopedContainer2.GetService<ODataMessageWriterSettings>();
+        ODataMessageWriterSettings writer22 = scopedContainer2.GetService<ODataMessageWriterSettings>();
+
+        Assert.NotNull(writer21);
+        Assert.NotNull(writer22);
+        Assert.Equal(writer21, writer22);
+
+        Assert.NotEqual(writer11, writer21);
+    }
+
     private interface ITestService { }
 
     private class TestService : ITestService { }


### PR DESCRIPTION
Message reader and Writer have the wrong scope in the DI container.
This could cause some issues whenever users retrieve and write to them in the scope of a request.

Fixes #1337 by updating the dependencies to 8.0.2 as well as moving reader and writer settings to scoped.
This includes https://github.com/OData/odata.net/pull/3058

