### PR TITLE
Add a README to NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ modelBuilder.EntitySet<Customer>("Customers");
 builder.Services.AddControllers().AddOData(
     options => options.Select().Filter().OrderBy().Expand().Count().SetMaxTop(null).AddRouteComponents(
         "odata",
-        modelBuilder.GetEdmModel()));
+        GetEdmModel()));
 
 var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ This is the official ASP.NET Core OData repository.
 
 * [ASP.NET Core OData 8.0 Preview for .NET 5](https://devblogs.microsoft.com/odata/asp-net-odata-8-0-preview-for-net-5/)
 
+
+#### **Documentation**:
+
+For comprehensive documentation, please refer to the following links:
+- [ASP.NET Core OData Overview](https://learn.microsoft.com/odata/webapi-8/overview)
+- [Getting Started](https://learn.microsoft.com/odata/webapi-8/getting-started)
+- [Fundamentals Overview](https://learn.microsoft.com/odata/webapi-8/fundamentals/overview)
+- [Tutorials](https://learn.microsoft.com/odata/webapi-8/tutorials/basic-crud)
+- [OData Dev Blogs](https://devblogs.microsoft.com/odata/)
+- [OData.org](https://www.odata.org/blog/)
+
 **Example**:
 * [ODataRoutingSample](https://github.com/OData/AspNetCoreOData/tree/main/sample/ODataRoutingSample): ASP.NET Core OData sample project in this repo.
   
@@ -47,8 +58,19 @@ This is the official ASP.NET Core OData repository.
  * [AspNetCoreOData.NewtonsoftJson.sln](AspNetCoreOData.NewtonsoftJson.sln)
  
    - Includes **Microsoft.AspNetCore.OData.NewtonsoftJson** project, Unit Test, E2E Test & Samples
-	
+
 ## 2. Basic Usage
+
+### Microsoft.AspNetCore.OData Package Installation
+Using .NET CLI:
+```bash
+dotnet add package Microsoft.AspNetCore.OData
+```
+
+Using Package Manager:
+```bash
+Install-Package Microsoft.AspNetCore.OData
+```
 
 In the ASP.NET Core Web Application project, update your `Startup.cs` as below:
 
@@ -77,6 +99,38 @@ public class Startup
     {
         // …
     }
+}
+```
+
+If you work with `Program.cs`, update as below. Refer to the [Getting Started Guide](https://learn.microsoft.com/odata/webapi-8/getting-started).
+```c#
+// Program.cs
+using Lab01.Models;
+using Microsoft.AspNetCore.OData;
+using Microsoft.OData.ModelBuilder;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var modelBuilder = new ODataConventionModelBuilder();
+modelBuilder.EntityType<Order>();
+modelBuilder.EntitySet<Customer>("Customers");
+
+builder.Services.AddControllers().AddOData(
+    options => options.Select().Filter().OrderBy().Expand().Count().SetMaxTop(null).AddRouteComponents(
+        "odata",
+        modelBuilder.GetEdmModel()));
+
+var app = builder.Build();
+
+app.UseRouting();
+
+app.MapControllers();
+
+app.Run();
+
+static IEdmModel GetEdmModel()
+{
+    // …
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,7 @@ public class Startup
 
 If you work with `Program.cs`, update as below. Refer to the [Getting Started Guide](https://learn.microsoft.com/odata/webapi-8/getting-started).
 ```c#
-// Program.cs
-using Lab01.Models;
-using Microsoft.AspNetCore.OData;
-using Microsoft.OData.ModelBuilder;
+// using statements
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	 <None Include="README.md" Pack="true" PackagePath="\" />
+	  <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -68,6 +69,10 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+	 <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -4,13 +4,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore.OData</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <!-- Let's generate our own assembly info -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IsPackable>true</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
### Description

This PR update `README` file to add the following:
- Add more links to ASP.NET OData documentation
- How to install `Microsoft.AspNetCore.OData` package using .NET CLI and Package Manager

It also update `csproj` file by adding `README.md` as the package readme file. This is to ensure README.md is package when generating NuGet package.

https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ 
https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile

#### Summary:
1. `<PackageReadmeFile>README.md</PackageReadmeFile>`:
    - This line specifies that the README.md file should be included as the readme file in the NuGet package. When someone views your package on NuGet.org, this README file will be displayed.
2. `<None Include="README.md" Pack="true" PackagePath="\"/>`:
   - This line includes the README.md file in the package. The `Include` attribute specifies the file to include.
   - The `Pack="true"` attribute ensures that the file is included in the NuGet package.
   - The `PackagePath="\"` attribute specifies the path within the package where the file will be placed. In this case, it places the README.md file at the root of the package.