### PR TITLE
ODataOutputFormatter fix - Make WriteResponseBodyAsync fully async

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -212,7 +212,7 @@ public class ODataOutputFormatter : TextOutputFormatter, IMediaTypeMappingCollec
     }
 
     /// <inheritdoc/>
-    public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
+    public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
     {
         if (context == null)
         {
@@ -239,7 +239,9 @@ public class ODataOutputFormatter : TextOutputFormatter, IMediaTypeMappingCollec
             // However, OData lib doesn't provide the method to overwrite/copyto stream
             // So, Here's the workaround
             Stream objStream = context.Object as Stream;
-            return CopyStreamAsync(objStream, response);
+            await CopyStreamAsync(objStream, response).ConfigureAwait(false);
+
+            return;
         }
 
         Uri baseAddress = GetBaseAddressInternal(request);
@@ -247,7 +249,7 @@ public class ODataOutputFormatter : TextOutputFormatter, IMediaTypeMappingCollec
 
         IODataSerializerProvider serializerProvider = request.GetRouteServices().GetRequiredService<IODataSerializerProvider>();
 
-        return ODataOutputFormatterHelper.WriteToStreamAsync(
+        await ODataOutputFormatterHelper.WriteToStreamAsync(
             type,
             context.Object,
             request.GetModel(),
@@ -256,7 +258,7 @@ public class ODataOutputFormatter : TextOutputFormatter, IMediaTypeMappingCollec
             contentType,
             request,
             request.Headers,
-            serializerProvider);
+            serializerProvider).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataOutFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataOutFormatterTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.OData.Extensions;
@@ -174,18 +175,18 @@ public class ODataOutputFormatterTests
 
     #region WriteResponseBodyAsync
     [Fact]
-    public void WriteResponseBodyAsyncODataOutputFormatter_ThrowsArgumentNull_Context()
+    public async Task WriteResponseBodyAsyncODataOutputFormatter_ThrowsArgumentNull_Context()
     {
         // Arrange & Act
         ODataOutputFormatter formatter = new ODataOutputFormatter(new[] { ODataPayloadKind.Resource });
         Encoding encoding = Encoding.UTF8;
 
         // Assert
-        ExceptionAssert.ThrowsArgumentNull(() => formatter.WriteResponseBodyAsync(context: null, encoding), "context");
+        await ExceptionAssert.ThrowsArgumentNullAsync(() => formatter.WriteResponseBodyAsync(context: null, encoding), "context");
     }
 
     [Fact]
-    public void WriteResponseBodyAsyncODataOutputFormatter_ThrowsArgumentNull_ObjectType()
+    public async Task WriteResponseBodyAsyncODataOutputFormatter_ThrowsArgumentNull_ObjectType()
     {
         // Arrange & Act
         ODataOutputFormatter formatter = new ODataOutputFormatter(new[] { ODataPayloadKind.Resource });
@@ -196,11 +197,11 @@ public class ODataOutputFormatterTests
             null);
 
         // Assert
-        ExceptionAssert.ThrowsArgumentNull(() => formatter.WriteResponseBodyAsync(context, Encoding.UTF8), "type");
+        await ExceptionAssert.ThrowsArgumentNullAsync(() => formatter.WriteResponseBodyAsync(context, Encoding.UTF8), "type");
     }
 
     [Fact]
-    public void WriteResponseBodyAsyncODataOutputFormatter_Throws_IfRequestIsNull()
+    public async Task WriteResponseBodyAsyncODataOutputFormatter_Throws_IfRequestIsNull()
     {
         // Arrange & Act
         ODataOutputFormatter formatter = new ODataOutputFormatter(new[] { ODataPayloadKind.Resource });
@@ -212,7 +213,7 @@ public class ODataOutputFormatterTests
             6);
 
         // Assert
-        ExceptionAssert.Throws<InvalidOperationException>(
+        await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
             () => formatter.WriteResponseBodyAsync(context, Encoding.UTF8),
             "The OData formatter requires an attached request in order to serialize.");
     }


### PR DESCRIPTION
ODataOutputFormatter fix - Make WriteResponseBodyAsync fully asynchronous.

Updated WriteResponseBodyAsync in ODataOutputFormatter.cs to be asynchronous, improving efficiency and giving ability to clients to better handle the error (ODataException) if thrown by ms writer.

This update has the potential to resolve several issues related to serializers.