### PR TITLE
Fix date() and time() function translation (#792)

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
@@ -390,10 +390,12 @@ public abstract class ExpressionBinderBase
 
         // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
         Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateOrOffset(arguments[0].Type));
-
-        // EF doesn't support new Date(int, int, int), also doesn't support other property access, for example DateTime.Date.
-        // Therefore, we just return the source (DateTime or DateTimeOffset).
-        return arguments[0];
+        
+        Type type = Nullable.GetUnderlyingType(arguments[0].Type) ?? arguments[0].Type;
+        PropertyInfo property = type.GetProperty(nameof(DateTime.Date));
+        
+        Expression propertyAccessExpr = ExpressionBinderHelper.MakePropertyAccess(property, arguments[0], QuerySettings);
+        return ExpressionBinderHelper.CreateFunctionCallWithNullPropagation(propertyAccessExpr, arguments, QuerySettings);
     }
 
     private Expression BindNow(SingleValueFunctionCallNode node)
@@ -403,7 +405,7 @@ public abstract class ExpressionBinderBase
         // Function Now() does not take any arguments.
         Expression[] arguments = BindArguments(node.Parameters);
         Contract.Assert(arguments.Length == 0);
-
+        
         return Expression.Property(null, typeof(DateTimeOffset), "UtcNow");
     }
 
@@ -416,9 +418,11 @@ public abstract class ExpressionBinderBase
         // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
         Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateOrOffset(arguments[0].Type));
 
-        // EF doesn't support new TimeOfDay(int, int, int, int), also doesn't support other property access, for example DateTimeOffset.DateTime.
-        // Therefore, we just return the source (DateTime or DateTimeOffset).
-        return arguments[0];
+        Type type = Nullable.GetUnderlyingType(arguments[0].Type) ?? arguments[0].Type;
+        PropertyInfo property = type.GetProperty(nameof(DateTime.TimeOfDay));
+
+        Expression propertyAccessExpr = ExpressionBinderHelper.MakePropertyAccess(property, arguments[0], QuerySettings);
+        return ExpressionBinderHelper.CreateFunctionCallWithNullPropagation(propertyAccessExpr, arguments, QuerySettings);
     }
 
     private Expression BindFractionalSeconds(SingleValueFunctionCallNode node)

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -699,9 +699,11 @@ public abstract partial class QueryBinder
         // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
         Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateOrOffset(arguments[0].Type));
 
-        // EF doesn't support new Date(int, int, int), also doesn't support other property access, for example DateTime.Date.
-        // Therefore, we just return the source (DateTime or DateTimeOffset).
-        return arguments[0];
+        Type type = Nullable.GetUnderlyingType(arguments[0].Type) ?? arguments[0].Type;
+        PropertyInfo property = type.GetProperty(nameof(DateTime.Date));
+        
+        Expression propertyAccessExpr = ExpressionBinderHelper.MakePropertyAccess(property, arguments[0], context.QuerySettings);
+        return ExpressionBinderHelper.CreateFunctionCallWithNullPropagation(propertyAccessExpr, arguments, context.QuerySettings);
     }
 
     /// <summary>
@@ -719,9 +721,11 @@ public abstract partial class QueryBinder
         // We should support DateTime & DateTimeOffset even though DateTime is not part of OData v4 Spec.
         Contract.Assert(arguments.Length == 1 && ExpressionBinderHelper.IsDateOrOffset(arguments[0].Type));
 
-        // EF doesn't support new TimeOfDay(int, int, int, int), also doesn't support other property access, for example DateTimeOffset.DateTime.
-        // Therefore, we just return the source (DateTime or DateTimeOffset).
-        return arguments[0];
+        Type type = Nullable.GetUnderlyingType(arguments[0].Type) ?? arguments[0].Type;
+        PropertyInfo property = type.GetProperty(nameof(DateTime.TimeOfDay));
+
+        Expression propertyAccessExpr = ExpressionBinderHelper.MakePropertyAccess(property, arguments[0], context.QuerySettings);
+        return ExpressionBinderHelper.CreateFunctionCallWithNullPropagation(propertyAccessExpr, arguments, context.QuerySettings);
     }
 
     /// <summary>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayController.cs
@@ -50,6 +50,11 @@ public class DCustomersController : ODataController
                 NullableOffsets = new [] { dto.AddMonths(e), (DateTimeOffset?)null, dto.AddDays(e) },
                 NullableDates = new [] { (Date)dto.AddYears(e).Date, (Date?)null, (Date)dto.AddMonths(e).Date },
                 NullableTimeOfDays = new [] { (TimeOfDay)dto.AddHours(e).TimeOfDay, (TimeOfDay?)null, (TimeOfDay)dto.AddMinutes(e).TimeOfDay },
+                
+                SameDayDateTime = dto.AddHours(e).DateTime,
+                SameDayNullableDateTime = e % 2 == 0 ? null : dto.AddHours(e).DateTime,
+                SameDayDateTimeOffset = dto.AddHours(6 - e),
+                SameDayNullableDateTimeOffset = e % 3 == 0 ? null : dto.AddHours(e),
 
             }).ToList();
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayController.cs
@@ -53,8 +53,8 @@ public class DCustomersController : ODataController
                 
                 SameDayDateTime = dto.AddHours(e).DateTime,
                 SameDayNullableDateTime = e % 2 == 0 ? null : dto.AddHours(e).DateTime,
-                SameDayDateTimeOffset = dto.AddHours(6 - e),
-                SameDayNullableDateTimeOffset = e % 3 == 0 ? null : dto.AddHours(e),
+                SameDayOffset = dto.AddHours(6 - e),
+                SameDayNullableOffset = e % 3 == 0 ? null : dto.AddHours(e),
 
             }).ToList();
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
@@ -43,8 +43,8 @@ public class DateAndTimeOfDayEdmModel
 
         customerType.Property(c => c.SameDayDateTime);
         customerType.Property(c => c.SameDayNullableDateTime);
-        customerType.Property(c => c.SameDayDateTimeOffset);
-        customerType.Property(c => c.SameDayNullableDateTimeOffset);
+        customerType.Property(c => c.SameDayOffset);
+        customerType.Property(c => c.SameDayNullableOffset);
 
         var customers = builder.EntitySet<DCustomer>("DCustomers");
        // customers.HasIdLink(link, true);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
@@ -41,6 +41,11 @@ public class DateAndTimeOfDayEdmModel
         customerType.CollectionProperty(c => c.NullableDates);
         customerType.CollectionProperty(c => c.NullableTimeOfDays);
 
+        customerType.Property(c => c.SameDayDateTime);
+        customerType.Property(c => c.SameDayNullableDateTime);
+        customerType.Property(c => c.SameDayDateTimeOffset);
+        customerType.Property(c => c.SameDayNullableDateTimeOffset);
+
         var customers = builder.EntitySet<DCustomer>("DCustomers");
        // customers.HasIdLink(link, true);
        // customers.HasEditLink(link, true);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
@@ -42,8 +42,8 @@ public class DCustomer
     
     public DateTime SameDayDateTime { get; set; }
     public DateTime? SameDayNullableDateTime { get; set; }
-    public DateTimeOffset SameDayDateTimeOffset { get; set; }
-    public DateTimeOffset? SameDayNullableDateTimeOffset { get; set; }
+    public DateTimeOffset SameDayOffset { get; set; }
+    public DateTimeOffset? SameDayNullableOffset { get; set; }
 }
 
 public class EfCustomer

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
@@ -39,6 +39,11 @@ public class DCustomer
     public IList<DateTimeOffset?> NullableOffsets { get; set; }
     public IList<Date?> NullableDates { get; set; }
     public IList<TimeOfDay?> NullableTimeOfDays { get; set; }
+    
+    public DateTime SameDayDateTime { get; set; }
+    public DateTime? SameDayNullableDateTime { get; set; }
+    public DateTimeOffset SameDayDateTimeOffset { get; set; }
+    public DateTimeOffset? SameDayNullableDateTimeOffset { get; set; }
 }
 
 public class EfCustomer

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DateAndTimeOfDay/DateAndTimeOfDayTest.cs
@@ -273,6 +273,18 @@ public class DateAndTimeOfDayTest : WebApiTestBase<DateAndTimeOfDayTest>
 
                 new[] {"$orderby=NullableTimeOfDay", "3 > 1 > 2 > 4 > 5"},
                 new[] {"$orderby=NullableTimeOfDay desc", "5 > 4 > 2 > 1 > 3"},
+                
+                new[] {"$orderby=date(SameDayDateTime), Id desc", "5 > 4 > 3 > 2 > 1"},
+                new[] {"$orderby=date(SameDayNullableDateTime), Id desc", "4 > 2 > 5 > 3 > 1"},
+                
+                new[] {"$orderby=date(SameDayDateTimeOffset), Id desc", "5 > 4 > 3 > 2 > 1"},
+                new[] {"$orderby=date(SameDayNullableDateTimeOffset), Id desc", "3 > 5 > 4 > 2 > 1"},
+                
+                new[] {"$orderby=time(SameDayDateTime)", "1 > 2 > 3 > 4 > 5"},
+                new[] {"$orderby=time(SameDayNullableDateTime)", "2 > 4 > 1 > 3 > 5"},
+                
+                new[] {"$orderby=time(SameDayDateTimeOffset)", "5 > 4 > 3 > 2 > 1"},
+                new[] {"$orderby=time(SameDayNullableDateTimeOffset)", "3 > 1 > 2 > 4 > 5"},
             };
             TheoryDataSet<string, string, string> data = new TheoryDataSet<string, string, string>();
             foreach (string mode in modes)
@@ -559,6 +571,10 @@ public class DateAndTimeOfDayTest : WebApiTestBase<DateAndTimeOfDayTest>
 
                 new[] {"$orderby=NullableOffset", "3 > 1 > 2 > 4 > 5"},
                 new[] {"$orderby=NullableOffset desc", "5 > 4 > 2 > 1 > 3"},
+                
+                new[] {"$orderby=date(NullableDateTime), Id desc", "4 > 2 > 3 > 1 > 5"},
+                
+                new[] {"$orderby=time(DateTime)", "1 > 2 > 3 > 4 > 5"},
             };
             TheoryDataSet<string, string> data = new TheoryDataSet<string, string>();
             foreach (string[] order in orders)


### PR DESCRIPTION
Fix #792 - `date()` function not being translated. Also fixes similar issue of `time()` function not being translated.

The comments previously implied that the `Date` and `TimeOfDay` properties of `DateTime` and `DateTimeOffset` were not supported by EF, but this is not the case with EF Core (see [function mappings documentation](https://learn.microsoft.com/en-us/ef/core/providers/sql-server/functions#date-and-time-functions)).

The translation has been updated to use these properties for the functions so that they work correctly. Test cases have been added for when they are used in $orderby specifically.

Note that this issue was not present in most circumstances when the `date()` function was used in $filter due to the type conversion used when dealing with Date types in binary expressions resulting in dates being compared via an integer representation instead: https://github.com/OData/AspNetCoreOData/blob/c860cdc6e4f63081bdefc16e4e21873952f8101f/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs#L425-L441

This won't work with EF6 as it doesn't support translating the `Date` property. Not sure if this is a problem, does this library even officially support EF6? Attempting to work around it feels somewhat out of scope.