### PR TITLE
Resolve the issue with IAsyncEnumerable

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -5087,6 +5087,14 @@
             <param name="writeContext">The serializer context.</param>
             <returns>The created operation or null if the operation should not be written.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataResourceSetSerializer.IsAsyncEnumerableType(System.Type)">
+            <summary>
+            Determines whether the specified <see cref="T:System.Type"/> represents an <see cref="T:System.Collections.Generic.IAsyncEnumerable`1"/> type.
+            </summary>
+            <param name="type">The <see cref="T:System.Type"/> to evaluate.</param>
+            <returns><see langword="true"/> if the specified <paramref name="type"/> is an <see cref="T:System.Collections.Generic.IAsyncEnumerable`1"/> type;
+            otherwise, <see langword="false"/>.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.Serialization.ODataSerializer">
             <summary>
             Base class for <see cref="T:Microsoft.AspNetCore.OData.Formatter.Serialization.IODataSerializer"/> implementations.

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/IAsyncEnumerableTests/IAsyncEnumerableTests.cs
@@ -6,9 +6,10 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Net.Http.Headers;
-using System.Net.Http;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.EntityFrameworkCore;
@@ -38,6 +39,13 @@ public class IAsyncEnumerableTests : WebODataTestBase<IAsyncEnumerableTests.Test
 
             services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
                 .AddRouteComponents("v2", edmModel));
+
+            services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                .AddRouteComponents("v3", IAsyncEnumerableEdmModel.GetEdmModel()))
+                .AddJsonOptions(opt =>
+                {
+                    opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                });
         }
    }
 
@@ -108,5 +116,32 @@ public class IAsyncEnumerableTests : WebODataTestBase<IAsyncEnumerableTests.Test
         List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
         Assert.Equal(3, customers.Count);
         Assert.Equal(2, customers[0].Orders.Count);
+    }
+
+    [Theory]
+    [InlineData("None")]
+    [InlineData("Generic")]
+    [InlineData("Typed")]
+    public async Task EnsureAsyncIteratorIsTreatedAsIAsyncEnumerable(string variant)
+    {
+        // Arrange
+        string queryUrl = $"v3/Customers?variant={variant}";
+        var expectedResult = "{\"@odata.context\":\"http://localhost/v3/$metadata#Customers\",\"value\":[{\"Id\":1,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"}},{\"Id\":2,\"Name\":\"Customer1\",\"Address\":{\"Name\":\"City0\",\"Street\":\"Street0\"}},{\"Id\":3,\"Name\":\"Customer0\",\"Address\":{\"Name\":\"City1\",\"Street\":\"Street1\"}}]}";
+        
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+        // Act
+       HttpResponseMessage response = await Client.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultObject = await response.Content.ReadAsStringAsync();
+        Assert.Equal(expectedResult, resultObject);
+
+        var json = await response.Content.ReadAsStringAsync();
+        List<Customer> customers = JToken.Parse(json)["value"].ToObject<List<Customer>>();
+        Assert.Equal(3, customers.Count);
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1450.*

### Description

Currently, when returning an `IAsyncEnumerable` from an async iterator method, it is not recognized as an `IAsyncEnumerable` by the `ODataOutputFormatter`.

This change handles the scenarios where `ODataResourceSetSerializer` processes objects that implement `IAsyncEnumerable<>` indirectly through interfaces. This ensures that such objects are correctly recognized as `IAsyncEnumerable<>` and processed accordingly.

For example, both `Typed` and `Generic` variants should be identified as `IAsyncEnumerable<>` and processed correctly

1. Typed
```csharp
 asyncEnumerable = GenericAsyncEnumerableWithDelay(asyncEnumerable, TimeSpan.FromSeconds(1));

...

private async IAsyncEnumerable<Customer> TypedAsyncEnumerableWithDelay(IAsyncEnumerable<Customer> asyncEnumerable, 
    TimeSpan delay)
{
    await foreach (var entity in asyncEnumerable)
    {
        await Task.Delay(delay);
        yield return entity;
    }
}

```

2. Generic
```csharp
 asyncEnumerable = TypedAsyncEnumerableWithDelay(asyncEnumerable, TimeSpan.FromSeconds(1));

...

private async IAsyncEnumerable<TEntity> GenericAsyncEnumerableWithDelay<TEntity>(IAsyncEnumerable<TEntity> asyncEnumerable, 
    TimeSpan delay)
{
    await foreach (var entity in asyncEnumerable)
    {
        await Task.Delay(delay);
        yield return entity;
    }
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
