### PR TITLE
Fix regression causing navigation properties to be auto-expanded in typeless scenarios

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterHelper.cs
@@ -159,6 +159,7 @@ internal static class ODataOutputFormatterHelper
             writeContext.QueryOptions = queryOptions;
             writeContext.SetComputedProperties(queryOptions?.Compute?.ComputeClause);
             writeContext.Type = type;
+            writeContext.IsDelta = serializer.ODataPayloadKind == ODataPayloadKind.Delta;
 
             //Set the SelectExpandClause on the context if it was explicitly specified.
             if (selectExpandDifferentFromQueryOptions != null)

--- a/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmEntityObjectCollection.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmEntityObjectCollection.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// <copyright file="EdmEntityCollectionObject.cs" company=".NET Foundation">
+// <copyright file="EdmEntityObjectCollection.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -4792,14 +4792,13 @@
             <param name="writer">The ODataWriter.</param>
             <returns>A task that represents the asynchronous write operation</returns>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.WriteResourceContent(Microsoft.OData.ODataWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode,Microsoft.AspNetCore.OData.Formatter.ResourceContext,System.Boolean)">
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.WriteResourceContent(Microsoft.OData.ODataWriter,Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode,Microsoft.AspNetCore.OData.Formatter.ResourceContext)">
             <summary>
             Writes the context of a Resource
             </summary>
             <param name="writer">The <see cref="T:Microsoft.OData.ODataWriter" /> to use to write the resource contents</param>
             <param name="selectExpandNode">The <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.SelectExpandNode"/> describing the response graph.</param>
             <param name="resourceContext">The context for the resource instance being written.</param>
-            <param name="isDelta">Whether to only write changed properties of the resource</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSerializer.CreateSelectExpandNode(Microsoft.AspNetCore.OData.Formatter.ResourceContext)">
             <summary>
@@ -5124,7 +5123,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/> class.
             </summary>
-            <param name="resource">The resource whose property is being nested.</param>
+            <param name="resource">The context for the resource instance being written</param>
             <param name="selectExpandClause">The <see cref="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.SelectExpandClause"/> for the property being nested.</param>
             <param name="edmProperty">The complex property being nested or the navigation property being expanded.
             If the resource property is the dynamic complex, the resource property is null.
@@ -5135,7 +5134,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext"/> class for nested resources.
             </summary>
-            <param name="resource">The resource whose property is being nested.</param>
+            <param name="resourceContext">The context for the resource instance being written.</param>
             <param name="edmProperty">The complex property being nested or the navigation property being expanded.
             If the resource property is the dynamic complex, the resource property is null.
             </param>
@@ -5231,6 +5230,11 @@
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.SelectExpandClause">
             <summary>
             Gets or sets the <see cref="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.SelectExpandClause"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.IsDelta">
+            <summary>
+            Gets or sets a value indicating whether a delta payload is being serialized.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.CurrentExpandedSelectItem">
@@ -5757,27 +5761,6 @@
             Returning DeltaKind of the object within DeltaResourceSet payload
             </summary>
         </member>
-        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection">
-            <summary>
-            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmObject"/> that is a collection of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmEntityObject"/>s.
-            </summary>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.#ctor(Microsoft.OData.Edm.IEdmCollectionTypeReference)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection"/> class.
-            </summary>
-            <param name="edmType">The edm type of the collection.</param>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.#ctor(Microsoft.OData.Edm.IEdmCollectionTypeReference,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Formatter.Value.IEdmEntityObject})">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection"/> class.
-            </summary>
-            <param name="edmType">The edm type of the collection.</param>
-            <param name="list">The list that is wrapped by the new collection.</param>
-        </member>
-        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.GetEdmType">
-            <inheritdoc/>
-        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObject">
             <summary>
             Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmEntityObject"/> with no backing CLR <see cref="T:System.Type"/>.
@@ -5801,6 +5784,27 @@
             </summary>
             <param name="edmType">The <see cref="T:Microsoft.OData.Edm.IEdmEntityType"/> of this object.</param>
             <param name="isNullable">true if this object can be nullable; otherwise, false.</param>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection">
+            <summary>
+            Represents an <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmObject"/> that is a collection of <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.IEdmEntityObject"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.#ctor(Microsoft.OData.Edm.IEdmCollectionTypeReference)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection"/> class.
+            </summary>
+            <param name="edmType">The edm type of the collection.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.#ctor(Microsoft.OData.Edm.IEdmCollectionTypeReference,System.Collections.Generic.IList{Microsoft.AspNetCore.OData.Formatter.Value.IEdmEntityObject})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection"/> class.
+            </summary>
+            <param name="edmType">The edm type of the collection.</param>
+            <param name="list">The list that is wrapped by the new collection.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObjectCollection.GetEdmType">
+            <inheritdoc/>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Value.EdmEnumObject">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Shipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Shipped.txt
@@ -470,7 +470,6 @@ Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Naviga
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.NavigationSource.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.ODataSerializerContext() -> void
-Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.ODataSerializerContext(Microsoft.AspNetCore.OData.Formatter.ResourceContext resource, Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmProperty edmProperty) -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Path.get -> Microsoft.OData.UriParser.ODataPath
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.Path.set -> void
 Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.QueryOptions.get -> Microsoft.AspNetCore.OData.Query.ODataQueryOptions
@@ -953,7 +952,6 @@ Microsoft.AspNetCore.OData.Query.HandleNullPropagationOption.False = 2 -> Micros
 Microsoft.AspNetCore.OData.Query.HandleNullPropagationOption.True = 1 -> Microsoft.AspNetCore.OData.Query.HandleNullPropagationOption
 Microsoft.AspNetCore.OData.Query.HttpRequestODataQueryExtensions
 Microsoft.AspNetCore.OData.Query.ICountOptionCollection
-Microsoft.AspNetCore.OData.Query.ICountOptionCollection.TotalCount.get -> long?Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.CanParse(Microsoft.AspNetCore.Http.HttpRequest request) -> bool
 Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser.ParseAsync(Microsoft.AspNetCore.Http.HttpRequest request) -> System.Threading.Tasks.Task<string>
 Microsoft.AspNetCore.OData.Query.ODataQueryContext

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializerContext.ODataSerializerContext(Microsoft.AspNetCore.OData.Formatter.ResourceContext resource, Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmProperty edmProperty) -> void
+Microsoft.AspNetCore.OData.Query.ICountOptionCollection.TotalCount.get -> long?
+Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessController.cs
@@ -1,0 +1,77 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter.Value;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+public class TypelessDeltaController : ODataController
+{
+    [HttpGet]
+    public EdmChangedObjectCollection GetChanges()
+    {
+        return TypelessDataSource.TypelessChangeSets;
+    }
+}
+
+public class TypedDeltaController : ODataController
+{
+    [HttpGet]
+    public DeltaSet<ChangeSet> GetChanges()
+    {
+        return TypelessDataSource.TypedChangeSets;
+    }
+}
+
+public class TypelessOrdersController : ODataController
+{
+    [HttpGet("Orders")]
+    public EdmEntityObjectCollection Get()
+    {
+        Request.Process();
+
+        return TypelessDataSource.TypelessUnchangedOrders;
+    }
+
+    [HttpGet("Orders({key})")]
+    public IEdmEntityObject Get(int key)
+    {
+        Request.Process();
+
+        var orderEntityObject = TypelessDataSource.TypelessUnchangedOrders.FirstOrDefault(d =>
+        {
+            if (d.TryGetPropertyValue("Id", out object value) && value.Equals(key))
+            {
+                return true;
+            }
+
+            return false;
+        });
+
+        return orderEntityObject;
+    }
+
+    [HttpGet("Orders/GetChanged()")]
+    public ActionResult<EdmChangedObjectCollection> GetChanged()
+    {
+        Request.Process();
+
+        return TypelessDataSource.TypelessChangedOrders;
+    }
+
+    [HttpGet("Orders/GetUnchanged()")]
+    public ActionResult<EdmEntityObjectCollection> GetUnchanged()
+    {
+        Request.Process();
+
+        return TypelessDataSource.TypelessUnchangedOrders;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessDataModel.cs
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+// Types included for comparison with typeless scenario
+public class ChangeSet
+{
+    public int Id { get; set; }
+    public object Changed { get; set; }
+}
+
+public class Customer
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public decimal CreditLimit { get; set; }
+    public List<Order> Orders { get; set; }
+}
+
+public class Order
+{
+    public int Id { get; set; }
+    public decimal Amount { get; set; }
+    public DateTimeOffset OrderDate { get; set; }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessDataSource.cs
@@ -1,0 +1,212 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessDataSource.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter.Value;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+internal static class TypelessDataSource
+{
+    private readonly static EdmChangedObjectCollection typelessChangeSets;
+    private readonly static DeltaSet<ChangeSet> typedChangeSets;
+    private readonly static EdmEntityObjectCollection typelessUnchangedOrders;
+    private readonly static EdmChangedObjectCollection typelessChangedOrders;
+
+    static TypelessDataSource()
+    {
+        typelessChangeSets = CreateTypelessChangeSets();
+        typedChangeSets = CreateTypedChangedSets();
+        typelessUnchangedOrders = CreateUnchangedOrders();
+        typelessChangedOrders = CreateChangedOrders();
+    }
+
+    private static EdmChangedObjectCollection CreateTypelessChangeSets()
+    {
+        var changeSets = new EdmChangedObjectCollection(TypelessEdmModel.ChangeSetEntityType);
+
+        var changeSetObject1 = new EdmEntityObject(TypelessEdmModel.ChangeSetEntityType);
+        changeSetObject1.TrySetPropertyValue("Id", 1);
+        changeSetObject1.TrySetPropertyValue("Changed", CreateTypelessChangedCustomer());
+        changeSets.Add(changeSetObject1);
+
+        var changeSetObject2 = new EdmEntityObject(TypelessEdmModel.ChangeSetEntityType);
+        changeSetObject2.TrySetPropertyValue("Id", 2);
+        changeSetObject2.TrySetPropertyValue("Changed", CreateTypelessChangedOrder());
+        changeSets.Add(changeSetObject2);
+
+        return changeSets;
+    }
+
+    private static DeltaSet<ChangeSet> CreateTypedChangedSets()
+    {
+        var changeSetDeltaSet = new DeltaSet<ChangeSet>();
+
+        var changeSetDeltaItem1 = new Delta<ChangeSet>();
+        changeSetDeltaItem1.TrySetPropertyValue("Id", 1);
+        changeSetDeltaItem1.TrySetPropertyValue("Changed", CreateTypedChangedCustomer());
+        changeSetDeltaSet.Add(changeSetDeltaItem1);
+
+        var changeSetDeltaItem2 = new Delta<ChangeSet>();
+        changeSetDeltaItem2.TrySetPropertyValue("Id", 2);
+        changeSetDeltaItem2.TrySetPropertyValue("Changed", CreateTypedChangedOrder());
+        changeSetDeltaSet.Add(changeSetDeltaItem2);
+
+        return changeSetDeltaSet;
+    }
+
+    private static EdmDeltaResourceObject CreateTypelessChangedCustomer()
+    {
+        var changedOrders = new EdmChangedObjectCollection(
+            EdmCoreModel.Instance.GetEntityType());
+
+        var changeOrder1Object = new EdmDeltaResourceObject(TypelessEdmModel.OrderEntityType);
+        changeOrder1Object.TrySetPropertyValue("Id", 1);
+        changedOrders.Add(changeOrder1Object);
+
+        var changedOrder2Object = new EdmDeltaDeletedResourceObject(TypelessEdmModel.OrderEntityType);
+        changedOrder2Object.Id = new Uri("http://tempuri.org/Orders(2)");
+        changedOrder2Object.TrySetPropertyValue("Id", 2);
+        changedOrders.Add(changedOrder2Object);
+
+        var changedCustomerObject = new EdmDeltaResourceObject(TypelessEdmModel.CustomerEntityType);
+        changedCustomerObject.TrySetPropertyValue("Id", 1);
+        changedCustomerObject.TrySetPropertyValue("Orders", changedOrders);
+
+        return changedCustomerObject;
+    }
+
+    private static EdmDeltaResourceObject CreateTypelessChangedOrder()
+    {
+        var changedOrderObject = new EdmDeltaResourceObject(TypelessEdmModel.OrderEntityType);
+        changedOrderObject.TrySetPropertyValue("Id", 1);
+        changedOrderObject.TrySetPropertyValue("Amount", 310m);
+
+        return changedOrderObject;
+    }
+
+    private static Delta<Customer> CreateTypedChangedCustomer()
+    {
+        var ordersDeltaSet = new DeltaSet<Order>();
+
+        var order1DeltaObject = new Delta<Order>();
+        order1DeltaObject.TrySetPropertyValue("Id", 1);
+        ordersDeltaSet.Add(order1DeltaObject);
+
+        var order2DeltaObject = new DeltaDeletedResource<Order>();
+        order2DeltaObject.Id = new Uri("http://tempuri.org/Orders(2)");
+        order2DeltaObject.TrySetPropertyValue("Id", 2);
+        ordersDeltaSet.Add(order2DeltaObject);
+
+        var customerDeltaObject = new Delta<Customer>();
+        customerDeltaObject.TrySetPropertyValue("Id", 1);
+        customerDeltaObject.TrySetPropertyValue("Orders", ordersDeltaSet);
+
+        return customerDeltaObject;
+    }
+
+    private static Delta<Order> CreateTypedChangedOrder()
+    {
+        var orderDeltaObject = new Delta<Order>();
+        orderDeltaObject.TrySetPropertyValue("Id", 1);
+        orderDeltaObject.TrySetPropertyValue("Amount", 310m);
+
+        return orderDeltaObject;
+    }
+
+    private static EdmEntityObjectCollection CreateUnchangedOrders()
+    {
+        var address1Object = new EdmComplexObject(TypelessEdmModel.AddressComplexType);
+        address1Object.TrySetPropertyValue("City", "Redmond");
+        address1Object.TrySetPropertyValue("State", "Washington");
+
+        var address2Object = new EdmComplexObject(TypelessEdmModel.AddressComplexType);
+        address2Object.TrySetPropertyValue("City", "Dallas");
+        address2Object.TrySetPropertyValue("State", "Texas");
+
+        var customer1Object = new EdmEntityObject(TypelessEdmModel.CustomerEntityType);
+        customer1Object.TrySetPropertyValue("Id", 1);
+        customer1Object.TrySetPropertyValue("Name", "Sue");
+        customer1Object.TrySetPropertyValue("CreditLimit", 1300m);
+
+        var customer2Object = new EdmEntityObject(TypelessEdmModel.CustomerEntityType);
+        customer2Object.TrySetPropertyValue("Id", 2);
+        customer2Object.TrySetPropertyValue("Name", "Joe");
+        customer2Object.TrySetPropertyValue("CreditLimit", 1700m);
+
+        var order1Object = new EdmEntityObject(TypelessEdmModel.OrderEntityType);
+        order1Object.TrySetPropertyValue("Id", 1);
+        order1Object.TrySetPropertyValue("Amount", 310m);
+        order1Object.TrySetPropertyValue("OrderDate", new DateTimeOffset(2025, 02, 7, 11, 59, 59, TimeSpan.Zero));
+        order1Object.TrySetPropertyValue("ShippingAddress", address1Object);
+        order1Object.TrySetPropertyValue("Customer", customer1Object);
+
+        var order2Object = new EdmEntityObject(TypelessEdmModel.OrderEntityType);
+        order2Object.TrySetPropertyValue("Id", 2);
+        order2Object.TrySetPropertyValue("Amount", 290m);
+        order2Object.TrySetPropertyValue("OrderDate", new DateTimeOffset(2025, 02, 14, 11, 59, 59, TimeSpan.Zero));
+        order2Object.TrySetPropertyValue("ShippingAddress", address2Object);
+        order2Object.TrySetPropertyValue("Customer", customer2Object);
+
+        return new EdmEntityObjectCollection(
+            new EdmCollectionTypeReference(
+                new EdmCollectionType(
+                    new EdmEntityTypeReference(TypelessEdmModel.OrderEntityType, false))))
+        {
+            order1Object,
+            order2Object
+        };
+    }
+
+    private static EdmChangedObjectCollection CreateChangedOrders()
+    {
+        // EdmComplexObject used in place of EdmDeltaComplexObject
+        var address1Object = new EdmComplexObject(TypelessEdmModel.AddressComplexType);
+        address1Object.TrySetPropertyValue("City", "Redmond");
+
+        var address2Object = new EdmDeltaComplexObject(TypelessEdmModel.AddressComplexType);
+        address2Object.TrySetPropertyValue("State", "Texas");
+
+        // EdmEntityObject used in place of EdmDeltaResourceObject
+        var customer1Object = new EdmEntityObject(TypelessEdmModel.CustomerEntityType);
+        customer1Object.TrySetPropertyValue("Id", 1);
+        customer1Object.TrySetPropertyValue("CreditLimit", 3100m);
+
+        var customer2Object = new EdmDeltaResourceObject(TypelessEdmModel.CustomerEntityType);
+        customer2Object.TrySetPropertyValue("Id", 2);
+        customer2Object.TrySetPropertyValue("Name", "Luc");
+
+        var order1Object = new EdmDeltaResourceObject(TypelessEdmModel.OrderEntityType);
+        order1Object.TrySetPropertyValue("Id", 1);
+        order1Object.TrySetPropertyValue("OrderDate", new DateTimeOffset(2025, 02, 7, 11, 59, 59, TimeSpan.Zero));
+        order1Object.TrySetPropertyValue("ShippingAddress", address1Object);
+        order1Object.TrySetPropertyValue("Customer", customer1Object);
+
+        // EdmEntityObject used in place of EdmDeltaResourceObject
+        var order2Object = new EdmEntityObject(TypelessEdmModel.OrderEntityType);
+        order2Object.TrySetPropertyValue("Id", 2);
+        order2Object.TrySetPropertyValue("Amount", 590m);
+        order2Object.TrySetPropertyValue("ShippingAddress", address2Object);
+        order2Object.TrySetPropertyValue("Customer", customer2Object);
+
+        return new EdmChangedObjectCollection(TypelessEdmModel.OrderEntityType)
+        {
+            order1Object,
+            order2Object
+        };
+    }
+
+    public static EdmChangedObjectCollection TypelessChangeSets => typelessChangeSets;
+    
+    public static DeltaSet<ChangeSet> TypedChangeSets => typedChangeSets;
+    
+    public static EdmEntityObjectCollection TypelessUnchangedOrders => typelessUnchangedOrders;
+    
+    public static EdmChangedObjectCollection TypelessChangedOrders => typelessChangedOrders;
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessEdmModel.cs
@@ -1,0 +1,133 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+internal static class TypelessEdmModel
+{
+    const string typelessNamespace = "Microsoft.AspNetCore.OData.E2E.Tests.Typeless";
+    const string defaultNamespace = "Default";
+
+    private static readonly EdmModel model;
+    private static readonly EdmEntityType deltaEntityType;
+    private static readonly EdmEntityType changeSetEntityType;
+    private static readonly EdmEntityType customerEntityType;
+    private static readonly EdmEntityType orderEntityType;
+    private static readonly EdmComplexType addressComplexType;
+
+    static TypelessEdmModel()
+    {
+        model = new EdmModel();
+
+        deltaEntityType = model.AddEntityType(typelessNamespace, "Delta");
+        var deltaChangeIdProperty = deltaEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+        deltaEntityType.AddKeys(deltaChangeIdProperty);
+
+        changeSetEntityType = model.AddEntityType(typelessNamespace, "ChangeSet");
+        var changeSetIdProperty = changeSetEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+        changeSetEntityType.AddKeys(changeSetIdProperty);
+
+        changeSetEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+        {
+            Name = "Changed",
+            Target = EdmCoreModel.Instance.GetEntityType(),
+            TargetMultiplicity = EdmMultiplicity.One
+        });
+
+        addressComplexType = model.AddComplexType(typelessNamespace, "Address");
+        addressComplexType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+        addressComplexType.AddStructuralProperty("State", EdmPrimitiveTypeKind.String);
+
+        orderEntityType = model.AddEntityType(typelessNamespace, "Order");
+        var orderIdProperty = orderEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+        orderEntityType.AddKeys(orderIdProperty);
+        orderEntityType.AddStructuralProperty("Amount", EdmPrimitiveTypeKind.Decimal);
+        orderEntityType.AddStructuralProperty("OrderDate", EdmPrimitiveTypeKind.DateTimeOffset);
+        orderEntityType.AddStructuralProperty("ShippingAddress", new EdmComplexTypeReference(addressComplexType, false));
+
+        customerEntityType = model.AddEntityType(typelessNamespace, "Customer");
+        var customerIdProperty = customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+        customerEntityType.AddKeys(customerIdProperty);
+        customerEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+        customerEntityType.AddStructuralProperty("CreditLimit", EdmPrimitiveTypeKind.Decimal);
+
+        var ordersNavigationProperty = customerEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+        {
+            Name = "Orders",
+            Target = orderEntityType,
+            TargetMultiplicity = EdmMultiplicity.Many
+        });
+
+        var customerNavigationProperty = orderEntityType.AddUnidirectionalNavigation(
+            new EdmNavigationPropertyInfo
+            {
+                Name = "Customer",
+                TargetMultiplicity = EdmMultiplicity.One,
+                Target = customerEntityType
+            });
+
+        var getChangesFunction = new EdmFunction(
+            namespaceName: defaultNamespace,
+            name: "GetChanges",
+            returnType: new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(changeSetEntityType, false))),
+            isBound: true,
+            entitySetPathExpression: null,
+            isComposable: true);
+        getChangesFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(deltaEntityType, false));
+        model.AddElement(getChangesFunction);
+
+        var orderEntityCollectionTypeReference = new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(orderEntityType, false)));
+
+        var getChangedFunction = new EdmFunction(
+            namespaceName: defaultNamespace,
+            name: "GetChanged",
+            returnType: orderEntityCollectionTypeReference,
+            isBound: true,
+            entitySetPathExpression: null,
+            isComposable: true);
+        getChangedFunction.AddParameter("bindingParameter", orderEntityCollectionTypeReference);
+        model.AddElement(getChangedFunction);
+
+        var getUnchangedFunction = new EdmFunction(
+            namespaceName: defaultNamespace,
+            name: "GetUnchanged",
+            returnType: orderEntityCollectionTypeReference,
+            isBound: true,
+            entitySetPathExpression: null,
+            isComposable: true);
+        getUnchangedFunction.AddParameter("bindingParameter", orderEntityCollectionTypeReference);
+        model.AddElement(getUnchangedFunction);
+
+        var defaultEntityContainer = model.AddEntityContainer("Default", "Container");
+        var customersEntitySet = defaultEntityContainer.AddEntitySet("Customers", customerEntityType);
+        var ordersEntitySet = defaultEntityContainer.AddEntitySet("Orders", orderEntityType);
+
+        customersEntitySet.AddNavigationTarget(ordersNavigationProperty, ordersEntitySet);
+        ordersEntitySet.AddNavigationTarget(customerNavigationProperty, customersEntitySet);
+
+        defaultEntityContainer.AddSingleton("TypelessDelta", deltaEntityType);
+        defaultEntityContainer.AddSingleton("TypedDelta", deltaEntityType);
+        defaultEntityContainer.AddEntitySet("ChangeSets", changeSetEntityType);
+
+        model.SetAnnotationValue(getChangesFunction, new ReturnedEntitySetAnnotation("ChangeSets"));
+    }
+
+    public static EdmEntityType DeltaEntityType => deltaEntityType;
+
+    public static EdmEntityType ChangeSetEntityType => changeSetEntityType;
+
+    public static EdmEntityType CustomerEntityType => customerEntityType;
+
+    public static EdmEntityType OrderEntityType => orderEntityType;
+
+    public static EdmComplexType AddressComplexType => addressComplexType;
+
+    public static EdmModel GetModel() => model;
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessExtensions.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessExtensions.cs
@@ -1,0 +1,29 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessExtensions.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+internal static class TypelessExtensions
+{
+    public static void Process(this HttpRequest request)
+    {
+        var path = request.ODataFeature().Path;
+        var elementType = path.EdmType().Definition.AsElementType();
+        var model = request.ODataFeature().Model;
+        var queryContext = new ODataQueryContext(model, elementType, path);
+        var queryOptions = new ODataQueryOptions(queryContext, request);
+
+        request.ODataFeature().SelectExpandClause = queryOptions.SelectExpand?.SelectExpandClause;
+        request.ODataFeature().ApplyClause = queryOptions.Apply?.ApplyClause;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Typeless/TypelessTests.cs
@@ -1,0 +1,207 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TypelessTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Typeless;
+
+public class TypelessTests : WebApiTestBase<TypelessTests>
+{
+    public TypelessTests(WebApiTestFixture<TypelessTests> fixture)
+        : base(fixture)
+    {
+    }
+
+    protected static void UpdateConfigureServices(IServiceCollection services)
+    {
+        var model = TypelessEdmModel.GetModel();
+
+        services.ConfigureControllers(typeof(TypelessOrdersController), typeof(TypelessDeltaController), typeof(TypedDeltaController));
+        services.AddControllers().AddOData(
+            options => options.EnableQueryFeatures().AddRouteComponents(TypelessEdmModel.GetModel()));
+    }
+
+    [Theory]
+    [InlineData("TypelessDelta/GetChanges()")]
+    [InlineData("TypedDelta/GetChanges()")] // Typed scenario included for comparison
+    public async Task TestPropertiesNotSetInDeltaAreNotIncludedInPayloadAsync(string requestUri)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith("/$metadata#ChangeSets/$delta\",\"value\":[" +
+            "{\"Id\":1," +
+            "\"Changed\":{" +
+            "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Customer\"," +
+            "\"Id\":1," +
+            "\"Orders@delta\":[{\"Id\":1},{\"@odata.removed\":{\"reason\":\"deleted\"},\"@odata.id\":\"http://tempuri.org/Orders(2)\",\"Id\":2}]}}," +
+            "{\"Id\":2," +
+            "\"Changed\":{" +
+            "\"@odata.type\":\"#Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order\"," +
+            "\"Id\":1," +
+            "\"Amount\":310}}]}",
+            content);
+    }
+
+    [Theory]
+    [InlineData("Orders", "Orders")]
+    [InlineData("Orders/GetUnchanged()", "Collection(Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order)")]
+    public async Task TestNavigationPropertyNotAutoExpandedAsync(string requestUri, string metadataFragment)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith($"/$metadata#{metadataFragment}\",\"value\":[" +
+            "{\"Id\":1," +
+            "\"Amount\":310," +
+            "\"OrderDate\":\"2025-02-07T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Redmond\",\"State\":\"Washington\"}}," +
+            "{\"Id\":2," +
+            "\"Amount\":290," +
+            "\"OrderDate\":\"2025-02-14T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Dallas\",\"State\":\"Texas\"}}]}",
+            content);
+    }
+
+    [Theory]
+    [InlineData("Orders", "Orders(Customer())")]
+    [InlineData("Orders/GetUnchanged()", "Collection(Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order)")]
+    public async Task TestNavigationPropertyExpandedAsync(string resourcePath, string metadataFragment)
+    {
+        // Arrange
+        var requestUri = $"{resourcePath}?$expand=Customer";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith($"/$metadata#{metadataFragment}\",\"value\":[" +
+            "{\"Id\":1," +
+            "\"Amount\":310," +
+            "\"OrderDate\":\"2025-02-07T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Redmond\",\"State\":\"Washington\"}," +
+            "\"Customer\":{\"Id\":1,\"Name\":\"Sue\",\"CreditLimit\":1300}}," +
+            "{\"Id\":2," +
+            "\"Amount\":290," +
+            "\"OrderDate\":\"2025-02-14T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Dallas\",\"State\":\"Texas\"}," +
+            "\"Customer\":{\"Id\":2,\"Name\":\"Joe\",\"CreditLimit\":1700}}]}",
+            content);
+    }
+
+    [Theory]
+    [InlineData("Orders", "Orders(Customer(Name))")]
+    [InlineData("Orders/GetUnchanged()", "Collection(Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order)")]
+    public async Task TestNavigationPropertyExpandedWithNestedSelectAsync(string resourcePath, string metadataFragment)
+    {
+        // Arrange
+        var requestUri = $"{resourcePath}?$expand=Customer($select=Name)";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith($"/$metadata#{metadataFragment}\",\"value\":[" +
+            "{\"Id\":1," +
+            "\"Amount\":310," +
+            "\"OrderDate\":\"2025-02-07T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Redmond\",\"State\":\"Washington\"}," +
+            "\"Customer\":{\"Name\":\"Sue\"}}," +
+            "{\"Id\":2," +
+            "\"Amount\":290," +
+            "\"OrderDate\":\"2025-02-14T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Dallas\",\"State\":\"Texas\"}," +
+            "\"Customer\":{\"Name\":\"Joe\"}}]}",
+            content);
+    }
+
+    [Theory]
+    [InlineData("Orders", "Orders(Id,Amount,Customer(Id,CreditLimit))")]
+    [InlineData("Orders/GetUnchanged()", "Collection(Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order)")]
+    public async Task TestSelectAndNavigationPropertyExpandedWithNestedSelectAsync(string resourcePath, string metadataFragment)
+    {
+        // Arrange
+        var requestUri = $"{resourcePath}?$select=Id,Amount&$expand=Customer($select=Id,CreditLimit)";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith($"/$metadata#{metadataFragment}\",\"value\":[" +
+            "{\"Id\":1,\"Amount\":310,\"Customer\":{\"Id\":1,\"CreditLimit\":1300}}," +
+            "{\"Id\":2,\"Amount\":290,\"Customer\":{\"Id\":2,\"CreditLimit\":1700}}]}",
+            content);
+    }
+
+    [Fact]
+    public async Task TestSingleResultSelectAndNavigationPropertyExpandedWithNestedSelectAsync()
+    {
+        // Arrange
+        var requestUri = "Orders(1)?$select=Id,Amount&$expand=Customer($select=Id,CreditLimit)";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith("/$metadata#Orders(Id,Amount,Customer(Id,CreditLimit))/$entity\"," +
+            "\"Id\":1,\"Amount\":310,\"Customer\":{\"Id\":1,\"CreditLimit\":1300}}",
+            content);
+    }
+
+    [Fact]
+    public async Task TestEdmEntityObjectAndEdmComplexObjectInChangedObjectCollection()
+    {
+        // Arrange
+        var requestUri = "Orders/GetChanged()";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var client = CreateClient();
+
+        // Act
+        var response = await client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.EndsWith("/$metadata#Collection(Microsoft.AspNetCore.OData.E2E.Tests.Typeless.Order)/$delta\",\"value\":[" +
+            "{\"Id\":1," +
+            "\"OrderDate\":\"2025-02-07T11:59:59Z\"," +
+            "\"ShippingAddress\":{\"City\":\"Redmond\"}," +
+            "\"Customer\":{\"Id\":1,\"CreditLimit\":3100}}," +
+            "{\"Id\":2," +
+            "\"Amount\":590," +
+            "\"ShippingAddress\":{\"State\":\"Texas\"}," +
+            "\"Customer\":{\"Id\":2,\"Name\":\"Luc\"}}]}",
+            content);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataSerializerContextTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/Serialization/ODataSerializerContextTest.cs
@@ -40,7 +40,7 @@ public class ODataSerializerContextTest
 
         // Act & Assert
         ExceptionAssert.ThrowsArgumentNull(
-            () => new ODataSerializerContext(resource: null, selectExpandClause: selectExpand, edmProperty: navProp), "resource");
+            () => new ODataSerializerContext(resource: null, selectExpandClause: selectExpand, edmProperty: navProp), "resourceContext");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1412

Fix regression causing navigation properties to be auto-expanded in typeless scenarios

The challenge we face is that `EdmEntityObject`, `EdmComplexObject`, `EdmDeltaResourceObject`, `EdmDeltaComplexObject`, and `EdmDeltaDeletedResourceObject` (together with their typed `internal` equivalents `TypedEdmEntityObject` and `TypedEdmComplexObject`) all implemement `IDelta`, `IDeltaSetItem`, and `IEdmChangedObject` interfaces directly or indirectly.

Illustration:
```csharp
using Microsoft.AspNetCore.OData.Deltas;
using Microsoft.AspNetCore.OData.Formatter.Value;
using Microsoft.OData.Edm;

var orderEntityType = new EdmEntityType("NS", "Order");
var addressComplexType = new EdmComplexType("NS", "Address");

var orderEntityObject = new EdmEntityObject(orderEntityType);
var addressComplexObject = new EdmComplexObject(addressComplexType);
var orderDeltaResourceObject = new EdmDeltaResourceObject(orderEntityType);
var addressDeltaComplexObject = new EdmDeltaComplexObject(addressComplexType);
var orderDeltaDeletedResourceObject = new EdmDeltaDeletedResourceObject(orderEntityType);

Console.WriteLine($"EdmEntityObject - Is IDelta: {orderEntityObject is IDelta}, Is DeltaSetItem: {orderEntityObject is IDeltaSetItem}, Is IEdmChangedObject: {orderEntityObject is IEdmChangedObject}, Is DeltaResource: {orderEntityObject.IsDeltaResource()}");
Console.WriteLine($"EdmComplexObject - Is IDelta: {addressComplexObject is IDelta}, Is DeltaSetItem: {addressComplexObject is IDeltaSetItem}, Is IEdmChangedObject: {addressComplexObject is IEdmChangedObject}, Is DeltaResource: {addressComplexObject.IsDeltaResource()}");
Console.WriteLine($"EdmDeltaResourceObject - Is IDelta: {orderDeltaResourceObject is IDelta}, Is DeltaSetItem: {orderDeltaResourceObject is IDeltaSetItem}, Is IEdmChangedObject: {orderDeltaResourceObject is IEdmChangedObject}, Is DeltaResource: {orderDeltaResourceObject.IsDeltaResource()}");
Console.WriteLine($"EdmDeltaComplexObject - Is IDelta: {addressDeltaComplexObject is IDelta}, Is DeltaSetItem: {addressDeltaComplexObject is IDeltaSetItem}, Is IEdmChangedObject: {addressDeltaComplexObject is IEdmChangedObject}, Is DeltaResource: {addressDeltaComplexObject.IsDeltaResource()}");
Console.WriteLine($"EdmDeltaDeletedResourceObject - Is IDelta: {orderDeltaDeletedResourceObject is IDelta}, Is DeltaSetItem: {orderDeltaDeletedResourceObject is IDeltaSetItem}, Is IEdmChangedObject: {orderDeltaDeletedResourceObject is IEdmChangedObject}, Is DeltaResource: {orderDeltaDeletedResourceObject.IsDeltaResource()}");
```

Result:
```
EdmEntityObject - Is IDelta: True, Is DeltaSetItem: True, Is IEdmChangedObject: True, Is DeltaResource: True
EdmComplexObject - Is IDelta: True, Is DeltaSetItem: True, Is IEdmChangedObject: True, Is DeltaResource: True
EdmDeltaResourceObject - Is IDelta: True, Is DeltaSetItem: True, Is IEdmChangedObject: True, Is DeltaResource: True
EdmDeltaComplexObject - Is IDelta: True, Is DeltaSetItem: True, Is IEdmChangedObject: True, Is DeltaResource: True
EdmDeltaDeletedResourceObject - Is IDelta: True, Is DeltaSetItem: True, Is IEdmChangedObject: True, Is DeltaResource: True
```

For the above reason, you can't tell by interrogating the object itself where it's a delta resource - specifically for `EdmEntityObject` and `EdmComplexObject` that can be present in both delta and non-delta payloads.

What this basically means, is that if you have a controller action like the typeless scenario below, where `Customer` is a navigation property, the navigation property is auto-expanded whether or not there's an `$expand` on the URL:
```csharp
public EdmEntityObjectCollection Get()
{
    var customerObject = new EdmEntityObject(TypelessEdmModel.CustomerEntityType);
    customerObject.TrySetPropertyValue("Id", 1);
    customerObject.TrySetPropertyValue("Name", "Sue");

    var orderObject = new EdmEntityObject(TypelessEdmModel.OrderEntityType);
    orderObject.TrySetPropertyValue("Id", 1);
    orderObject.TrySetPropertyValue("Amount", 310m);
    orderObject.TrySetPropertyValue("Customer", customerObject);

    return new EdmEntityObjectCollection(
        new EdmCollectionTypeReference(
            new EdmCollectionType(
                new EdmEntityTypeReference(TypelessEdmModel.OrderEntityType, false))))
    {
        orderObject
    };
}
```

The buggy logic is here:
https://github.com/OData/AspNetCoreOData/blob/c60d9e0e9f68d23ee8ccd84e854ef7e430fe6edb/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataResourceSerializer.cs#L497
We use the `ODataResourceSerializer` to serialize both delta and non-delta payloads. When the above statement is evaluated, it'll always return true for nearly all (if not all) typeless Edm objects, including those in the code sample above, that shouldn't be serialized as a delta.

Telling whether an object is a delta or non-delta resource in typeless scenarios becomes a dicey affair.
I propose in this pull request to use the serializer context (via `ODataSerializerContext`) to indicate whether its a delta payload being written or not.

This change fixes the regression and addresses the challenge described above.