### PR TITLE
Allow custom implementations of ICountOptionCollection. Fixes #1382

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ICountOptionCollection.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ICountOptionCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.OData.Query;
 /// <summary>
 /// Represents a collection that has total count.
 /// </summary>
-internal interface ICountOptionCollection : IEnumerable
+public interface ICountOptionCollection : IEnumerable
 {
     /// <summary>
     /// Gets a value representing the total count of the collection.


### PR DESCRIPTION
This PR fixes #1382 

By making ICountOptionCollection public implementers can provide their own TotalCount implementation for nested resource sets.

A unit test have been included to showcase the intended use and behavior.