### PR TITLE
CA2254 fixes possible formatting errors

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -199,7 +199,7 @@ public class AttributeRoutingConvention : IODataControllerActionConvention
 
             // Whether we throw exception or mark it as warning is a design pattern.
             // throw new ODataException(warning);
-            _logger.LogWarning(warning);
+            _logger.LogWarning("{Message}", warning);
             return null;
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/KeySegmentTemplate.cs
@@ -208,7 +208,7 @@ public class KeySegmentTemplate : ODataSegmentTemplate
                     ILoggerFactory loggerFactory = context.HttpContext?.RequestServices?.GetService<ILoggerFactory>();
                     if (loggerFactory != null)
                     {
-                        loggerFactory.CreateLogger<KeySegmentTemplate>().LogError(message, ex);
+                        loggerFactory.CreateLogger<KeySegmentTemplate>().LogError(ex, "{Message}", message);
                         return false;
                     }
                     else

--- a/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Template/SegmentTemplateHelpers.cs
@@ -100,7 +100,7 @@ internal static class SegmentTemplateHelpers
                         ILoggerFactory loggerFactory = context.HttpContext?.RequestServices?.GetService<ILoggerFactory>();
                         if (loggerFactory != null)
                         {
-                            loggerFactory.CreateLogger("ODataFunctionParameterMatcher").LogError(message, ex);
+                            loggerFactory.CreateLogger("ODataFunctionParameterMatcher").LogError(ex, "{Message}", message);
                             return null;
                         }
                         else


### PR DESCRIPTION
According to [CA2254 docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254) template of a log message should be a static expression.
There are a number of places where instead of logging it might cause and causes in my case subsequent formatting exception. 
