### PR TITLE
Fixes #1397: Conventional routing cannot identify the endpoint for action to query property without the key

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/ActionModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ActionModelExtensions.cs
@@ -103,6 +103,11 @@ public static class ActionModelExtensions
 
         // TODO: shall we make sure the type is matching?
         var keys = entityType.Key().ToArray();
+        if (keys.Length == 0)
+        {
+            return false;
+        }
+
         if (keys.Length == 1)
         {
             // one key


### PR DESCRIPTION
Fixes #1397: Conventional routing cannot identify the endpoint for action to query property without the key