### PR TITLE
Checking ITruncatedCollecton.IsTruncated after enumeration. Fixes #1384

### DIFF
--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -9,8 +9,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.ServerSidePaging;
 
@@ -220,6 +223,62 @@ public class NoContainmentPagingCustomersController : ODataController
         return Ok(customer.Orders);
     }
 }
+public class UntypedPagingCustomerOrdersController : ODataController
+{
+    public ActionResult Get()
+    {
+        ODataQuerySettings querySettings = new ODataQuerySettings();
+        IEdmModel model = HttpContext.ODataFeature().Model;
+        ODataQueryOptions queryOptions = CreateQueryOptions(model);
+        SetSelectExpandClauseOnODataFeature(model.EntityContainer.FindEntitySet("UntypedPagingCustomerOrders").EntityType, new Dictionary<string, string> { { "$expand", "Orders" } });
+
+        return Ok(queryOptions.ApplyTo(NoContainmentPagingDataSource.UntypedCustomerOrders.AsQueryable(), querySettings, AllowedQueryOptions.All & ~AllowedQueryOptions.SkipToken));
+    }
+
+    private ODataQueryOptions CreateQueryOptions(IEdmModel model)
+    {
+        ODataQueryContext context = CreateQueryContext(model, Request.ODataFeature().Path);
+        ODataQueryOptions queryOptions = new ODataQueryOptions(context, Request);
+        return queryOptions;
+    }
+
+    private static ODataQueryContext CreateQueryContext(IEdmModel model, ODataPath path)
+    {
+        IEdmStructuredType edmStructuredType = null;
+        foreach (var segment in path)
+        {
+            if (segment.EdmType is IEdmCollectionType collectionType)
+                edmStructuredType = collectionType.ElementType.AsEntity().EntityDefinition();
+            if (segment.EdmType is IEdmEntityType entityType)
+                edmStructuredType = entityType;
+            if (segment.EdmType is IEdmComplexType complexType)
+                edmStructuredType = complexType;
+        }
+        if (edmStructuredType == null)
+        {
+            throw new ArgumentException("No structured type in path");
+        }
+
+        return new ODataQueryContext(model, edmStructuredType, path);
+    }
+
+    private void SetSelectExpandClauseOnODataFeature(IEdmType edmEntityType, IDictionary<string, string> options = null)
+    {
+        if (!Request.IsCountRequest() && Request.ODataFeature().SelectExpandClause == null)
+        {
+            SelectExpandClause selectExpand;
+
+            ODataPath odataPath = Request.ODataFeature().Path;
+            var segment = odataPath.FirstSegment as EntitySetSegment;
+            IEdmNavigationSource source = segment?.EntitySet;
+            ODataQueryOptionParser parser = new ODataQueryOptionParser(Request.GetModel(), edmEntityType, source, options, Request.ODataFeature().Services);
+            selectExpand = parser.ParseSelectAndExpand();
+
+            //Set the SelectExpand Clause on the ODataFeature otherwise OData formatter won't show the expand and select properties in the response.
+            Request.ODataFeature().SelectExpandClause = selectExpand;
+        }
+    }
+}
 
 public class ContainmentPagingMenusController : ODataController
 {
@@ -300,9 +359,9 @@ public class CollectionPagingCustomersController : ODataController
             Tags = new List<string> { "Tier 1", "Gen-Z", "HNW" },
             Categories = new List<CollectionPagingCategory>
             {
-                CollectionPagingCategory.Retailer,
-                CollectionPagingCategory.Wholesaler,
-                CollectionPagingCategory.Distributor
+            CollectionPagingCategory.Retailer,
+            CollectionPagingCategory.Wholesaler,
+            CollectionPagingCategory.Distributor
             },
             Locations = new List<CollectionPagingLocation>(
                 Enumerable.Range(1, TargetSize).Select(dx => new CollectionPagingLocation

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -359,9 +359,9 @@ public class CollectionPagingCustomersController : ODataController
             Tags = new List<string> { "Tier 1", "Gen-Z", "HNW" },
             Categories = new List<CollectionPagingCategory>
             {
-            CollectionPagingCategory.Retailer,
-            CollectionPagingCategory.Wholesaler,
-            CollectionPagingCategory.Distributor
+                CollectionPagingCategory.Retailer,
+                CollectionPagingCategory.Wholesaler,
+                CollectionPagingCategory.Distributor
             },
             Locations = new List<CollectionPagingLocation>(
                 Enumerable.Range(1, TargetSize).Select(dx => new CollectionPagingLocation

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataSource.cs
@@ -102,7 +102,14 @@ public static class NoContainmentPagingDataSource
             Orders = orders.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
         }));
 
+    private static readonly List<UntypedPagingCustomerOrder> untypedCustomerOrders = new List<UntypedPagingCustomerOrder>(
+        Enumerable.Range(1, TargetSize).Select(idx => new UntypedPagingCustomerOrder
+        {
+            Id = idx
+        }));
+
     public static List<NoContainmentPagingCustomer> Customers => customers;
+    public static List<UntypedPagingCustomerOrder> UntypedCustomerOrders => untypedCustomerOrders;
 
     public static List<NoContainmentPagingOrder> Orders => orders;
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
@@ -42,6 +42,7 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
             typeof(ContainmentPagingCustomersController),
             typeof(ContainmentPagingCompanyController),
             typeof(NoContainmentPagingCustomersController),
+            typeof(UntypedPagingCustomerOrdersController),
             typeof(ContainmentPagingMenusController),
             typeof(ContainmentPagingRibbonController),
             typeof(CollectionPagingCustomersController));
@@ -56,6 +57,7 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
         builder.EntitySet<ContainmentPagingCustomer>("ContainmentPagingCustomers");
         builder.Singleton<ContainmentPagingCustomer>("ContainmentPagingCompany");
         builder.EntitySet<NoContainmentPagingCustomer>("NoContainmentPagingCustomers");
+        builder.EntitySet<UntypedPagingCustomerOrder>("UntypedPagingCustomerOrders");
         builder.EntitySet<NoContainmentPagingOrder>("NoContainmentPagingOrders");
         builder.EntitySet<NoContainmentPagingOrderItem>("NoContainmentPagingOrderItems");
         builder.EntitySet<ContainmentPagingMenu>("ContainmentPagingMenus");
@@ -239,6 +241,24 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
         Assert.Contains("/prefix/NoContainmentPagingCustomers/2/Orders?$expand=Items&$skip=2", content);
 
         Assert.Contains("/prefix/NoContainmentPagingCustomers?$expand=Orders", content);
+    }
+
+    [Fact]
+    public async Task VerifyExpectedNextLinksGeneratedForNestedExpandUntypedOrders()
+    {
+        // Arrange
+        var requestUri = "/prefix/UntypedPagingCustomerOrders?$expand=Orders";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+         
+        // Assert
+        Assert.Contains("/prefix/UntypedPagingCustomerOrders/1/Orders?$skip=2", content);
+        Assert.Contains("/prefix/UntypedPagingCustomerOrders/2/Orders?$skip=2", content);
+        Assert.Contains("/prefix/UntypedPagingCustomerOrders/3/Orders?$skip=2", content);
     }
 
     [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataResourceSetSerializerTests.cs
@@ -651,7 +651,7 @@ public class ODataResourceSetSerializerTests
         // Arange
         IEnumerable instance = new TruncatedEnumerable(2);
 
-        var request = RequestFactory.Create("GET", "http://localhost/Customers?$expend=Orders", opt => opt.AddRouteComponents(_model));
+        var request = RequestFactory.Create("GET", "http://localhost/Customers?$expand=Orders", opt => opt.AddRouteComponents(_model));
 
         IEdmNavigationProperty navProp = _customerSet.EntityType.NavigationProperties().First();
         SelectExpandClause selectExpandClause = new SelectExpandClause(new SelectItem[0], allSelected: true);

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/SerializationTestsHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/SerializationTestsHelpers.cs
@@ -24,7 +24,8 @@ internal class SerializationTestsHelpers
         model.AddElement(sizeType);
 
         var customerType = new EdmEntityType("Default", "Customer");
-        customerType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32);
+        var idProperty = customerType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32);
+        customerType.AddKeys(idProperty);
         customerType.AddStructuralProperty("FirstName", EdmPrimitiveTypeKind.String);
         customerType.AddStructuralProperty("LastName", EdmPrimitiveTypeKind.String);
         customerType.AddStructuralProperty("Size", new EdmComplexTypeReference(sizeType,true));

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/SerializationTestsHelpers.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/SerializationTestsHelpers.cs
@@ -106,9 +106,8 @@ internal class SerializationTestsHelpers
             specialOrderType.NavigationProperties().Single(np => np.Name == "SpecialCustomer"),
             customerSet);
 
-        NavigationSourceLinkBuilderAnnotation linkAnnotation = new MockNavigationSourceLinkBuilderAnnotation();
-        model.SetNavigationSourceLinkBuilder(customerSet, linkAnnotation);
-        model.SetNavigationSourceLinkBuilder(orderSet, linkAnnotation);
+        model.SetNavigationSourceLinkBuilder(customerSet, new NavigationSourceLinkBuilderAnnotation(customerSet, model));
+        model.SetNavigationSourceLinkBuilder(orderSet, new NavigationSourceLinkBuilderAnnotation(orderSet, model));
 
         model.AddElement(container);
         return model;


### PR DESCRIPTION
This PR fixes #1384 

The reading of ITruncatedCollection.IsTruncated (used by ODataResourceSetSerializer for nested resource sets) is postponed until after enumeration have completed.

This change is to support other implementations of ITruncatedCollection than the List<T> based TruncatedCollection<T>. Other implementations might not have the collection in memory when before enumeration starts and thus might not know if the data has been truncated like the List<T> based one.

Some tests have been added - both my attempt to write a unittest with Mocks and an E2E test.
