### PR TITLE
Set the time zone in ODataQuerySettings from the request context

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -26,7 +26,7 @@ internal static class ODataQueryContextExtensions
             returnSettings.CopyFrom(settings);
         }
 
-        returnSettings.TimeZone = context.Request.GetTimeZoneInfo();
+        returnSettings.TimeZone ??= context.Request.GetTimeZoneInfo();
 
         return returnSettings;
     }

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -7,6 +7,7 @@
 
 using System.Linq;
 using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,8 @@ internal static class ODataQueryContextExtensions
         {
             returnSettings.CopyFrom(settings);
         }
+
+        returnSettings.TimeZone = context.Request.GetTimeZoneInfo();
 
         return returnSettings;
     }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryContextExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryContextExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataQueryOptionTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.Tests.Query.Query;
+
+public class ODataQueryContextExtensionsTests
+{
+    [Fact]
+    public void GetODataQuerySettings_WithContext_SetsTimeZone()
+    {
+        // Arrange
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging().AddControllers().AddOData();
+        IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        Mock<HttpRequest> mockHttpRequest = new Mock<HttpRequest>();
+        Mock<HttpContext> mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.SetupGet(x => x.RequestServices).Returns(serviceProvider);
+        mockHttpRequest.Setup(x => x.HttpContext)
+            .Returns(mockHttpContext.Object);
+
+        ODataQueryContext context = new ODataQueryContext
+        {
+            Request = mockHttpRequest.Object,
+        };
+
+        // Act
+        ODataQuerySettings querySettings = context.GetODataQuerySettings();
+
+        // Assert
+        Assert.NotNull(querySettings.TimeZone);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryContextExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryContextExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// <copyright file="ODataQueryOptionTests.cs" company=".NET Foundation">
+// <copyright file="ODataQueryContextExtensionsTests.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>


### PR DESCRIPTION
Fixes OData#384