### PR TITLE
Fix Default ODataEnumSerializer and ODataEnumDeserializer Fails to Convert Multi-Value Flag Enum Values to Lower Camel Case

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
@@ -156,7 +156,6 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
                 // - if the enum member is defined as "Friday" and the value is "fri", we need to match them.
                 // - if the enum member is defined as "FullTime" and the value is "Full Time", we need to match them.
                 // - if the enum member is defined as "PartTime" and the value is "part time", we need to match them.
-                parsed = false;
                 foreach (IEdmEnumMember enumMember in enumType.Members)
                 {
                     // Check if the current value matches the enum member name.
@@ -164,8 +163,14 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
                     if (parsed)
                     {
                         Enum clrEnumMember = memberMapAnnotation.GetClrEnumMember(enumMember);
-                        result |= Convert.ToInt64(clrEnumMember);
-                        break;
+                        if(clrEnumMember != null)
+                        {
+                            result |= Convert.ToInt64(clrEnumMember);
+                            break;
+                        }
+
+                        // If the enum member is not found, the value is not valid.
+                        parsed = false;
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
@@ -94,7 +94,7 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
         {
             if (enumValue != null)
             {
-                IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name.Equals(enumValue.Value, StringComparison.InvariantCultureIgnoreCase));
+                IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == enumValue.Value);
                 if (enumMember != null)
                 {
                     var clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
@@ -128,9 +128,9 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
     private static object ReadFlagsEnumValue(ODataEnumValue enumValue, IEdmEnumType enumType, Type clrType, ClrEnumMemberAnnotation memberMapAnnotation)
     {
         long result = 0;
-        Type clrEnumType = TypeHelper.GetUnderlyingTypeOrSelf(clrType);
-        ReadOnlySpan<char> source = enumValue.Value.AsSpan().Trim();
+        clrType = TypeHelper.GetUnderlyingTypeOrSelf(clrType);
 
+        ReadOnlySpan<char> source = enumValue.Value.AsSpan().Trim();
         int start = 0;
         while (start < source.Length)
         {
@@ -144,7 +144,7 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
             // Extract the current value.
             ReadOnlySpan<char> currentValue = source[start..end].Trim();
 
-            bool parsed = Enum.TryParse(clrEnumType, currentValue, true, out object enumMemberParsed);
+            bool parsed = Enum.TryParse(clrType, currentValue, true, out object enumMemberParsed);
             if (parsed)
             {
                 result |= Convert.ToInt64((Enum)enumMemberParsed);
@@ -181,6 +181,6 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
             start = end + 1;
         }
 
-        return result == 0 ? null : Enum.ToObject(clrEnumType, result);
+        return result == 0 ? null : Enum.ToObject(clrType, result);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
@@ -138,6 +138,8 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
         for(int i = 0; i < count; i++)
         {
             ReadOnlySpan<char> value = source[ranges[i]];
+
+            // Try to find the enum member in the EDM model.
             IEdmEnumMember enumMember = null;
             foreach (IEdmEnumMember member in enumType.Members)
             {
@@ -165,5 +167,4 @@ public class ODataEnumDeserializer : ODataEdmTypeDeserializer
 
         return result == 0 ? null : Enum.ToObject(clrEnumType, result);
     }
-
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataEnumDeserializer.cs
@@ -6,7 +6,6 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
@@ -187,7 +187,7 @@ public class ODataEnumSerializer : ODataEdmTypeSerializer
     /// <param name="graphEnum">The enum value.</param>
     /// <param name="memberMapAnnotation">The annotation containing the mapping of CLR enum members to EDM enum members.</param>
     /// <returns>A comma-separated string of the names of the flags that are set.</returns>
-    private string GetFlagsEnumValue(Enum graphEnum, ClrEnumMemberAnnotation memberMapAnnotation)
+    private static string GetFlagsEnumValue(Enum graphEnum, ClrEnumMemberAnnotation memberMapAnnotation)
     {
         List<string> flagsList = new List<string>();
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -3522,14 +3522,13 @@
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadFlagsEnumValue(Microsoft.OData.ODataEnumValue,Microsoft.OData.Edm.IEdmEnumType,System.Type,System.Boolean,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadFlagsEnumValue(Microsoft.OData.ODataEnumValue,Microsoft.OData.Edm.IEdmEnumType,System.Type,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
             <summary>
             Reads the value of a flags enum.
             </summary>
             <param name="enumValue">The OData enum value.</param>
             <param name="enumType">The EDM enum type.</param>
             <param name="clrType">The EDM enum CLR type.</param>
-            <param name="enablePropertyNameCaseInsensitive">The value indicating whether to enable case insensitive for the property name in conventional routing.</param>
             <param name="memberMapAnnotation">The annotation containing the mapping of CLR enum members to EDM enum members.</param>
             <returns>The deserialized flags enum value.</returns>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -3522,12 +3522,14 @@
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadFlagsEnumValue(Microsoft.OData.ODataEnumValue,Microsoft.OData.Edm.IEdmEnumType,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadFlagsEnumValue(Microsoft.OData.ODataEnumValue,Microsoft.OData.Edm.IEdmEnumType,System.Type,System.Boolean,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
             <summary>
             Reads the value of a flags enum.
             </summary>
             <param name="enumValue">The OData enum value.</param>
             <param name="enumType">The EDM enum type.</param>
+            <param name="clrType">The EDM enum CLR type.</param>
+            <param name="enablePropertyNameCaseInsensitive">The value indicating whether to enable case insensitive for the property name in conventional routing.</param>
             <param name="memberMapAnnotation">The annotation containing the mapping of CLR enum members to EDM enum members.</param>
             <returns>The deserialized flags enum value.</returns>
         </member>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -3522,6 +3522,15 @@
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadInline(System.Object,Microsoft.OData.Edm.IEdmTypeReference,Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializerContext)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataEnumDeserializer.ReadFlagsEnumValue(Microsoft.OData.ODataEnumValue,Microsoft.OData.Edm.IEdmEnumType,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
+            <summary>
+            Reads the value of a flags enum.
+            </summary>
+            <param name="enumValue">The OData enum value.</param>
+            <param name="enumType">The EDM enum type.</param>
+            <param name="memberMapAnnotation">The annotation containing the mapping of CLR enum members to EDM enum members.</param>
+            <returns>The deserialized flags enum value.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataPrimitiveDeserializer">
             <summary>
             Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Deserialization.ODataDeserializer"/> that can read OData primitive types.
@@ -4650,6 +4659,14 @@
             <param name="enumType">The EDM enum type of the value.</param>
             <param name="writeContext">The serializer write context.</param>
             <returns>The created <see cref="T:Microsoft.OData.ODataEnumValue"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataEnumSerializer.GetFlagsEnumValue(System.Enum,Microsoft.OData.ModelBuilder.ClrEnumMemberAnnotation)">
+            <summary>
+            Gets the combined names of the flags set in a Flags enum value.
+            </summary>
+            <param name="graphEnum">The enum value.</param>
+            <param name="memberMapAnnotation">The annotation containing the mapping of CLR enum members to EDM enum members.</param>
+            <returns>A comma-separated string of the names of the flags that are set.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataErrorSerializer">
             <summary>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
@@ -46,6 +46,7 @@ public class EmployeesController : ODataController
                 SkillSet=new List<Skill> { Skill.CSharp, Skill.Sql },
                 Gender=Gender.Female,
                 AccessLevel=AccessLevel.Execute,
+                EmployeeType = EmployeeType.FullTime | EmployeeType.PartTime,
                 FavoriteSports=new FavoriteSports()
                 {
                     LikeMost=Sport.Pingpong,
@@ -58,6 +59,7 @@ public class EmployeesController : ODataController
                 SkillSet=new List<Skill>(),
                 Gender=Gender.Female,
                 AccessLevel=AccessLevel.Read,
+                EmployeeType = EmployeeType.Contract,
                 FavoriteSports=new FavoriteSports()
                 {
                     LikeMost=Sport.Pingpong,
@@ -70,6 +72,7 @@ public class EmployeesController : ODataController
                 SkillSet=new List<Skill> { Skill.Web, Skill.Sql },
                 Gender=Gender.Female,
                 AccessLevel=AccessLevel.Read|AccessLevel.Write,
+                EmployeeType = EmployeeType.Intern | EmployeeType.FullTime | EmployeeType.PartTime,
                 FavoriteSports=new FavoriteSports()
                 {
                     LikeMost=Sport.Pingpong|Sport.Basketball,
@@ -119,6 +122,13 @@ public class EmployeesController : ODataController
     {
         var employee = Employees.SingleOrDefault(e => e.ID == key);
         return Ok(employee.FavoriteSports);
+    }
+
+    [EnableQuery]
+    public IActionResult GetEmployeeTypeFromEmployee(int key)
+    {
+        var employee = Employees.SingleOrDefault(e => e.ID == key);
+        return Ok(employee.EmployeeType);
     }
 
     [HttpGet("Employees({key})/FavoriteSports/LikeMost")]

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Deltas;
 using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Query;
-using Microsoft.AspNetCore.OData.Routing.Attributes;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
@@ -42,10 +42,10 @@ public enum AccessLevel
 [DataContract(Name = "employeeType")]
 public enum EmployeeType
 {
-    [EnumMember(Value = "fulltime")]
+    [EnumMember(Value = "full time")]
     FullTime = 1,
 
-    [EnumMember(Value = "parttime")]
+    [EnumMember(Value = "Part Time")]
     PartTime = 2,
 
     [EnumMember(Value = "contract")]

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
@@ -23,6 +23,8 @@ public class Employee
 
     public AccessLevel AccessLevel { get; set; }
 
+    public EmployeeType EmployeeType { get; set; }
+
     public FavoriteSports FavoriteSports { get; set; }
 }
 
@@ -34,6 +36,23 @@ public enum AccessLevel
     Write = 2,
 
     Execute = 4
+}
+
+[Flags]
+[DataContract(Name = "employeeType")]
+public enum EmployeeType
+{
+    [EnumMember(Value = "fulltime")]
+    FullTime = 1,
+
+    [EnumMember(Value = "parttime")]
+    PartTime = 2,
+
+    [EnumMember(Value = "contract")]
+    Contract = 4,
+
+    [EnumMember(Value = "intern")]
+    Intern = 8
 }
 
 public enum Gender

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
@@ -21,6 +21,7 @@ internal class EnumsEdmModel
         employee.CollectionProperty<Skill>(c => c.SkillSet);
         employee.EnumProperty<Gender>(c => c.Gender);
         employee.EnumProperty<AccessLevel>(c => c.AccessLevel);
+        employee.EnumProperty<EmployeeType>(c => c.EmployeeType);
         employee.ComplexProperty<FavoriteSports>(c => c.FavoriteSports);
 
         var skill = builder.EnumType<Skill>();
@@ -36,6 +37,12 @@ internal class EnumsEdmModel
         accessLevel.Member(AccessLevel.Execute);
         accessLevel.Member(AccessLevel.Read);
         accessLevel.Member(AccessLevel.Write);
+
+        var employeeType = builder.EnumType<EmployeeType>();
+        employeeType.Member(EmployeeType.FullTime);
+        employeeType.Member(EmployeeType.PartTime);
+        employeeType.Member(EmployeeType.Contract);
+        employeeType.Member(EmployeeType.Intern);
 
         var favoriteSports = builder.ComplexType<FavoriteSports>();
         favoriteSports.EnumProperty<Sport>(f => f.LikeMost);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
@@ -267,7 +267,7 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
         response = await client.GetAsync(requestUri);
         json = await response.Content.ReadAsObject<JObject>();
         var employeeTypeValue = json.GetValue("value").ToString();
-        Assert.Equal("fulltime, parttime", employeeTypeValue);
+        Assert.Equal("full time, Part Time", employeeTypeValue);
         if (format != "application/json;odata.metadata=none")
         {
             var context = json.GetValue("@odata.context").ToString();
@@ -281,17 +281,17 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
         {
             return new TheoryDataSet<string, int, string, string>
             {
-                { "application/json;odata.metadata=full", 1, "Execute", "fulltime, parttime" },
-                { "application/json;odata.metadata=minimal", 1, "Execute", "fulltime, parttime"  },
-                { "application/json;odata.metadata=none", 1, "Execute", "fulltime, parttime" },
+                { "application/json;odata.metadata=full", 1, "Execute", "full time, Part Time" },
+                { "application/json;odata.metadata=minimal", 1, "Execute", "full time, Part Time"  },
+                { "application/json;odata.metadata=none", 1, "Execute", "full time, Part Time" },
 
                 { "application/json;odata.metadata=full", 2, "Read", "contract" },
                 { "application/json;odata.metadata=minimal", 2, "Read", "contract" },
                 { "application/json;odata.metadata=none", 2, "Read", "contract" },
 
-                { "application/json;odata.metadata=full", 3, "Read, Write", "fulltime, parttime, intern" },
-                { "application/json;odata.metadata=minimal", 3, "Read, Write", "fulltime, parttime, intern" },
-                { "application/json;odata.metadata=none", 3, "Read, Write", "fulltime, parttime, intern" },
+                { "application/json;odata.metadata=full", 3, "Read, Write", "full time, Part Time, intern" },
+                { "application/json;odata.metadata=minimal", 3, "Read, Write", "full time, Part Time, intern" },
+                { "application/json;odata.metadata=none", 3, "Read, Write", "full time, Part Time, intern" },
             };
         }
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
@@ -289,9 +289,9 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
                 { "application/json;odata.metadata=minimal", 2, "Read", "contract" },
                 { "application/json;odata.metadata=none", 2, "Read", "contract" },
 
-                { "application/json;odata.metadata=full", 3, "Read, Write", "intern, fulltime, parttime" },
-                { "application/json;odata.metadata=minimal", 3, "Read, Write", "intern, fulltime, parttime" },
-                { "application/json;odata.metadata=none", 3, "Read, Write", "intern, fulltime, parttime" },
+                { "application/json;odata.metadata=full", 3, "Read, Write", "fulltime, parttime, intern" },
+                { "application/json;odata.metadata=minimal", 3, "Read, Write", "fulltime, parttime, intern" },
+                { "application/json;odata.metadata=none", 3, "Read, Write", "fulltime, parttime, intern" },
             };
         }
     }
@@ -318,7 +318,7 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
 
         // Assert
         Assert.Equal(expectedAccessLevelValue, accessLevel);
-        Assert.Equal(expectedAccessLevelValue, accessLevel);
+        Assert.Equal(expectedEmployeeTypeValue, employeeType);
 
         if (format != "application/json;odata.metadata=none")
         {

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEnumDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEnumDeserializerTests.cs
@@ -146,10 +146,13 @@ public class ODataEnumDeserializerTests
     }
 
     [Theory]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"mon\"}", Day.Monday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday\"}", Day.Monday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday\"}", Day.Monday)]
-    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, tuesday\"}", Day.Monday | Day.Tuesday)]
-    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, tuesday\"}", Day.Monday | Day.Tuesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\" monday, friday  \"}", Day.Monday | Day.Friday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"mon, fri\"}", Day.Monday | Day.Friday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday,  tuesday \"}", Day.Monday | Day.Tuesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\" Monday, tuesday  \"}", Day.Monday | Day.Tuesday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Tuesday\"}", Day.Monday | Day.Tuesday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, tuesday, thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Tuesday, thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
@@ -158,8 +161,6 @@ public class ODataEnumDeserializerTests
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Friday\"}", Day.Monday | Day.Friday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, tuesday,  fri\"}", Day.Monday | Day.Tuesday | Day.Friday)]
     [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, fri, Wednesday\"}", Day.Monday | Day.Friday | Day.Wednesday)]
-    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, fri\"}", Day.Monday | Day.Friday)]
-    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, fri\"}", Day.Monday | Day.Friday)]
     public async Task ReadAsync_Works_ForModelAliasWithFlags(string content, Day expectedDay)
     {
         // Arrange
@@ -224,7 +225,7 @@ public class ODataEnumDeserializerTests
     [DataContract(Name = "day")]
     public enum Day
     {
-        [EnumMember(Value = "monday")]
+        [EnumMember(Value = "mon")]
         Monday = 1,
 
         [EnumMember(Value = "tuesday")]

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEnumDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataEnumDeserializerTests.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -114,12 +115,14 @@ public class ODataEnumDeserializerTests
         Assert.Equal("Blue", color.Value);
     }
 
-    [Fact]
-    public async Task ReadAsync_Works_ForModelAlias()
+    [Theory]
+    [InlineData("{\"@odata.type\":\"#NS.level\",\"value\":\"veryhigh\"}", Level.High)]
+    [InlineData("{\"@odata.type\":\"#NS.level\",\"value\":\"High\"}", Level.High)]
+    [InlineData("{\"@odata.type\":\"#NS.level\",\"value\":\"low\"}", Level.Low)]
+    [InlineData("{\"@odata.type\":\"#NS.level\",\"value\":\"Low\"}", Level.Low)]
+    public async Task ReadAsync_Works_ForModelAlias(string content, Level expectedLevel)
     {
         // Arrange
-        string content = "{\"@odata.type\":\"#NS.level\",\"value\":\"veryhigh\"}";
-
         var builder = new ODataConventionModelBuilder();
         builder.EnumType<Level>().Namespace = "NS";
         IEdmModel model = builder.GetEdmModel();
@@ -139,7 +142,47 @@ public class ODataEnumDeserializerTests
 
         // Assert
         Level level = Assert.IsType<Level>(value);
-        Assert.Equal(Level.High, level);
+        Assert.Equal(expectedLevel, level);
+    }
+
+    [Theory]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday\"}", Day.Monday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday\"}", Day.Monday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, tuesday\"}", Day.Monday | Day.Tuesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, tuesday\"}", Day.Monday | Day.Tuesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Tuesday\"}", Day.Monday | Day.Tuesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, tuesday, thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Tuesday, thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, tuesday, Thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Tuesday, Thursday\"}", Day.Monday | Day.Tuesday | Day.Thursday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, Friday\"}", Day.Monday | Day.Friday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, tuesday,  fri\"}", Day.Monday | Day.Tuesday | Day.Friday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, fri, Wednesday\"}", Day.Monday | Day.Friday | Day.Wednesday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"Monday, fri\"}", Day.Monday | Day.Friday)]
+    [InlineData("{\"@odata.type\":\"#NS.day\",\"value\":\"monday, fri\"}", Day.Monday | Day.Friday)]
+    public async Task ReadAsync_Works_ForModelAliasWithFlags(string content, Day expectedDay)
+    {
+        // Arrange
+        var builder = new ODataConventionModelBuilder();
+        builder.EnumType<Day>().Namespace = "NS";
+        IEdmModel model = builder.GetEdmModel();
+
+        ODataEnumDeserializer deserializer = new ODataEnumDeserializer();
+        ODataDeserializerContext readContext = new ODataDeserializerContext
+        {
+            Model = model,
+            ResourceType = typeof(Day)
+        };
+
+        HttpRequest request = RequestFactory.Create("Post", "http://localhost/", _edmModel);
+
+        // Act
+        object value = await deserializer.ReadAsync(ODataTestUtil.GetODataMessageReader(request.GetODataMessage(content), model),
+            typeof(Day), readContext);
+
+        // Assert
+        Day day = Assert.IsType<Day>(value);
+        Assert.Equal(expectedDay, day);
     }
 
     [Fact]
@@ -175,5 +218,25 @@ public class ODataEnumDeserializerTests
 
         [EnumMember(Value = "veryhigh")]
         High
+    }
+
+    [Flags]
+    [DataContract(Name = "day")]
+    public enum Day
+    {
+        [EnumMember(Value = "monday")]
+        Monday = 1,
+
+        [EnumMember(Value = "tuesday")]
+        Tuesday = 2,
+
+        [EnumMember(Value = "wednesday")]
+        Wednesday = 4,
+
+        [EnumMember(Value = "thursday")]
+        Thursday = 8,
+
+        [EnumMember(Value = "fri")]
+        Friday = 16
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1359](https://github.com/OData/AspNetCoreOData/issues/1359).*

### Description

Currently, the `ODataEnumSerializer` and `ODataEnumDeserializer` fails to convert multi-value Flag enums to LowerCamelCase as specified in `EnumMember` attribute. However, this works with single-value Flag enums.

### Example:

Consider the following Flag enum:
```cs
[Flags]
[DataContract(Name = "exampleEnum")]
public enum ExampleEnum
{
    [EnumMember(Value = "firstValue")]
    FirstValue = 1,

    [EnumMember(Value = "secondValue")]
    SecondValue = 2,

    [EnumMember(Value = "thirdValue")]
    ThirdValue = 4
}
```
With the default ODataEnumSerializer, a `single-value` Flag enum like `ExampleEnum.FirstValue` is correctly converted to ("`firstValue`"). However, a `multi-value` Flag enum like `ExampleEnum.FirstValue | ExampleEnum.SecondValue` is not converted to ("`firstValue, secondValue`") as expected. Instead, it remains in its original form as `"FirstValue, SecondValue"`

This change modifies both `ODataEnumSerializer` and `ODataEnumDeserializer` to correctly convert multi-value Flag enums to LowerCamelCase. This is to ensure that the `serialization` and `deserialization` of multi-value Flag enums are consistent with the single-value Flag enums.

With this change, the following are supported by default without having to write custom converters:
- `GET odata/examples`:
   ```json
  {
    "@odata.context": "https://localhost:7085/odata/$metadata#Examples",
    "value": [
      {
        "id": 1,
        "name": "Example1",
        "ExampleEnum": "firstValue"
      },
      {
        "id": 2,
        "name": "Example2",
        "ExampleEnum": "firstValue, secondValue" // support write-to multi-value Flags enums to Lower Camel Case
      },
      ...
    ]
  }
   ```

- `POST odata/examples`:
   ```json
  {
     "Id": 0,
     "Name": "John Doe Example",
     "ExampleEnum": "firstValue, thirdValue" // support read-in multi-value Flags enums in Lower Camel Case
  }
   ```

- `PATCH odata/examples(1)`:
   ```json
  {
       "ExampleEnum": "firstValue, thirdValue" // support read-in multi-value Flags enums in Lower Camel Case
  }
   ```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*