### PR TITLE
Fix Enum Flag Logic to Correctly Match Specific Flags

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Serialization/ODataEnumSerializer.cs
@@ -201,7 +201,7 @@ public class ODataEnumSerializer : ODataEdmTypeSerializer
             long flagValue = Convert.ToInt64(flag);
 
             // Using bitwise operations to check if a flag is set, which is more efficient than Enum.HasFlag
-            if ((graphValue & flagValue) != 0 && flagValue != 0)
+            if (flagValue != 0 && (graphValue & flagValue) == flagValue)
             {
                 IEdmEnumMember flagMember = memberMapAnnotation.GetEdmEnumMember(flag);
                 if (flagMember != null)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
@@ -157,6 +157,19 @@ public class EmployeesController : ODataController
         return Updated(employee.SkillSet);
     }
 
+    [HttpPost("Employees({key})/AddAccessRight")]
+    public IActionResult AddAccessRight(int key, [FromODataBody] AccessLevel accessRight)
+    {
+        var employee = Employees.FirstOrDefault(e => e.ID == key);
+        if (employee == null)
+        {
+            return NotFound();
+        }
+
+        employee.AccessLevel = accessRight;
+        return Ok(employee.AccessLevel);
+    }
+
     public IActionResult Put(int key, [FromBody]Employee employee)
     {
         employee.ID = key;

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
@@ -31,11 +31,15 @@ public class Employee
 [Flags]
 public enum AccessLevel
 {
+    None = 0,
+
     Read = 1,
 
     Write = 2,
 
-    Execute = 4
+    Execute = 4,
+
+    Admin = 7 // Read | Write | Execute
 }
 
 [Flags]

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
@@ -34,9 +34,11 @@ internal class EnumsEdmModel
         gender.Member(Gender.Male);
 
         var accessLevel = builder.EnumType<AccessLevel>();
+        accessLevel.Member(AccessLevel.None);
         accessLevel.Member(AccessLevel.Execute);
         accessLevel.Member(AccessLevel.Read);
         accessLevel.Member(AccessLevel.Write);
+        accessLevel.Member(AccessLevel.Admin);
 
         var employeeType = builder.EnumType<EmployeeType>();
         employeeType.Member(EmployeeType.FullTime);
@@ -92,6 +94,10 @@ internal class EnumsEdmModel
 
         var functionConfiguration = employee.Function("FindAccessLevel");
         functionConfiguration.Returns<AccessLevel>();
+
+        var actionAddAccessRight = employee.Action("AddAccessRight");
+        actionAddAccessRight.Parameter<AccessLevel>("accessRight");
+        actionAddAccessRight.Returns<AccessLevel>();
     }
 
     private static void AddUnboundActionsAndFunctions(ODataModelBuilder odataModelBuilder)


### PR DESCRIPTION
## Description

This PR addresses an issue with the `Flags enum` logic where the `bitwise AND` operation `(graphValue & flagValue) != 0` incorrectly matches combined flags when only specific flags are intended. 

The current logic `(graphValue & flagValue) != 0` checks if any of the bits in `flagValue` are set. While this works for simple flag checks, it fails when combined flags are involved. For example, if `Admin` is a combination of `Read, Write, and Execute`, checking for `Read and Write` using the current logic will also match Admin, which is not the intended behavior.

```cs
[Flags]
 public enum AccessLevel
 {
     None = 0,
     Read = 1,
     Write = 2,
     Execute = 4,
     Admin = 7 // Read | Write | Execute
 }
```

To resolve this issue, the logic has been updated to `(graphValue & flagValue) == flagValue`, which ensures that only the specified flags are matched correctly. This change prevents combined flags from being incorrectly matched when checking for specific flags.