### PR TITLE
Validate ODL Version in csproj against builder.versions.settings.targets and update ODataLibPackageDependency to 8.2.3

### DIFF
--- a/pipelines/azure_pipelines.yml
+++ b/pipelines/azure_pipelines.yml
@@ -57,6 +57,12 @@ extends:
           inputs:
             version: 8.x
             includePreviewVersions: true
+        
+        - task: PowerShell@2
+          displayName: Validate OData Package Versions
+          inputs:
+            targetType: 'inline'
+            script: 'powershell.exe -executionpolicy remotesigned -File $(Build.SourcesDirectory)\tool\ValidateODataPackageVersions.ps1'
         - task: DotNetCoreCLI@2
           displayName: build Microsoft.AspNetCore.OData
           inputs:

--- a/pipelines/azure_pipelines.yml
+++ b/pipelines/azure_pipelines.yml
@@ -57,7 +57,6 @@ extends:
           inputs:
             version: 8.x
             includePreviewVersions: true
-        
         - task: PowerShell@2
           displayName: Validate OData Package Versions
           inputs:

--- a/tool/ValidateODataPackageVersions.ps1
+++ b/tool/ValidateODataPackageVersions.ps1
@@ -1,4 +1,3 @@
-
 <#
 .SYNOPSIS
 Validates the package versions in the .csproj file against the lower bound of the ODataLibPackageDependency version range in the builder.versions.settings.targets.
@@ -90,7 +89,9 @@ foreach($key in $odataPackageDependenciesDict.Keys) {
     # Validate the versions
     foreach ($version in $packageVersions) {
         if ($version -ne $lowerBoundVersion) {
-            throw "Error.ODataPackageVersionsMismatch: '$key' Package version '$version' in '$CSPROJ_FILENAME' do not match the lower bound '$lowerBoundVersion' of the '$key' in '$BUILDER_VERSION_TARGETS_FILENAME'."
+            $exception = New-Object System.Exception(
+                "Error: '$key' Package version '$version' in '$csprojPath' do not match the lower bound '$lowerBoundVersion' of the '$key' in '$builderVersionTargetsPath'.")
+            throw $exception
         }
     }
 

--- a/tool/ValidateODataPackageVersions.ps1
+++ b/tool/ValidateODataPackageVersions.ps1
@@ -23,14 +23,12 @@ $BUILDER_VERSION_TARGETS_FILENAME = "builder.versions.settings.targets"
 $CSPROJ_FILENAME = "Microsoft.AspNetCore.OData.csproj"
 
 # Path to your builder.versions.settings.targets file
-if ($builderVersionTargetsPath -eq "")
-{
+if ($builderVersionTargetsPath -eq "") {
     $builderVersionTargetsPath = "$PSScriptRoot\$BUILDER_VERSION_TARGETS_FILENAME"
 }
 
 # Path to your .csproj file
-if ($csprojPath -eq "")
-{
+if ($csprojPath -eq "") {
     $csprojPath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath "src/Microsoft.AspNetCore.OData/$CSPROJ_FILENAME"
 }
 
@@ -79,7 +77,7 @@ $csprojPackageReferencesDict = @{
 }
 
 
-foreach($key in $odataPackageDependenciesDict.Keys) {
+foreach ($key in $odataPackageDependenciesDict.Keys) {
     $lowerBoundVersion = $odataPackageDependenciesDict[$key]
     $packageReferences = $PackageReference | Where-Object { $_.Include -match $csprojPackageReferencesDict[$key] }
     $packageVersions = $packageReferences.Version
@@ -90,7 +88,7 @@ foreach($key in $odataPackageDependenciesDict.Keys) {
     foreach ($version in $packageVersions) {
         if ($version -ne $lowerBoundVersion) {
             $exception = New-Object System.Exception(
-                "Error: '$key' Package version '$version' in '$csprojPath' do not match the lower bound '$lowerBoundVersion' of the '$key' in '$builderVersionTargetsPath'.")
+                "Error.VersionMismatch: '$key' version '$version' in '$csprojPath' do not match the lower bound '$lowerBoundVersion' of '$key' in '$builderVersionTargetsPath'.")
             throw $exception
         }
     }

--- a/tool/ValidateODataPackageVersions.ps1
+++ b/tool/ValidateODataPackageVersions.ps1
@@ -1,0 +1,98 @@
+
+<#
+.SYNOPSIS
+Validates the package versions in the .csproj file against the lower bound of the ODataLibPackageDependency version range in the builder.versions.settings.targets.
+
+.PARAMETER builderVersionTargetsPath
+Specifies the path to the builder.versions.settings.targets file.
+
+.PARAMETER csprojPath
+Specifies the path to the .csproj file.
+#>
+
+Param(
+  [string]
+  $builderVersionTargetsPath,
+  [string]
+  $csprojPath
+)
+
+# Constants
+$ODATA_LIB_PACKAGE_DEPENDENCY_KEY = "ODataLibPackageDependency"
+$ODATA_MODEL_BUILDER_PACKAGE_DEPENDENCY_KEY = "ODataModelBuilderPackageDependency"
+$BUILDER_VERSION_TARGETS_FILENAME = "builder.versions.settings.targets"
+$CSPROJ_FILENAME = "Microsoft.AspNetCore.OData.csproj"
+
+# Path to your builder.versions.settings.targets file
+if ($builderVersionTargetsPath -eq "")
+{
+    $builderVersionTargetsPath = "$PSScriptRoot\$BUILDER_VERSION_TARGETS_FILENAME"
+}
+
+# Path to your .csproj file
+if ($csprojPath -eq "")
+{
+    $csprojPath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath "src/Microsoft.AspNetCore.OData/$CSPROJ_FILENAME"
+}
+
+# Function to extract the OData package dependency version range from the targets file
+function Get-ODataPackageDependencyVersion {
+    param (
+        [xml]$targets,
+        [string]$dependencyName
+    )
+    $dependencyVersionRange = [string]$targets.Project.PropertyGroup.$dependencyName
+    $dependencyVersionRange = $dependencyVersionRange.Trim()
+    $dependencyVersionRange = $dependencyVersionRange -replace "\s", ""
+
+    # Extract the lower bound version from the version range
+    $lowerBoundVersion = $dependencyVersionRange -replace "\[([^\]]+),.*", '$1'
+    return $lowerBoundVersion
+}
+
+# Dictionary to store the OData package dependencies
+$odataPackageDependenciesDict = [System.Collections.Generic.Dictionary[String,String]]::new()
+
+# Load the targets file
+[xml]$targets = Get-Content $builderVersionTargetsPath
+
+# Extract the ODataLibPackageDependency version range
+$lowerBoundVersion = Get-ODataPackageDependencyVersion -targets $targets -dependencyName $ODATA_LIB_PACKAGE_DEPENDENCY_KEY
+$odataPackageDependenciesDict.Add($ODATA_LIB_PACKAGE_DEPENDENCY_KEY, $lowerBoundVersion)
+
+# Extract the ODataModelBuilderPackageDependency version range
+$lowerBoundVersion = Get-ODataPackageDependencyVersion -targets $targets -dependencyName $ODATA_MODEL_BUILDER_PACKAGE_DEPENDENCY_KEY
+$odataPackageDependenciesDict.Add($ODATA_MODEL_BUILDER_PACKAGE_DEPENDENCY_KEY, $lowerBoundVersion)
+
+# Extract the lower bound version from the version range
+$lowerBoundVersion = $odataPackageDependenciesDict[$ODATA_LIB_PACKAGE_DEPENDENCY_KEY] 
+
+# Load the .csproj file
+[xml]$csproj = Get-Content $csprojPath
+
+# Extract the PackageReference versions
+$PackageReference = $csproj.Project.ItemGroup.PackageReference
+
+# Dictionary to store the PackageReferences
+$csprojPackageReferencesDict = @{
+    $ODATA_LIB_PACKAGE_DEPENDENCY_KEY = "Microsoft.OData.Core|Microsoft.OData.Client|Microsoft.OData.Edm|Microsoft.Spatial"
+    $ODATA_MODEL_BUILDER_PACKAGE_DEPENDENCY_KEY = "Microsoft.OData.ModelBuilder"
+}
+
+
+foreach($key in $odataPackageDependenciesDict.Keys) {
+    $lowerBoundVersion = $odataPackageDependenciesDict[$key]
+    $packageReferences = $PackageReference | Where-Object { $_.Include -match $csprojPackageReferencesDict[$key] }
+    $packageVersions = $packageReferences.Version
+
+    Write-Host "Validating the package versions of '$key' in '$CSPROJ_FILENAME' against the lower bound of the '$key' version range in '$BUILDER_VERSION_TARGETS_FILENAME'."
+
+    # Validate the versions
+    foreach ($version in $packageVersions) {
+        if ($version -ne $lowerBoundVersion) {
+            throw "Error.ODataPackageVersionsMismatch: '$key' Package version '$version' in '$CSPROJ_FILENAME' do not match the lower bound '$lowerBoundVersion' of the '$key' in '$BUILDER_VERSION_TARGETS_FILENAME'."
+        }
+    }
+
+    Write-Host "Validation successful: Package versions match the lower bound of the $key version range."
+}

--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -9,7 +9,7 @@
   
     <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
-    <ODataLibPackageDependency>[8.2.2, 9.0.0)</ODataLibPackageDependency>
+    <ODataLibPackageDependency>[8.2.3, 9.0.0)</ODataLibPackageDependency>
     <ODataModelBuilderPackageDependency>[2.0.0, 3.0.0)</ODataModelBuilderPackageDependency>
   </PropertyGroup>
 

--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">9</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">1</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">2</VersionBuild>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">3</VersionBuild>
     <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
   </PropertyGroup>
   


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1387](https://github.com/OData/AspNetCoreOData/issues/1387).*

### Description:

This change involves:
- Add PowerShell script to validate the OData Package version in `Microsoft.AspNetCore.OData.csproj` against the version in `builder.versions.settings.targets`.
- Add a step in the pipeline to validate the OData Package version by running a PowerShell script.
- Update ODataLibPackageDependency version to [8.2.3, 9.0.0)

This approach is to ensure that the OData Package version in the `Microsoft.AspNetCore.OData.csproj` file matches the version in `builder.versions.settings.targets` as we consider the option of moving away hardcoded `.nuspec` file:
https://github.com/OData/AspNetCoreOData/blob/df9c340d71e69511158069b86035c01f6696d978/src/Microsoft.AspNetCore.OData.Release.nuspec#L19-L26