### PR TITLE
Fix regression where timestamp property is incorrectly expected in complex type

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -604,12 +604,6 @@ public class ODataResourceSerializer : ODataEdmTypeSerializer
 
         InitializeODataResource(selectExpandNode, resource, resourceContext);
 
-        string etag = CreateETag(resourceContext);
-        if (etag != null)
-        {
-            resource.ETag = etag;
-        }
-
         // Try to add the dynamic properties if the structural type is open.
         AppendDynamicProperties(resource, selectExpandNode, resourceContext);
 
@@ -665,12 +659,6 @@ public class ODataResourceSerializer : ODataEdmTypeSerializer
         };
 
         InitializeODataResource(selectExpandNode, resource, resourceContext);
-
-        string etag = CreateETag(resourceContext);
-        if (etag != null)
-        {
-            resource.ETag = etag;
-        }
 
         // Try to add the dynamic properties if the structural type is open.
         AppendDynamicPropertiesInternal(resource, selectExpandNode, resourceContext);
@@ -742,6 +730,12 @@ public class ODataResourceSerializer : ODataEdmTypeSerializer
                 {
                     resource.EditLink = selfLinks.EditLink;
                 }
+            }
+
+            string etag = CreateETag(resourceContext);
+            if (etag != null)
+            {
+                resource.ETag = etag;
             }
         }
    }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagTests.cs
@@ -1,0 +1,111 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ETagTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.ETags;
+
+public class ETagTests : WebApiTestBase<ETagTests>
+{
+    public ETagTests(WebApiTestFixture<ETagTests> fixture)
+        : base(fixture)
+    {
+    }
+
+    protected static void UpdateConfigureServices(IServiceCollection services)
+    {
+        services.ConfigureControllers(typeof(ETagSimpleThingsController), typeof(MetadataController));
+        services.AddControllers().AddOData(options => options.Select().AddRouteComponents(GetEdmModel()));
+
+        services.AddControllers(opt => opt.Filters.Add(new ETagActionFilterAttribute()));
+    }
+
+    private static IEdmModel GetEdmModel()
+    {
+        var modelBuilder = new ODataConventionModelBuilder();
+        modelBuilder.EntitySet<ETagSimpleThing>("ETagSimpleThings");
+        modelBuilder.ComplexType<ETagComplexThing>();
+
+        return modelBuilder.GetEdmModel();
+    }
+
+    [Fact]
+    public async Task TestETagInPayloadForEntityWithNestedComplexProperty()
+    {
+        // Arrange
+        HttpClient client = CreateClient();
+        string requestUri = "ETagSimpleThings";
+
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        var result = (await response.Content.ReadAsObject<JObject>())["value"] as JArray;
+        Assert.Equal(2, result.Count);
+        var resultAt0 = Assert.IsType<JObject>(result[0]);
+        var resultAt1 = Assert.IsType<JObject>(result[1]);
+        Assert.Equal("W/\"MA==\"", resultAt0.GetValue("@odata.etag"));
+        Assert.Equal("W/\"MA==\"", resultAt1.GetValue("@odata.etag"));
+    }
+
+    [Fact]
+    public async Task TestETagInHeaderForEntityWithNestedComplexProperty()
+    {
+        // Arrange
+        HttpClient client = CreateClient();
+        string requestUri = "ETagSimpleThings(1)";
+
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(response.Headers.ETag);
+        var etagInHeader = response.Headers.ETag.ToString();
+        Assert.Equal("W/\"MA==\"", etagInHeader);
+    }
+
+    [Fact]
+    public async Task TestMetadataForEntityWithNestedComplexProperty()
+    {
+        // Arrange
+        HttpClient client = CreateClient();
+        string requestUri = "$metadata";
+
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("<EntitySet Name=\"ETagSimpleThings\" EntityType=\"Microsoft.AspNetCore.OData.E2E.Tests.ETags.ETagSimpleThing\">" +
+            "<Annotation Term=\"Org.OData.Core.V1.OptimisticConcurrency\">" +
+            "<Collection>" +
+            "<PropertyPath>RowChangeNumber</PropertyPath>" +
+            "</Collection>" +
+            "</Annotation>" +
+            "</EntitySet>",
+            content);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
@@ -177,6 +177,34 @@ public class ETagsCustomersController : ODataController
     }
 }
 
+public class ETagSimpleThingsController : ODataController
+{
+    private readonly static ETagSimpleThing[] things =
+    [
+        new ETagSimpleThing { Id = 1, Name = "Thing 1", ComplexThing = new ETagComplexThing { Name = "Complex 1" } },
+        new ETagSimpleThing { Id = 2, Name = "Thing 2" }
+    ];
+
+    [EnableQuery]
+    public ActionResult<IEnumerable<ETagSimpleThing>> Get()
+    {
+        return Ok(things);
+    }
+
+    [EnableQuery]
+    public ActionResult<ETagSimpleThing> Get(int key)
+    {
+        var thing = things.FirstOrDefault(t => t.Id == key);
+
+        if (thing == null)
+        {
+            return NotFound();
+        }
+
+        return thing;
+    }
+}
+
 internal class Helpers
 {
     internal static ETagsCustomer CreateCustomer(int i)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
@@ -42,3 +42,18 @@ public class ETagsCustomer
     [Contained]
     public ETagsCustomer ContainedCustomer { get; set; }
 }
+
+public class ETagSimpleThing
+{
+    [Key]
+    public int Id { get; set; }
+    [Timestamp]
+    public ulong RowChangeNumber { get; set; }
+    public string Name { get; set; }
+    public ETagComplexThing ComplexThing { get; set; }
+}
+
+public class ETagComplexThing
+{
+    public string Name { get; set; }
+}


### PR DESCRIPTION
Fixes #1400

## Description
Fix regression where timestamp property is incorrectly expected in complex type.

Regression introduced in https://github.com/OData/AspNetCoreOData/pull/1365 after the call for `CreateTag` was moved to an execution path that handles complex nested resource as well.

CreateResource:
https://github.com/OData/AspNetCoreOData/blob/c860cdc6e4f63081bdefc16e4e21873952f8101f/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs#L607

### Additional Details:
`CreateTag` method calls `GetConcurrencyProperties(IEdmModel, IEdmNavigationSource)`. When writing a complex nested resource, `ResourceContext.NavigationSource` will be initialized to the navigation source for the parent entity type. For that reason, the concurrency properties returned will be for `IEdmNavigationSource.EntityType`, which is what causes an exception to be thrown since the complex type doesn't contain a property with the concurrency property name. It is not expected that complex types contain concurrency properties.

The `CreateTag` call was moved to the `if (resourceContext.StructuredType.TypeKind == EdmTypeKind.Entity && resourceContext.NavigationSource != null)` block to fix the bug:
![image](https://github.com/user-attachments/assets/f005cc54-392a-43a9-8840-3e18006ce8fd)

Before https://github.com/OData/AspNetCoreOData/pull/1365: https://github.com/OData/AspNetCoreOData/blob/73e0378e7f651f1dfc77dbae0acd4cb3716ce975/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs#L617

