### PR TITLE
Custom method can now have nullable parameters and nullable arguments for 9.x

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
@@ -700,7 +700,7 @@ public abstract class ExpressionBinderBase
         MethodInfo methodInfo;
         if (UriFunctionsBinder.TryGetMethodInfo(node.Name, methodArgumentsType, out methodInfo))
         {
-            return ExpressionBinderHelper.MakeFunctionCall(methodInfo, QuerySettings, arguments);
+            return ExpressionBinderHelper.MakeCustomFunctionCall(methodInfo, arguments);
         }
 
         return null;

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
@@ -247,11 +247,27 @@ internal static class ExpressionBinderHelper
         return CreateFunctionCallWithNullPropagation(functionCall, arguments, querySettings);
     }
 
-    public static Expression CreateFunctionCallWithNullPropagation(Expression functionCall, Expression[] arguments, ODataQuerySettings querySettings)
-    {
-        if (querySettings.HandleNullPropagation == HandleNullPropagationOption.True)
+        //Custom methods might contain nullable parameters and, therefore, also should be able to take arguments of type Nullable<T>
+        public static Expression MakeCustomFunctionCall(MethodInfo method, params Expression[] arguments)
         {
-            Expression test = CheckIfArgumentsAreNull(arguments);
+            Expression functionCall;
+            if (method.IsStatic)
+            {
+                functionCall = Expression.Call(null, method, arguments);
+            }
+            else
+            {
+                functionCall = Expression.Call(arguments.First(), method, arguments.Skip(1));
+            }
+
+            return functionCall;
+        }
+
+        public static Expression CreateFunctionCallWithNullPropagation(Expression functionCall, Expression[] arguments, ODataQuerySettings querySettings)
+        {
+            if (querySettings.HandleNullPropagation == HandleNullPropagationOption.True)
+            {
+                Expression test = CheckIfArgumentsAreNull(arguments);
 
             if (test == FalseConstant)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
@@ -247,27 +247,27 @@ internal static class ExpressionBinderHelper
         return CreateFunctionCallWithNullPropagation(functionCall, arguments, querySettings);
     }
 
-        //Custom methods might contain nullable parameters and, therefore, also should be able to take arguments of type Nullable<T>
-        public static Expression MakeCustomFunctionCall(MethodInfo method, params Expression[] arguments)
+    //Custom methods might contain nullable parameters and, therefore, also should be able to take arguments of type Nullable<T>
+    public static Expression MakeCustomFunctionCall(MethodInfo method, params Expression[] arguments)
+    {
+        Expression functionCall;
+        if (method.IsStatic)
         {
-            Expression functionCall;
-            if (method.IsStatic)
-            {
-                functionCall = Expression.Call(null, method, arguments);
-            }
-            else
-            {
-                functionCall = Expression.Call(arguments.First(), method, arguments.Skip(1));
-            }
-
-            return functionCall;
+            functionCall = Expression.Call(null, method, arguments);
+        }
+        else
+        {
+            functionCall = Expression.Call(arguments.First(), method, arguments.Skip(1));
         }
 
-        public static Expression CreateFunctionCallWithNullPropagation(Expression functionCall, Expression[] arguments, ODataQuerySettings querySettings)
+        return functionCall;
+    }
+
+    public static Expression CreateFunctionCallWithNullPropagation(Expression functionCall, Expression[] arguments, ODataQuerySettings querySettings)
+    {
+        if (querySettings.HandleNullPropagation == HandleNullPropagationOption.True)
         {
-            if (querySettings.HandleNullPropagation == HandleNullPropagationOption.True)
-            {
-                Expression test = CheckIfArgumentsAreNull(arguments);
+            Expression test = CheckIfArgumentsAreNull(arguments);
 
             if (test == FalseConstant)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -754,12 +754,12 @@ public abstract partial class QueryBinder
         Expression[] arguments = BindArguments(node.Parameters, context);
         IEnumerable<Type> methodArgumentsType = arguments.Select(argument => argument.Type);
 
-        // Search for custom method info that are binded to the node name
-        MethodInfo methodInfo;
-        if (UriFunctionsBinder.TryGetMethodInfo(node.Name, methodArgumentsType, out methodInfo))
-        {
-            return ExpressionBinderHelper.MakeFunctionCall(methodInfo, context.QuerySettings, arguments);
-        }
+            // Search for custom method info that are binded to the node name
+            MethodInfo methodInfo;
+            if (UriFunctionsBinder.TryGetMethodInfo(node.Name, methodArgumentsType, out methodInfo))
+            {
+                return ExpressionBinderHelper.MakeCustomFunctionCall(methodInfo, arguments);
+            }
 
         return null;
     }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -754,12 +754,12 @@ public abstract partial class QueryBinder
         Expression[] arguments = BindArguments(node.Parameters, context);
         IEnumerable<Type> methodArgumentsType = arguments.Select(argument => argument.Type);
 
-            // Search for custom method info that are binded to the node name
-            MethodInfo methodInfo;
-            if (UriFunctionsBinder.TryGetMethodInfo(node.Name, methodArgumentsType, out methodInfo))
-            {
-                return ExpressionBinderHelper.MakeCustomFunctionCall(methodInfo, arguments);
-            }
+        // Search for custom method info that are binded to the node name
+        MethodInfo methodInfo;
+        if (UriFunctionsBinder.TryGetMethodInfo(node.Name, methodArgumentsType, out methodInfo))
+        {
+            return ExpressionBinderHelper.MakeCustomFunctionCall(methodInfo, arguments);
+        }
 
         return null;
     }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/QueryBinderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/QueryBinderTests.cs
@@ -5,27 +5,23 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reflection;
-using Moq;
-using Xunit;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.AspNetCore.OData.Query.Wrapper;
+using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.AspNetCore.OData.Tests.Commons;
-using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.OData.Tests.Models;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
 using Microsoft.OData.UriParser;
-using Microsoft.AspNetCore.OData.Tests.Models;
-using Microsoft.AspNetCore.OData.TestCommon;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.OData.Tests.Query.Expressions;
 


### PR DESCRIPTION
Fixes https://github.com/OData/AspNetCoreOData/issues/1084

This PR will make it possible to create custom function for nullable types.

See PR #1090 with similar change for 8.x