### PR TITLE
Handle IAsyncEnumerable Results When Returning Non-Generic IActionResult

### DIFF
--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableController.cs
@@ -52,6 +52,13 @@ public class CustomersController : ODataController
         return Ok(_context.Customers.AsAsyncEnumerable());
     }
 
+    [EnableQuery]
+    [HttpGet("v3/Customers")]
+    public IActionResult CustomersDataNoInferred()
+    {
+        return Ok(_context.Customers.AsAsyncEnumerable());
+    }
+
     public async IAsyncEnumerable<Customer> CreateCollectionAsync<T>()
     {
         await Task.Delay(5);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
@@ -38,6 +38,9 @@ public class IAsyncEnumerableTests : WebODataTestBase<IAsyncEnumerableTests.Test
 
             services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
                 .AddRouteComponents("v2", edmModel));
+
+            services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                .AddRouteComponents("v3", edmModel));
         }
    }
 
@@ -108,5 +111,26 @@ public class IAsyncEnumerableTests : WebODataTestBase<IAsyncEnumerableTests.Test
         List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
         Assert.Equal(3, customers.Count);
         Assert.Equal(2, customers[0].Orders.Count);
+    }
+
+    [Fact]
+    public async Task UsingAsAsyncEnumerableWorksWithUntypedResult()
+    {
+        // Arrange
+        string queryUrl = "v3/Customers";
+        var expectedResult = "{\"@odata.context\":\"http://localhost/v3/$metadata#Customers\",\"value\":[{\"Id\":1,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"}},{\"Id\":2,\"Name\":\"Customer1\",\"Address\":{\"Name\":\"City0\",\"Street\":\"Street0\"}},{\"Id\":3,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"}}]}";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+        // Act
+        HttpResponseMessage response = await Client.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var resultObject = await response.Content.ReadAsStringAsync();
+        Assert.Equal(expectedResult, resultObject);
+
+        List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
+        Assert.Equal(3, customers.Count);
     }
 }


### PR DESCRIPTION
Adds an additional check in the [`ODataResourceSetSerializer`](https://github.com/OData/AspNetCoreOData/compare/main...etherfactor:bugfix/1450-async-iterator?expand=1#diff-4b47a17b59881163a375d365ce2d4f9177b8eabe5240be89ec8281584aba2d71) that handles a non-generic `IActionResult` response type.

The [`ObjectResultExecutor`](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
) infers the return type from the generic `ActionResult<>`, but falls back on the explicit type of the returned object if the action result is the non-generic `IActionResult`. When an instance of `IAsyncEnumerable<>` is returned in an `IActionResult` response, its type definition is always the generated state machine class, not `IAsyncEnumerable<>`, causing the original condition to fail.

Also adds a test that covers this particular case.