### PR TITLE
Mark EdmDeltaResourceObject and EdmDeltaComplexObjects types as obsolete

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmDeltaComplexObject.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmDeltaComplexObject.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Value;
 /// Represents an <see cref="IEdmChangedObject"/> with no backing CLR <see cref="Type"/>.
 /// Used to hold the Entry object in the Delta Feed Payload.
 /// </summary>
+[Obsolete("EdmDeltaComplexObject is obsolete and will be dropped in the 10.x release. Please use EdmComplexObject instead.")]
 [NonValidatingParameterBinding]
 public class EdmDeltaComplexObject : EdmComplexObject
 {

--- a/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmDeltaResourceObject.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Value/EdmDeltaResourceObject.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.OData.Formatter.Value;
 /// Represents an <see cref="IEdmChangedObject"/> with no backing CLR <see cref="Type"/>.
 /// Used to hold the Entry object in the Delta Feed Payload.
 /// </summary>
+[Obsolete("EdmDeltaResourceObject is obsolete and will be dropped in the 10.x release. Please use EdmEntityObject instead.")]
 [NonValidatingParameterBinding]
 public class EdmDeltaResourceObject : EdmEntityObject, IEdmChangedObject
 {

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -2529,6 +2529,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Value.EdmComplexObjectCollecti
 }
 
 [
+ObsoleteAttribute(),
 NonValidatingParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Formatter.Value.EdmDeltaComplexObject : Microsoft.AspNetCore.OData.Formatter.Value.EdmComplexObject, IDynamicMetaObjectProvider, IDelta, IDeltaSetItem, IEdmChangedObject, IEdmComplexObject, IEdmObject, IEdmStructuredObject {
@@ -2574,6 +2575,7 @@ public class Microsoft.AspNetCore.OData.Formatter.Value.EdmDeltaLink : Microsoft
 }
 
 [
+ObsoleteAttribute(),
 NonValidatingParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Formatter.Value.EdmDeltaResourceObject : Microsoft.AspNetCore.OData.Formatter.Value.EdmEntityObject, IDynamicMetaObjectProvider, IDelta, IDeltaSetItem, IEdmChangedObject, IEdmEntityObject, IEdmObject, IEdmStructuredObject {


### PR DESCRIPTION
Mark `EdmDeltaResourceObject` and `EdmDeltaComplexObjects` types as obsolete. `EdmEntityObject` and `EdmComplexObject` respectively should be used instead.

Related to https://github.com/OData/AspNetCoreOData/issues/1429