### PR TITLE
Fix: Include DateOnly and TimeOnly in Non-standard to their standard EDM Primitive Conversions

### DIFF
--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateOnlyTimeOnly/DateAndTimeOfDayWithEfTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateOnlyTimeOnly/DateAndTimeOfDayWithEfTest.cs
@@ -232,6 +232,26 @@ public class DateOnlyAndTimeOnlyWithEfTest : WebApiTestBase<DateOnlyAndTimeOnlyW
         Assert.Equal(expect, string.Join(",", result["value"].Select(e => e["Id"].ToString())));
     }
 
+    [Theory]
+    [InlineData("?$apply=groupby((Birthday))", 5)]
+    [InlineData("?$apply=groupby((PublishDay))", 4)]
+    [InlineData("?$apply=groupby((CreatedTime))", 5)]
+    public async Task CanGroupBy_OnDateOnlyAndTimeOnlyProperties(string applyGroupBy, int expectCount)
+    {
+        // Arrange
+        string Uri = "odata/DateOnlyTimeOnlyModels" + applyGroupBy;
+        var request = new HttpRequestMessage(HttpMethod.Get, Uri);
+        HttpClient client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsObject<JArray>();
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(expectCount, result.Count());
+    }
+
     [Fact]
     public async Task PostEntity_WithDateOnlyAndTimeOnlyProperties()
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1327](https://github.com/OData/AspNetCoreOData/issues/1327).*

### Description

This PR included `DateOnly` and `TimeOnly` types as non-standard EDM primitive types in the `ConvertNonStandardPrimitives` method. This is to be able to convert these types to their standard EDM primitive types.

Given the following model:
```cs
public class DateOnyTimeOnlyModel
{
    public int Id { get; set; }

    public DateOnly Birthday { get; set; }

    public DateOnly EndDay { get; set; }

    public TimeOnly CreatedTime { get; set; }

    public TimeOnly? EndTime { get; set; }
}
```

With `DateOnly` and `TimeOnly` types added, the `HandleObjectType` method now supports the following:
- `$apply=groupby((EndDay))`
- `$apply=groupby((CreatedTime))`
- `$apply=groupby((EndTime),aggregate(Birthday with min as MinBirthday))`
- `?$apply=groupby((EndDay),aggregate(Id with max as MaxId))&$orderby=PublishDay`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*