### PR TITLE
Enable minimal API OData

### DIFF
--- a/AspNetCoreOData.sln
+++ b/AspNetCoreOData.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ODataAlternateKeySample", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkServer", "sample\BenchmarkServer\BenchmarkServer.csproj", "{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ODataMiniApi", "sample\ODataMiniApi\ODataMiniApi.csproj", "{53645862-60E1-403A-B9BB-911D3801010F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53645862-60E1-403A-B9BB-911D3801010F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53645862-60E1-403A-B9BB-911D3801010F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53645862-60E1-403A-B9BB-911D3801010F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53645862-60E1-403A-B9BB-911D3801010F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +96,7 @@ Global
 		{647EFCFA-55A7-4F0A-AD40-4B6EB1BFCFFA} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 		{7B153669-A42F-4511-8BDB-587B3B27B2F3} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 		{8346AD1B-00E3-462D-B6B1-9AA3C2FB2850} = {B1F86961-6958-4617-ACA4-C231F95AE099}
+		{53645862-60E1-403A-B9BB-911D3801010F} = {B1F86961-6958-4617-ACA4-C231F95AE099}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {540C9752-AAC0-49EA-BA60-78490C90FF86}

--- a/sample/ODataMiniApi/AppDb.cs
+++ b/sample/ODataMiniApi/AppDb.cs
@@ -1,0 +1,180 @@
+//-----------------------------------------------------------------------------
+// <copyright file="AppDb.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+
+namespace ODataMiniApi;
+
+public class AppDb : DbContext
+{
+    public AppDb(DbContextOptions<AppDb> options) : base(options) { }
+
+    public DbSet<School> Schools => Set<School>();
+
+    public DbSet<Student> Students => Set<Student>();
+
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<School>().HasKey(x => x.SchoolId);
+        modelBuilder.Entity<Student>().HasKey(x => x.StudentId);
+        modelBuilder.Entity<School>().OwnsOne(x => x.MailAddress);
+
+        modelBuilder.Entity<Customer>().HasKey(x => x.Id);
+        modelBuilder.Entity<Order>().HasKey(x => x.Id);
+        modelBuilder.Entity<Customer>().OwnsOne(x => x.Info);
+    }
+}
+
+static class AppDbExtension
+{
+    public static void MakeSureDbCreated(this WebApplication app)
+    {
+        using (var scope = app.Services.CreateScope())
+        {
+            var services = scope.ServiceProvider;
+            var context = services.GetRequiredService<AppDb>();
+
+            if (context.Schools.Count() == 0)
+            {
+                #region Students
+                var students = new List<Student>
+                {
+                    // Mercury school
+                    new Student { SchoolId = 1, StudentId = 10, FirstName = "Spens", LastName = "Alex", FavoriteSport = "Soccer", Grade = 87, BirthDay = new DateOnly(2009, 11, 15) },
+                    new Student { SchoolId = 1, StudentId = 11, FirstName = "Jasial", LastName = "Eaine", FavoriteSport = "Basketball", Grade = 45, BirthDay = new DateOnly(1989, 8, 3) },
+                    new Student { SchoolId = 1, StudentId = 12, FirstName = "Niko", LastName = "Rorigo", FavoriteSport = "Soccer", Grade = 78, BirthDay = new DateOnly(2019, 5, 5) },
+                    new Student { SchoolId = 1, StudentId = 13, FirstName = "Roy", LastName = "Rorigo", FavoriteSport = "Tennis", Grade = 67, BirthDay = new DateOnly(1975, 11, 4) },
+                    new Student { SchoolId = 1, StudentId = 14, FirstName = "Zaral", LastName = "Clak", FavoriteSport = "Basketball", Grade = 54, BirthDay = new DateOnly(2008, 1, 4) },
+
+                    // Venus school
+                    new Student { SchoolId = 2, StudentId = 20, FirstName = "Hugh", LastName = "Briana", FavoriteSport = "Basketball", Grade = 78, BirthDay = new DateOnly(1959, 5, 6) },
+                    new Student { SchoolId = 2, StudentId = 21, FirstName = "Reece", LastName = "Len", FavoriteSport = "Basketball", Grade = 45, BirthDay = new DateOnly(2004, 2, 5) },
+                    new Student { SchoolId = 2, StudentId = 22, FirstName = "Javanny", LastName = "Jay", FavoriteSport = "Soccer", Grade = 87, BirthDay = new DateOnly(2003, 6, 5) },
+                    new Student { SchoolId = 2, StudentId = 23, FirstName = "Ketty", LastName = "Oak", FavoriteSport = "Tennis", Grade = 99, BirthDay = new DateOnly(1998, 7, 25) },
+                    
+                    // Earth School
+                    new Student { SchoolId = 3, StudentId = 30, FirstName = "Mike", LastName = "Wat", FavoriteSport = "Tennis", Grade = 93, BirthDay = new DateOnly(1999, 5, 15) },
+                    new Student { SchoolId = 3, StudentId = 31, FirstName = "Sam", LastName = "Joshi", FavoriteSport = "Soccer", Grade = 78, BirthDay = new DateOnly(2000, 6, 23) },
+                    new Student { SchoolId = 3, StudentId = 32, FirstName = "Kerry", LastName = "Travade", FavoriteSport = "Basketball", Grade = 89, BirthDay = new DateOnly(2001, 2, 6) },
+                    new Student { SchoolId = 3, StudentId = 33, FirstName = "Pett", LastName = "Jay", FavoriteSport = "Tennis", Grade = 63, BirthDay = new DateOnly(1998, 11, 7) },
+
+                    // Mars School
+                    new Student { SchoolId = 4, StudentId = 40, FirstName = "Mike", LastName = "Wat", FavoriteSport = "Soccer", Grade = 64, BirthDay = new DateOnly(2011, 11, 15) },
+                    new Student { SchoolId = 4, StudentId = 41, FirstName = "Sam", LastName = "Joshi", FavoriteSport = "Basketball", Grade = 98, BirthDay = new DateOnly(2005, 6, 6) },
+                    new Student { SchoolId = 4, StudentId = 42, FirstName = "Kerry", LastName = "Travade", FavoriteSport = "Soccer", Grade = 88, BirthDay = new DateOnly(2011, 5, 13) },
+
+                    // Jupiter School
+                    new Student { SchoolId = 5, StudentId = 50, FirstName = "David", LastName = "Padron", FavoriteSport = "Tennis", Grade = 77, BirthDay = new DateOnly(2015, 12, 3) },
+                    new Student { SchoolId = 5, StudentId = 53, FirstName = "Jeh", LastName = "Brook", FavoriteSport = "Basketball", Grade = 69, BirthDay = new DateOnly(2014, 10, 15) },
+                    new Student { SchoolId = 5, StudentId = 54, FirstName = "Steve", LastName = "Johnson", FavoriteSport = "Soccer", Grade = 100, BirthDay = new DateOnly(1995, 3, 2) },
+
+                    // Saturn School
+                    new Student { SchoolId = 6, StudentId = 60, FirstName = "John", LastName = "Haney", FavoriteSport = "Soccer", Grade = 99, BirthDay = new DateOnly(2008, 12, 1) },
+                    new Student { SchoolId = 6, StudentId = 61, FirstName = "Morgan", LastName = "Frost", FavoriteSport = "Tennis", Grade = 17, BirthDay = new DateOnly(2009, 11, 4) },
+                    new Student { SchoolId = 6, StudentId = 62, FirstName = "Jennifer", LastName = "Viles", FavoriteSport = "Basketball", Grade = 54, BirthDay = new DateOnly(1989, 3, 15) },
+
+                    // Uranus School
+                    new Student { SchoolId = 7, StudentId = 72, FirstName = "Matt", LastName = "Dally", FavoriteSport = "Basketball", Grade = 77, BirthDay = new DateOnly(2011, 11, 4) },
+                    new Student { SchoolId = 7, StudentId = 73, FirstName = "Kevin", LastName = "Vax", FavoriteSport = "Basketball", Grade = 93, BirthDay = new DateOnly(2012, 5, 12) },
+                    new Student { SchoolId = 7, StudentId = 76, FirstName = "John", LastName = "Clarey", FavoriteSport = "Soccer", Grade = 95, BirthDay = new DateOnly(2008, 8, 8) },
+
+                    // Neptune School
+                    new Student { SchoolId = 8, StudentId = 81, FirstName = "Adam", LastName = "Singh", FavoriteSport = "Tennis", Grade = 92, BirthDay = new DateOnly(2006, 6, 23) },
+                    new Student { SchoolId = 8, StudentId = 82, FirstName = "Bob", LastName = "Joe", FavoriteSport = "Soccer", Grade = 88, BirthDay = new DateOnly(1978, 11, 15) },
+                    new Student { SchoolId = 8, StudentId = 84, FirstName = "Martin", LastName = "Dalton", FavoriteSport = "Tennis", Grade = 77, BirthDay = new DateOnly(2017, 5, 14) },
+
+                    // Pluto School
+                    new Student { SchoolId = 9, StudentId = 91, FirstName = "Michael", LastName = "Wu", FavoriteSport = "Soccer", Grade = 97, BirthDay = new DateOnly(2022, 9, 22) },
+                    new Student { SchoolId = 9, StudentId = 93, FirstName = "Rachel", LastName = "Wottle", FavoriteSport = "Soccer", Grade = 81, BirthDay = new DateOnly(2022, 10, 5) },
+                    new Student { SchoolId = 9, StudentId = 97, FirstName = "Aakash", LastName = "Aarav", FavoriteSport = "Soccer", Grade = 98, BirthDay = new DateOnly(2003, 3, 15) },
+
+                    // Shyline high School
+                    new Student { SchoolId = 10, StudentId = 101, FirstName = "Steve", LastName = "Chu", FavoriteSport = "Soccer", Grade = 77, BirthDay = new DateOnly(2002, 11, 12) },
+                    new Student { SchoolId = 10, StudentId = 123, FirstName = "Wash", LastName = "Dish", FavoriteSport = "Tennis", Grade = 81, BirthDay = new DateOnly(2002, 12, 5) },
+                    new Student { SchoolId = 10, StudentId = 106, FirstName = "Ren", LastName = "Wu", FavoriteSport = "Soccer", Grade = 88, BirthDay = new DateOnly(2003, 3, 15) }
+                };
+
+                foreach (var s in students)
+                {
+                    context.Students.Add(s);
+                }
+                #endregion
+
+                #region Schools
+                var schools = new List<School>
+                {
+                    new School { SchoolId = 1, SchoolName = "Mercury Middle School", MailAddress = new Address { ApartNum = 241, City = "Kirk", Street = "156TH AVE", ZipCode = "98051" } },
+                    new HighSchool { SchoolId = 2, SchoolName = "Venus High School", MailAddress = new Address { ApartNum = 543, City = "AR", Street = "51TH AVE PL", ZipCode = "98043" }, NumberOfStudents = 1187, PrincipalName = "Venus TT" },
+                    new School { SchoolId = 3, SchoolName = "Earth University", MailAddress = new Address { ApartNum = 101, City = "Belly", Street = "24TH ST", ZipCode = "98029" } },
+                    new School { SchoolId = 4, SchoolName = "Mars Elementary School ", MailAddress = new Address { ApartNum = 123, City = "Issaca", Street = "Mars Rd", ZipCode = "98023" }  },
+                    new School { SchoolId = 5, SchoolName = "Jupiter College", MailAddress = new Address { ApartNum = 443, City = "Redmond", Street = "Sky Freeway", ZipCode = "78123" } },
+                    new School { SchoolId = 6, SchoolName = "Saturn Middle School", MailAddress = new Address { ApartNum = 11, City = "Moon", Street = "187TH ST", ZipCode = "68133" } },
+                    new HighSchool { SchoolId = 7, SchoolName = "Uranus High School", MailAddress = new Address { ApartNum = 123, City = "Greenland", Street = "Sun Street", ZipCode = "88155" }, NumberOfStudents = 886, PrincipalName = "Uranus Sun" },
+                    new School { SchoolId = 8, SchoolName = "Neptune Elementary School", MailAddress = new Address  { ApartNum = 77, City = "BadCity", Street = "Moon way", ZipCode = "89155" } },
+                    new School { SchoolId = 9, SchoolName = "Pluto University", MailAddress = new Address { ApartNum = 12004, City = "Sahamish", Street = "Universals ST", ZipCode = "10293" } },
+                    new HighSchool { SchoolId =10, SchoolName = "Shyline High School", MailAddress = new Address { ApartNum = 4004, City = "Sammamish", Street = "8TH ST", ZipCode = "98029"}, NumberOfStudents = 976, PrincipalName = "Laly Fort" }
+                };
+
+                foreach (var s in schools)
+                {
+                    s.Students = students.Where(std => std.SchoolId == s.SchoolId).ToList();
+
+                    context.Schools.Add(s);
+                }
+                #endregion
+
+                context.SaveChanges();
+            }
+
+            if (context.Customers.Count() == 0)
+            {
+                #region Customers and Orders
+
+                var customers = new List<Customer>
+                {
+                    new Customer { Id = 1, Name = "Alice", Info = new Info { Email = "alice@example.com", Phone = "123-456-7819" },
+                        Orders = [
+                            new Order { Id = 11, Amount = 9},
+                            new Order { Id = 12, Amount = 19},
+                        ] },
+                    new Customer { Id = 2, Name = "Johnson", Info = new Info { Email = "johnson@abc.com", Phone = "233-468-7289" },
+                        Orders = [
+                            new Order { Id = 21, Amount =8},
+                            new Order { Id = 22, Amount = 76},
+                        ] },
+                    new Customer { Id = 3, Name = "Peter", Info = new Info { Email = "peter@earth.org", Phone = "223-656-7889" },
+                        Orders = [
+                            new Order { Id = 32, Amount = 7 }
+                        ] },
+
+                    new Customer { Id = 4, Name = "Sam", Info = new Info { Email = "sam@ms.edu", Phone = "245-876-0989" },
+                        Orders = [
+                            new Order { Id = 41, Amount = 5 },
+                            new Order { Id = 42, Amount = 32}
+                        ] }
+                };
+
+                foreach (var s in customers)
+                {
+                    context.Customers.Add(s);
+                    foreach (var o in s.Orders)
+                    {
+                        context.Orders.Add(o);
+                    }
+                }
+                #endregion
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/sample/ODataMiniApi/AppModels.cs
+++ b/sample/ODataMiniApi/AppModels.cs
@@ -1,0 +1,101 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="AppModels.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ODataMiniApi;
+
+public class EdmModelBuilder
+{
+    public static IEdmModel GetEdmModel()
+    {
+        var builder = new ODataConventionModelBuilder();
+        builder.EntitySet<School>("Schools");
+        builder.ComplexType<Address>();
+        builder.ComplexType<Student>();
+
+        builder.EntitySet<Customer>("Customers");
+        builder.EntitySet<Order>("Orders");
+        builder.ComplexType<Info>();
+        return builder.GetEdmModel();
+    }
+}
+
+public class School
+{
+    public int SchoolId { get; set; }
+
+    public string SchoolName { get; set; }
+
+    public Address MailAddress { get; set; }
+
+    public virtual IList<Student> Students { get; set; }
+}
+
+public class HighSchool : School
+{
+    // Additional properties specific to HighSchool
+    public int NumberOfStudents { get; set; }
+    public string PrincipalName { get; set; }
+}
+
+public class Student
+{
+    public int StudentId { get; set; }
+
+    public string FirstName { get; set; }
+
+    public string LastName { get; set; }
+
+    public string FavoriteSport { get; set; }
+
+    public int Grade { get; set; }
+
+    public int SchoolId { get; set; }
+
+    public DateOnly BirthDay { get; set; }
+}
+
+[ComplexType]
+public class Address
+{
+    public int ApartNum { get; set; }
+
+    public string City { get; set; }
+
+    public string Street { get; set; }
+
+    public string ZipCode { get; set; }
+}
+
+
+public class Customer
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public Info Info { get; set; }
+
+    //[AutoExpand]
+    public List<Order> Orders { get; set; }
+}
+
+public class Order
+{
+    public int Id { get; set; }
+
+    public int Amount { get; set; }
+}
+
+public class Info
+{
+    public string Email { get; set; }
+    public string Phone { get; set; }
+}

--- a/sample/ODataMiniApi/CustomersAndOrders.http
+++ b/sample/ODataMiniApi/CustomersAndOrders.http
@@ -52,3 +52,13 @@ GET {{ODataMiniApi_HostAddress}}/v0/?$filter=amount%20gt%2015
 GET {{ODataMiniApi_HostAddress}}/v1/orders?$filter=amount%20gt%2015
 ###
 GET {{ODataMiniApi_HostAddress}}/v2/orders?$filter=amount%20gt%2015
+
+
+###
+
+PATCH {{ODataMiniApi_HostAddress}}/v1/customers/1
+Content-Type: application/json 
+
+{ 
+  "name": "kerry"
+} 

--- a/sample/ODataMiniApi/CustomersAndOrders.http
+++ b/sample/ODataMiniApi/CustomersAndOrders.http
@@ -1,0 +1,54 @@
+﻿@ODataMiniApi_HostAddress = http://localhost:5177
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/customers
+
+### [AutoExpand]
+### 4.01 Delta Payload Get "odata." prefix even in 4.01?
+### 
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/v0/customers
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/v00/customers?$select=name&$expand=info&$top=2&$orderby=id
+###
+
+GET {{ODataMiniApi_HostAddress}}/v1/customers?$select=name,info&$top=2&$orderby=id
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/customers?$select=name&$top=2&$orderby=id&$expand=info
+###
+GET {{ODataMiniApi_HostAddress}}/v1/customers?$select=name,info&$top=2&$orderby=id%20desc
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/v2/customers?$select=name&$top=2&$orderby=id
+
+###
+GET {{ODataMiniApi_HostAddress}}/v2/customers?$select=name&$top=2&$orderby=id&$expand=orders($select=amount)
+###
+GET {{ODataMiniApi_HostAddress}}/v2/customers?$select=name,info&$top=2&$orderby=id%20desc
+
+###
+# GET {{ODataMiniApi_HostAddress}}/v11/customers?$select=name&$expand=info // throw exception because 'info' is not navigation property
+GET {{ODataMiniApi_HostAddress}}/v11/customers?$select=name,info
+
+###
+GET {{ODataMiniApi_HostAddress}}/v3/customers
+
+###
+GET {{ODataMiniApi_HostAddress}}/v5/customers
+// throw exception since the delegate needs parameters, but we cannot easily provide the parameters.
+
+
+### $filter=amount gt 15
+GET {{ODataMiniApi_HostAddress}}/v0/?$filter=amount%20gt%2015
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/orders?$filter=amount%20gt%2015
+###
+GET {{ODataMiniApi_HostAddress}}/v2/orders?$filter=amount%20gt%2015

--- a/sample/ODataMiniApi/Endpoints/CustomersEndpoints.cs
+++ b/sample/ODataMiniApi/Endpoints/CustomersEndpoints.cs
@@ -1,0 +1,122 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="CustomersEndpoints.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Results;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace ODataMiniApi.Students;
+
+/// <summary>
+/// Add customers endpoint
+/// </summary>
+public static class CustomersEndpoints
+{
+    public static IEndpointRouteBuilder MapCustomersEndpoints(this IEndpointRouteBuilder app, IEdmModel model)
+    {
+        app.MapGet("/customers", (AppDb db) => db.Customers.Include(s => s.Orders))
+           //.WithODa
+            .WithODataResult() // default: built the complex type property by default?
+            // If enable Query, define them as entity type
+            // If no query, define them as complex type?
+            .WithODataModel(model)
+            .WithODataVersion(ODataVersion.V401)
+            .WithODataBaseAddressFactory(c => new Uri("http://abc.com"));
+        //.WithODataServices(c => c.AddSingleton<ODataMessageWriterSettings>;
+
+        // app.MapGet("v0/customers", (AppDb db) => Results.Extensions.AsOData(db.Customers.Include(s => s.Orders)));
+
+        //app.MapGet("v00/customers", (AppDb db, ODataQueryOptions<Customer> queryOptions) =>
+        //{
+        //    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking; // This line seems required otherwise it will throw exception
+        //    var result = queryOptions.ApplyTo(db.Customers.Include(s => s.Orders));
+        //    return Results.Extensions.AsOData(result);
+        //});
+
+        app.MapGet("v1/customers", (AppDb db, ODataQueryOptions<Customer> queryOptions) =>
+        {
+            db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking; // This line seems required otherwise it will throw exception
+            return queryOptions.ApplyTo(db.Customers.Include(s => s.Orders));
+        })
+            .WithODataResult()
+            .WithODataModel(model)
+        ;
+
+        // Be noted, [ODataModelConfiguration] configures the 'Info' as complex type
+        // So, in this case, the 'Info' property on 'Customer' is a structural property, not a navigation property.
+        app.MapGet("v11/customers", (AppDb db, [ODataModelConfiguration] ODataQueryOptions<Customer> queryOptions) =>
+        {
+            db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            return queryOptions.ApplyTo(db.Customers.Include(s => s.Orders));
+        });
+
+        app.MapGet("v2/customers", (AppDb db) =>
+        {
+            db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            return db.Customers.Include(s => s.Orders);
+        })
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            //.WithODataModel(model)
+            ;
+
+        //app.MapGet("v3/customers", (AppDb db) =>
+        //{
+        //    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        //    return Results.Extensions.AsOData(db.Customers.Include(s => s.Orders));
+        //})
+        //    .AddODataQueryEndpointFilter()
+            
+        //    //.WithODataModel(model)
+        //    ;
+
+        // To discuss? To provide the MapODataGet, MapODataPost, MapODataPatch....
+        // It seems we cannot generate the Delegate easily.
+        //app.MapODataGet("v5/customers", (AppDb db) =>
+        //{
+        //    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        //    return db.Customers.Include(s => s.Orders);
+        //});
+        return app;
+    }
+
+    // Scenarios using groups
+    public static IEndpointRouteBuilder MapOrdersEndpoints(this IEndpointRouteBuilder app, IEdmModel model)
+    {
+        var group = app.MapGroup("")
+            .WithODataResult()
+            .WithODataModel(model);
+
+        group.MapGet("v0/orders", (AppDb db) => db.Orders)
+            ;
+
+        group.MapGet("v1/orders", (AppDb db, ODataQueryOptions<Order> queryOptions) =>
+        {
+            db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking; // This line seems required otherwise it will throw exception
+            return queryOptions.ApplyTo(db.Orders);
+        })
+          //  .WithODataResult()
+          //  .WithODataModel(model)
+            ;
+
+        group.MapGet("v2/orders", (AppDb db) =>
+        {
+            db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            return db.Orders;
+        })
+            .AddODataQueryEndpointFilter()
+            //.WithODataResult()
+            //.WithODataModel(model)
+            ;
+
+        return app;
+    }
+
+}

--- a/sample/ODataMiniApi/MetadataHandler.cs
+++ b/sample/ODataMiniApi/MetadataHandler.cs
@@ -1,0 +1,90 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="CustomizedMetadataHandler.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using Microsoft.AspNetCore.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace ODataMiniApi;
+
+
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
+public class ODataModelConfigurationAttribute : Attribute, IODataModelConfiguration
+{
+    public ODataModelBuilder Apply(HttpContext context, ODataModelBuilder builder, Type clrType)
+    {
+        if (clrType == typeof(Customer))
+        {
+            builder.AddComplexType(typeof(Info));
+        }
+
+        return builder;
+    }
+}
+
+/*
+public class CustomizedMetadataHandler : ODataMetadataHandler
+{
+    protected override async ValueTask WriteAsJsonAsync(HttpContext context, IEdmModel model)
+    {
+        context.Response.ContentType = "application/json";
+
+        JsonWriterOptions options = new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Indented = false,
+            SkipValidation = false
+        };
+
+        // we can't use response body directly since ODL writes the JSON CSDL using Synchronous operations.
+        using (MemoryStream memStream = new MemoryStream())
+        {
+            using (Utf8JsonWriter jsonWriter = new Utf8JsonWriter(memStream, options))
+            {
+                CsdlJsonWriterSettings settings = new CsdlJsonWriterSettings();
+                settings.IsIeee754Compatible = true;
+                IEnumerable<EdmError> errors;
+                bool ok = CsdlWriter.TryWriteCsdl(model, jsonWriter, settings, out errors);
+                jsonWriter.Flush();
+            }
+
+            memStream.Seek(0, SeekOrigin.Begin);
+            string output = new StreamReader(memStream).ReadToEnd();
+            await context.Response.WriteAsync(output).ConfigureAwait(false);
+        }
+    }
+
+    protected override async ValueTask WriteAsXmlAsync(HttpContext context, IEdmModel model)
+    {
+        context.Response.ContentType = "application/xml";
+
+        using (StringWriter sw = new StringWriter())
+        {
+            XmlWriterSettings settings = new XmlWriterSettings();
+            settings.Encoding = Encoding.UTF8;
+            settings.Indent = false;
+
+            using (XmlWriter xw = XmlWriter.Create(sw, settings))
+            {
+                IEnumerable<EdmError> errors;
+                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, out errors);
+                xw.Flush();
+            }
+
+            string output = sw.ToString();
+            await context.Response.WriteAsync(output).ConfigureAwait(false);
+        }
+    }
+}
+*/

--- a/sample/ODataMiniApi/ODataMetadataApi.http
+++ b/sample/ODataMiniApi/ODataMetadataApi.http
@@ -1,0 +1,70 @@
+﻿@ODataMiniApi_HostAddress = http://localhost:5177
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$document
+
+##
+// The above request gets the following result:
+//{
+//  "@odata.context": "http://localhost:5177/$metadata",
+//  "value": [
+//    {
+//      "name": "Schools",
+//      "kind": "EntitySet",
+//      "url": "Schools"
+//    },
+//    {
+//      "name": "Customers",
+//      "kind": "EntitySet",
+//      "url": "Customers"
+//    },
+//    {
+//      "name": "Orders",
+//      "kind": "EntitySet",
+//      "url": "Orders"
+//    }
+//  ]
+//}
+
+###
+GET {{ODataMiniApi_HostAddress}}/v2/$document
+
+##
+// The above request gets the following result (has customized context URL)
+//{
+//  "@odata.context": "http://localhost:5177/v2/$metadata",
+//  "value": [
+//    {
+//      "name": "Schools",
+//      "kind": "EntitySet",
+//      "url": "Schools"
+//    },
+//    {
+//      "name": "Customers",
+//      "kind": "EntitySet",
+//      "url": "Customers"
+//    },
+//    {
+//      "name": "Orders",
+//      "kind": "EntitySet",
+//      "url": "Orders"
+//    }
+//  ]
+//}
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$metadata
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$metadata?$format=application/xml
+
+# The above two requests get the CSDL-XML file (No-indent by default)
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$metadata?$format=application/json
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$metadata
+Accept: application/json
+
+# The above two requests get the CSDL-JSON file

--- a/sample/ODataMiniApi/ODataMiniApi.csproj
+++ b/sample/ODataMiniApi/ODataMiniApi.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/sample/ODataMiniApi/ODataMiniApi.http
+++ b/sample/ODataMiniApi/ODataMiniApi.http
@@ -1,0 +1,93 @@
+﻿@ODataMiniApi_HostAddress = http://localhost:5177
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/giveschools?$select=SchoolName
+
+###
+
+# It's wrong to use $expand=MailAddress
+# because the MailAddress is complex type in the pre-built edm model.
+GET {{ODataMiniApi_HostAddress}}/myschools?$select=schoolName&$expand=MailAddress
+
+###
+
+# be noted: if use the model directly, the mailAddress is configured as complex property
+GET {{ODataMiniApi_HostAddress}}/myschools?$select=schoolName,MailAddress
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/schools?$select=schoolName,schoolid&$expand=MailAddress&$top=1
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/schools?$select=schoolName,schoolid,MailAddress&$top=1&$count=true
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/v1/$odata?$format=application/json
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$odata?$format=application/xml
+
+###
+GET {{ODataMiniApi_HostAddress}}/customized/$odata
+
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$document
+###
+GET {{ODataMiniApi_HostAddress}}/v1/$metadata?$format=application/json
+
+###
+
+# We need to figure out what payload should look like?
+# Since it's a collection, how to add '@odata.count' property into the collection?
+# Or use the PageResult<T>
+GET {{ODataMiniApi_HostAddress}}/schoolspage?$select=schoolName,MailAddress&$count=true
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/schoolspage?$count=true
+
+### 
+
+GET {{ODataMiniApi_HostAddress}}/odata/students
+
+### 
+GET {{ODataMiniApi_HostAddress}}/odata/students?$select=FirstName&$top=3
+
+###
+
+@id=1
+GET {{ODataMiniApi_HostAddress}}/schools/{{id}}?$select=SchoolName
+
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/odata/schools
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/giveschools1
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/giveschools2
+
+###
+GET {{ODataMiniApi_HostAddress}}/giveschools2?$select=schoolName
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/giveschools3
+
+###
+GET {{ODataMiniApi_HostAddress}}/giveschools3?$select=schoolName
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/getschools1
+
+###
+
+GET {{ODataMiniApi_HostAddress}}/odata/getschools1

--- a/sample/ODataMiniApi/Program.cs
+++ b/sample/ODataMiniApi/Program.cs
@@ -1,0 +1,171 @@
+//-----------------------------------------------------------------------------
+// <copyright file="Program.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query;
+using ODataMiniApi;
+using ODataMiniApi.Students;
+using Microsoft.OData.Edm;
+using Microsoft.AspNetCore.OData.Results;
+using System.Text.Json;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddDbContext<AppDb>(options => options.UseInMemoryDatabase("SchoolStudentList"));
+
+// In pre-built OData, MailAddress and Student are complex types
+IEdmModel model = EdmModelBuilder.GetEdmModel();
+
+
+builder.Services.ConfigureHttpJsonOptions(options => {
+    options.SerializerOptions.WriteIndented = true;
+    options.SerializerOptions.IncludeFields = true;
+});
+
+builder.Services.AddOData(q => q.EnableAll());
+
+var app = builder.Build();
+app.MakeSureDbCreated();
+
+ODataMiniMetadata me = new ODataMiniMetadata();
+me.Services = services =>
+{
+    services.AddSingleton<IFilterBinder, FilterBinder>();
+};
+
+app.MapGet("test", () => "hello world").WithODataResult();
+
+// Group
+var group = app.MapGroup("")
+//    .WithOData2(metadata => metadata.IsODataFormat = true, services => services.AddSingleton<IFilterBinder>(new FilterBinder()))
+    ;
+
+group.MapGet("v1", () => "hello v1")
+    .AddEndpointFilter(async (efiContext, next) =>
+    {
+        var endpoint = efiContext.HttpContext.GetEndpoint();
+        app.Logger.LogInformation("----Before calling");
+        var result = await next(efiContext);
+        app.Logger.LogInformation($"----After calling, {result?.GetType().Name}");
+        return result;
+    }
+    ).Finally(v =>
+    {
+        v.Metadata.Add(new School());
+    });
+group.MapGet("v2", () => "hello v2");
+
+//
+app.MapGet("/giveschools1", (AppDb db) =>
+{
+    return db.Schools.Include(s => s.Students);
+});
+
+app.MapGet("/giveschools2", (AppDb db, ODataQueryOptions<School> options) =>
+{
+    return options.ApplyTo(db.Schools);
+})
+    .WithODataResult();
+
+app.MapGet("/giveschools3", (AppDb db) =>
+{
+    return db.Schools.Include(s => s.Students);
+})
+    .WithODataResult()
+    .AddODataQueryEndpointFilter(querySetup: q => q.PageSize = 3, validationSetup: q => q.MaxSkip = 4); 
+
+//app.MapGet("/odata/schools", (AppDb db) =>
+//{
+//    return Results.Extensions.OData(db.Schools.Include(s => s.Students));
+//});
+
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+{ WriteIndented = true };
+app.MapGet("/", () =>
+    Results.Json(new School { SchoolName = "Walk dog", SchoolId = 8 }, options));
+
+// OData $metadata, I use $odata for routing.
+#region ODataMetadata
+//app.MapODataMetadata1("/v1/$odata", model);
+//app.MapODataMetadata("/customized/$odata", model, new CustomizedMetadataHandler());
+
+app.MapODataServiceDocument("v1/$document", model);
+
+app.MapODataServiceDocument("v2/$document", model)
+    .WithODataBaseAddressFactory(c => new Uri("http://localhost:5177/v2"));
+
+app.MapODataMetadata("v1/$metadata", model);
+
+#endregion
+
+#region School Endpoints
+
+app.MapGet("/myschools", (AppDb db) =>
+{
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return db.Schools;
+})
+    .WithODataModel(model)
+ //   .AddODataQueryEndpointFilter(new ODataQueryEndpointFilter(app.Services.GetRequiredService<ILoggerFactory>()));
+    .AddODataQueryEndpointFilter(querySetup: q => q.PageSize = 3, validationSetup: q => q.MaxSkip = 4);
+
+// use the server side pagesize?
+app.MapGet("/schoolspage", (AppDb db) =>
+{
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return new PageResult<School>(db.Schools, new Uri("/schoolspage?$skip=2", UriKind.Relative), count: db.Schools.Count());
+    //return db.Schools;
+})
+    .WithODataModel(model)
+    .AddODataQueryEndpointFilter(querySetup: q => q.PageSize = 3);
+
+app.MapGet("/schools", (AppDb db, ODataQueryOptions<School> options) => {
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return options.ApplyTo(db.Schools);
+}).WithODataModel(model);
+
+// Use the model built on the fly
+app.MapGet("/schools/{id}", async (int id, AppDb db, ODataQueryOptions<School> options) => {
+    
+    School school = await db.Schools.Include(c => c.MailAddress)
+        .Include(c => c.Students).FirstOrDefaultAsync(s => s.SchoolId == id);
+    if (school == null)
+    {
+        return Results.NotFound($"Cannot find school with id '{id}'");
+    }
+    else
+    {
+        return Results.Ok(options.ApplyTo(school, new ODataQuerySettings()));
+    }
+});
+
+// Use the model built on the fly
+app.MapGet("/customized/schools", (AppDb db, ODataQueryOptions<School> options) =>
+{
+    db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    return options.ApplyTo(db.Schools);
+});
+
+#endregion
+
+app.MapCustomersEndpoints(model);
+
+app.MapOrdersEndpoints(model);
+
+app.MapSchoolEndpoints(model);
+
+// Endpoints for students
+app.MapStudentEndpoints();
+
+app.Run();
+
+/// <summary>
+/// This is required in E2E test to identify the assembly.
+/// </summary>
+public partial class Program
+{ }

--- a/sample/ODataMiniApi/Properties/launchSettings.json
+++ b/sample/ODataMiniApi/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:27886",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sample/ODataMiniApi/Schools/SchoolEndpoints.cs
+++ b/sample/ODataMiniApi/Schools/SchoolEndpoints.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="SchoolEndpoints.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OData.Edm;
+
+namespace ODataMiniApi.Students;
+
+/// <summary>
+/// Add school endpoint
+/// </summary>
+public static class SchoolEndpoints
+{
+    public static IEndpointRouteBuilder MapSchoolEndpoints(this IEndpointRouteBuilder app, IEdmModel model)
+    {
+        app.MapGet("/getschools1", (AppDb db) => db.Schools.Include(s => s.Students));
+
+        app.MapGet("/odata/getschools1", (AppDb db) => db.Schools.Include(s => s.Students))
+            .WithODataResult();
+
+        app.MapGet("/odata/getschools2", (AppDb db) => db.Schools.Include(s => s.Students))
+            .WithODataModel(model);
+
+        app.MapGet("/odata/getschools2", (AppDb db) => db.Schools.Include(s => s.Students))
+            .WithODataResult()
+            .WithODataModel(model);
+        return app;
+    }
+
+}

--- a/sample/ODataMiniApi/Students/StudentEndpoints.cs
+++ b/sample/ODataMiniApi/Students/StudentEndpoints.cs
@@ -1,0 +1,209 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="StudentEndpoints.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.EntityFrameworkCore;
+
+namespace ODataMiniApi.Students;
+
+/// <summary>
+/// Add student endpoint to support CRUD operations.
+/// The codes are implemented as simple as possible. Please file issues to us for any issues.
+/// </summary>
+public static class StudentEndpoints
+{
+    public static async Task<IResult> GetStudentByIdAsync(int id, AppDb db, ODataQueryOptions<Student> options)
+    {
+        Student student = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (student == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+        else
+        {
+            return Results.Ok(options.ApplyTo(student, new ODataQuerySettings()));
+        }
+    }
+
+    public static async Task<IResult> PatchStudentByIdAsync(int id, AppDb db, [FromBody] IDictionary<string, object> properties)
+    {
+        // TODO: need to support Delta<Student> to replace IDictionary<string, object> in the next step
+        Student oldStudent = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (oldStudent == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+
+        int oldSchoolId = oldStudent.SchoolId;
+
+        var studentProperties = typeof(Student).GetProperties();
+        foreach (var property in properties)
+        {
+            PropertyInfo propertyInfo = studentProperties.FirstOrDefault(p => string.Equals(p.Name, property.Key, StringComparison.OrdinalIgnoreCase));
+            if (propertyInfo == null)
+            {
+                return Results.BadRequest($"Cannot find property '{property.Key}' on student");
+            }
+
+            // For simplicity
+            if (propertyInfo.PropertyType == typeof(string))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToString());
+            }
+            else if (propertyInfo.PropertyType == typeof(int))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToInt());
+            }
+            else if (propertyInfo.PropertyType == typeof(DateOnly))
+            {
+                propertyInfo.SetValue(oldStudent, property.Value.ConvertToDateOnly());
+            }
+        }
+
+        if (oldSchoolId != oldStudent.SchoolId)
+        {
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == oldSchoolId);
+            school.Students.Remove(oldStudent);
+
+            school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == oldStudent.SchoolId);
+            if (school == null)
+            {
+                return Results.NotFound($"Cannot find school using the school Id '{oldStudent.SchoolId}' that the new student provides.");
+            }
+            else
+            {
+                school.Students.Add(oldStudent);
+            }
+        }
+
+        await db.SaveChangesAsync();
+
+        return Results.Ok(oldStudent);
+    }
+
+    public static async Task<IResult> DeleteStudentByIdAsync(int id, AppDb db)
+    {
+        Student student = await db.Students.FirstOrDefaultAsync(s => s.StudentId == id);
+        if (student == null)
+        {
+            return Results.NotFound($"Cannot find student with id '{id}'");
+        }
+        else
+        {
+            db.Students.Remove(student);
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == student.SchoolId);
+            school.Students.Remove(student);
+            await db.SaveChangesAsync();
+            return Results.Ok();
+        }
+    }
+
+    public static IEndpointRouteBuilder MapStudentEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Let's use the group to build the student endpoints
+        var students = app.MapGroup("/odata");
+
+        // GET http://localhost:5177/odata/students?$select=lastName&$top=3
+        students.MapGet("/students", async (AppDb db, ODataQueryOptions<Student> options) =>
+        {
+            await db.Students.ToListAsync();
+            return options.ApplyTo(db.Students);
+        });
+
+        //GET http://localhost:5177/odata/students/12?select=lastName
+        students.MapGet("/students/{id}", GetStudentByIdAsync);
+
+        //GET http://localhost:5177/odata/students(12)?select=lastName
+        students.MapGet("/students({id})", GetStudentByIdAsync);
+
+        // POST http://localhost:5177/odata/students
+        // Content-Type: application/json
+        // BODY:
+        /*
+{
+
+"firstName": "Soda",
+"lastName": "Yu",
+"favoriteSport": "Soccer",
+"grade": 7,
+"schoolId": 3,
+"birthDay": "1977-11-04"
+}
+        */
+        students.MapPost("/students", async (Student student, AppDb db) =>
+        {
+            int studentId = db.Students.Max(s => s.StudentId) + 1;
+            student.StudentId = studentId;
+            School school = await db.Schools.Include(c => c.Students).FirstOrDefaultAsync(c => c.SchoolId == student.SchoolId);
+            if (school == null)
+            {
+                return Results.NotFound($"Cannot find school using the school Id '{student.SchoolId}' that the new student provides.");
+            }
+            else
+            {
+                school.Students.Add(student);
+            }
+
+            db.Students.Add(student);
+            await db.SaveChangesAsync();
+
+            return Results.Created($"/odata/students/{studentId}", student);
+        });
+
+        // PATCH http://localhost:5177/odata/students/10
+        // Content-Type: application/json
+        // BODY:
+        /*
+{
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "schoolId": 4
+}
+         */
+        students.MapPatch("/students({id})", PatchStudentByIdAsync);
+        students.MapPatch("/students/{id}", PatchStudentByIdAsync);
+
+        // DELETE http://localhost:5177/odata/students/10
+        students.MapDelete("/students({id})", DeleteStudentByIdAsync);
+        students.MapDelete("/students/{id}", DeleteStudentByIdAsync);
+        return app;
+    }
+
+    private static string ConvertToString(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.String)
+        {
+            return json.GetString();
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to string");
+    }
+
+    private static int ConvertToInt(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.Number)
+        {
+            return json.GetInt32();
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to int");
+    }
+
+    private static DateOnly ConvertToDateOnly(this object value)
+    {
+        if (value is JsonElement json && json.ValueKind == JsonValueKind.String)
+        {
+            string str = json.GetString();
+            return DateOnly.Parse(str);
+        }
+
+        throw new InvalidCastException($"Cannot convert '{value}' to DateOnly");
+    }
+}

--- a/sample/ODataMiniApi/appsettings.Development.json
+++ b/sample/ODataMiniApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sample/ODataMiniApi/appsettings.json
+++ b/sample/ODataMiniApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/sample/ODataMiniApi/readme.md
+++ b/sample/ODataMiniApi/readme.md
@@ -1,0 +1,308 @@
+# ASP.NET Core OData (8.x) Minimal API Sample
+
+---
+This is an ASP.NET Core OData 8.x minimal API project. 
+
+Minimal APIs are a simplified approach for building fast HTTP APIs with ASP.NET Core. You can build fully functioning REST endpoints with minimal code and configuration. Skip traditional scaffolding and avoid unnecessary controllers by fluently declaring API routes and actions. 
+
+
+## Basic endpoints
+
+1) GET `http://localhost:5177/schools`
+
+```json
+[
+    {
+        "schoolId": 1,
+        "schoolName": "Mercury Middle School",
+        "mailAddress": {
+            "apartNum": 241,
+            "city": "Kirk",
+            "street": "156TH AVE",
+            "zipCode": "98051"
+        },
+        "students": null
+    },
+    {
+        "schoolId": 2,
+        ...
+    }
+    ...
+]    
+```
+
+2) GET `http://localhost:5177/schools?$expand=mailaddress&$select=schoolName&$top=2`
+
+```json
+[
+    {
+        "MailAddress": {
+            "ApartNum": 241,
+            "City": "Kirk",
+            "Street": "156TH AVE",
+            "ZipCode": "98051"
+        },
+        "SchoolName": "Mercury Middle School"
+    },
+    {
+        "MailAddress": {
+            "ApartNum": 543,
+            "City": "AR",
+            "Street": "51TH AVE PL",
+            "ZipCode": "98043"
+        },
+        "SchoolName": "Venus High School"
+    }
+]
+```
+
+3) GET `http://localhost:5177/schools/5?$expand=students($top=1)&$select=schoolName`
+
+```json
+{
+    "Students": [
+        {
+            "StudentId": 50,
+            "FirstName": "David",
+            "LastName": "Padron",
+            "FavoriteSport": "Tennis",
+            "Grade": 77,
+            "SchoolId": 5,
+            "BirthDay": "2015-12-03"
+        }
+    ],
+    "SchoolName": "Jupiter College"
+}
+```
+
+4) GET `http://localhost:5177/customized/schools?$select=schoolName,mailAddress&$orderby=schoolName&$top=1`
+
+This endpoint uses the `OData model` from configuration, which builds `Address` as complex type, so we can use `$select`
+
+```json
+[
+    {
+        "SchoolName": "Earth University",
+        "MailAddress": {
+            "ApartNum": 101,
+            "City": "Belly",
+            "Street": "24TH ST",
+            "ZipCode": "98029"
+        }
+    }
+]
+```
+
+## Student CRUD endpoints
+
+I grouped student endpoints under `odata` group intentionally.
+
+1) GET `http://localhost:5177/odata/students?$select=lastName&$top=3`
+
+```json
+[
+    {
+        "LastName": "Alex"
+    },
+    {
+        "LastName": "Eaine"
+    },
+    {
+        "LastName": "Rorigo"
+    }
+]
+```
+
+2) POST `http://localhost:5177/odata/students`  with the following body:
+Content-Type: application/json
+
+```json
+{
+
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "favoriteSport": "Soccer",
+    "grade": 7,
+    "schoolId": 3,
+    "birthDay": "1977-11-04"
+}
+```
+
+Check using `http://localhost:5177/schools/3`, you can see a new student added:
+
+```json
+[
+  "schoolId": 3,
+    "schoolName": "Earth University",
+    "mailAddress": {
+        "apartNum": 101,
+        "city": "Belly",
+        "street": "24TH ST",
+        "zipCode": "98029"
+    },
+    "students": [
+        ...
+        {
+            "studentId": 98,
+            "firstName": "Sokuda",
+            "lastName": "Yu",
+            "favoriteSport": "Soccer",
+            "grade": 7,
+            "schoolId": 3,
+            "birthDay": "1977-11-04"
+        }
+    ]
+}
+```
+
+3) Patch `http://localhost:5177/odata/students/10`
+Content-Type: application/json
+
+```json
+{
+
+    "firstName": "Sokuda",
+    "lastName": "Yu",
+    "schoolId": 4
+}
+```
+
+This will change the student, and also move the student from `Schools(1)` to `Schools(4)`
+
+4) Delete `http://localhost:5177/odata/students/10`
+
+This will delete the `Students(10)`
+
+
+## OData CSDL metadata
+
+I built one metadata endpoint to return the CSDL representation of 'customized' OData.
+
+I use '$odata' to return the metadata.
+
+Try: GET http://localhost:5177/customized/$odata, You can get CSDL XML representation:
+
+```xml
+<?xml version="1.0" encoding="utf-16"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:DataServices>
+        <Schema Namespace="ODataMiniApi" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityType Name="School">
+                <Key>
+                    <PropertyRef Name="SchoolId" />
+                </Key>
+                <Property Name="SchoolId" Type="Edm.Int32" Nullable="false" />
+                <Property Name="SchoolName" Type="Edm.String" />
+                <Property Name="MailAddress" Type="ODataMiniApi.Address" />
+                <Property Name="Students" Type="Collection(ODataMiniApi.Student)" />
+            </EntityType>
+            <ComplexType Name="Address">
+                <Property Name="ApartNum" Type="Edm.Int32" Nullable="false" />
+                <Property Name="City" Type="Edm.String" />
+                <Property Name="Street" Type="Edm.String" />
+                <Property Name="ZipCode" Type="Edm.String" />
+            </ComplexType>
+            <ComplexType Name="Student">
+                <Property Name="StudentId" Type="Edm.Int32" Nullable="false" />
+                <Property Name="FirstName" Type="Edm.String" />
+                <Property Name="LastName" Type="Edm.String" />
+                <Property Name="FavoriteSport" Type="Edm.String" />
+                <Property Name="Grade" Type="Edm.Int32" Nullable="false" />
+                <Property Name="SchoolId" Type="Edm.Int32" Nullable="false" />
+                <Property Name="BirthDay" Type="Edm.Date" Nullable="false" />
+            </ComplexType>
+        </Schema>
+        <Schema Namespace="Default" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityContainer Name="Container">
+                <EntitySet Name="Schools" EntityType="ODataMiniApi.School" />
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>
+```
+
+You can use 'Accept' request header or '$format' or 'format' query option to specify JSON or XML format, by default it's XML format.
+
+Try: GET http://localhost:5177/customized/$odata, You can get CSDL XML representation:
+Request Header:
+Accept: application/json
+
+You can get:
+
+```json
+{
+    "$Version": "4.0",
+    "$EntityContainer": "Default.Container",
+    "ODataMiniApi": {
+        "School": {
+            "$Kind": "EntityType",
+            "$Key": [
+                "SchoolId"
+            ],
+            "SchoolId": {
+                "$Type": "Edm.Int32"
+            },
+            "SchoolName": {
+                "$Nullable": true
+            },
+            "MailAddress": {
+                "$Type": "ODataMiniApi.Address",
+                "$Nullable": true
+            },
+            "Students": {
+                "$Collection": true,
+                "$Type": "ODataMiniApi.Student",
+                "$Nullable": true
+            }
+        },
+        "Address": {
+            "$Kind": "ComplexType",
+            "ApartNum": {
+                "$Type": "Edm.Int32"
+            },
+            "City": {
+                "$Nullable": true
+            },
+            "Street": {
+                "$Nullable": true
+            },
+            "ZipCode": {
+                "$Nullable": true
+            }
+        },
+        "Student": {
+            "$Kind": "ComplexType",
+            "StudentId": {
+                "$Type": "Edm.Int32"
+            },
+            "FirstName": {
+                "$Nullable": true
+            },
+            "LastName": {
+                "$Nullable": true
+            },
+            "FavoriteSport": {
+                "$Nullable": true
+            },
+            "Grade": {
+                "$Type": "Edm.Int32"
+            },
+            "SchoolId": {
+                "$Type": "Edm.Int32"
+            },
+            "BirthDay": {
+                "$Type": "Edm.Date"
+            }
+        }
+    },
+    "Default": {
+        "Container": {
+            "$Kind": "EntityContainer",
+            "Schools": {
+                "$Collection": true,
+                "$Type": "ODataMiniApi.School"
+            }
+        }
+    }
+}
+```

--- a/sample/ODataRoutingSample/Controllers/v1/CustomersController.cs
+++ b/sample/ODataRoutingSample/Controllers/v1/CustomersController.cs
@@ -41,7 +41,7 @@ public class CustomersController : ControllerBase
 
     // For example: http://localhost:5000/v1/customers?$apply=groupby((Name), aggregate($count as count))&$orderby=name desc
     [HttpGet]
-    [EnableQuery]
+    [EnableQuery(PageSize = 2)]
     public IActionResult Get()
     {
         return Ok(GetCustomers());

--- a/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
@@ -517,6 +517,11 @@ internal static class TypeHelper
             return type.GetGenericArguments().First();
         }
 
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            return type.GetGenericArguments().First();
+        }
+
         return type;
     }
 

--- a/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
@@ -15,8 +15,19 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Results;
+using Microsoft.OData;
+using System.Net.Http;
+using Microsoft.AspNetCore.OData.Extensions;
 
 namespace Microsoft.AspNetCore.OData.Deltas;
 
@@ -423,6 +434,64 @@ public class Delta<T> : Delta, IDelta, ITypedDelta where T : class
 
                 deltaNestedResource.CopyChangedValues(originalNestedResource);
             }
+        }
+    }
+
+    /// <summary>
+    /// Binds the <see cref="HttpContext"/> and <see cref="ParameterInfo"/> to generate the <see cref="Delta{T}"/>.
+    /// </summary>
+    /// <param name="context">The HttpContext.</param>
+    /// <param name="parameter">The parameter info.</param>
+    /// <returns>The built <see cref="Delta{T}"/></returns>
+    public static async ValueTask<Delta<T>> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
+        ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
+
+        var endpoint = context.GetEndpoint();
+        ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
+        if (metadata is null || metadata.Model is null || metadata.PathFactory is null)
+        {
+            throw new ODataException($"Please call WithODataModel and WithODataPathFactory for the endpoint");
+        }
+
+        IEdmModel model = metadata.Model;
+
+        context.ODataFeature().Model = model;
+        context.ODataFeature().Services = context.GetOrCreateServiceProvider();
+        context.ODataFeature().Path = metadata.PathFactory(context, typeof(T));
+        HttpRequest request = context.Request;
+        Type type = typeof(Delta<T>);
+        IList<IDisposable> toDispose = new List<IDisposable>();
+        Uri baseAddress = GetBaseAddress(context, metadata);
+
+        ODataVersion version = ODataResult.GetODataVersion(request, metadata);
+
+        object result = await ODataInputFormatter.ReadFromStreamAsync(
+                type,
+                defaultValue: null,
+                baseAddress,
+                version,
+                request,
+                toDispose).ConfigureAwait(false);
+
+        foreach (IDisposable obj in toDispose)
+        {
+            obj.Dispose();
+        }
+
+        return await ValueTask.FromResult(result as Delta<T>);
+    }
+
+    private static Uri GetBaseAddress(HttpContext httpContext, ODataMiniMetadata options)
+    {
+        if (options.BaseAddressFactory is not null)
+        {
+            return options.BaseAddressFactory(httpContext);
+        }
+        else
+        {
+            return ODataInputFormatter.GetDefaultBaseAddress(httpContext.Request);
         }
     }
 

--- a/src/Microsoft.AspNetCore.OData/Edm/IODataModelConfiguration.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/IODataModelConfiguration.cs
@@ -1,0 +1,28 @@
+//-----------------------------------------------------------------------------
+// <copyright file="IODataModelConfiguration.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.Edm;
+
+/// <summary>
+/// Defines a contract used to apply extra logic on the model builder.
+/// </summary>
+public interface IODataModelConfiguration
+{
+    /// <summary>
+    /// Applies model configurations using the provided builder.
+    /// </summary>
+    /// <param name="context">The HttpContext.</param>
+    /// <param name="builder">The <see cref="ODataModelBuilder">builder</see> used to apply configurations.</param>
+    /// <param name="clrType">The top CLR type.</param>
+    /// <returns>The model builder or a totally new builder to use.</returns>
+    ODataModelBuilder Apply(HttpContext context, ODataModelBuilder builder, Type clrType);
+}
+

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataQueryFilterInvocationContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataQueryFilterInvocationContext.cs
@@ -1,0 +1,32 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataQueryFilterInvocationContext.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.OData.Extensions;
+
+/// <summary>
+/// Provides an abstraction for wrapping the <see cref="EndpointFilterInvocationContext"/> and the <see cref="System.Reflection.MethodInfo"/> associated with a route handler.
+/// </summary>
+public class ODataQueryFilterInvocationContext
+{
+    /// <summary>
+    /// The <see cref="MethodInfo"/> associated with the current route handler.
+    /// </summary>
+    public MethodInfo MethodInfo { get; init; }
+
+    /// <summary>
+    /// The <see cref="EndpointFilterInvocationContext"/> associated with the current route filter.
+    /// </summary>
+    public EndpointFilterInvocationContext InvocationContext { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="HttpContext"/>.
+    /// </summary>
+    public HttpContext HttpContext => InvocationContext.HttpContext;
+}

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2574,6 +2574,20 @@
             Gets the whole expand path.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration">
+            <summary>
+            Defines a contract used to apply extra logic on the model builder.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration.Apply(Microsoft.AspNetCore.Http.HttpContext,Microsoft.OData.ModelBuilder.ODataModelBuilder,System.Type)">
+            <summary>
+            Applies model configurations using the provided builder.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataModelBuilder">builder</see> used to apply configurations.</param>
+            <param name="clrType">The top CLR type.</param>
+            <returns>The model builder or a totally new builder to use.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.IODataTypeMapper">
             <summary>
             Provides the mapping between CLR type and Edm type.
@@ -3226,6 +3240,26 @@
             <param name="request">The Http request.</param>
             <param name="segments">The OData path segments.</param>
             <returns>The generated OData link.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext">
+            <summary>
+            Provides an abstraction for wrapping the <see cref="T:Microsoft.AspNetCore.Http.EndpointFilterInvocationContext"/> and the <see cref="T:System.Reflection.MethodInfo"/> associated with a route handler.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.MethodInfo">
+            <summary>
+            The <see cref="P:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.MethodInfo"/> associated with the current route handler.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.InvocationContext">
+            <summary>
+            The <see cref="T:Microsoft.AspNetCore.Http.EndpointFilterInvocationContext"/> associated with the current route filter.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.HttpContext">
+            <summary>
+            Gets the <see cref="P:Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.HttpContext"/>.
+            </summary>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Extensions.SerializableErrorExtensions">
             <summary>
@@ -6509,6 +6543,127 @@
             <param name="routePattern">The given route pattern.</param>
             <returns>The <see cref="T:Microsoft.AspNetCore.Builder.IApplicationBuilder"/>.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions">
+            <summary>
+            Extension methods for adding <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> to a route handler.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapODataServiceDocument(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder,System.String,Microsoft.OData.Edm.IEdmModel)">
+            <summary>
+            Adds a <see cref="T:Microsoft.AspNetCore.Routing.RouteEndpoint"/> to the <see cref="T:Microsoft.AspNetCore.Routing.IEndpointRouteBuilder"/> that matches HTTP GET requests to get the OData service document.
+            </summary>
+            <param name="endpoints">The <see cref="T:Microsoft.AspNetCore.Routing.IEndpointRouteBuilder"/> to add the route to.</param>
+            <param name="pattern">The route pattern.</param>
+            <param name="model">The related Edm model used to generate the service document.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapODataMetadata(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder,System.String,Microsoft.OData.Edm.IEdmModel)">
+            <summary>
+            Adds a <see cref="T:Microsoft.AspNetCore.Routing.RouteEndpoint"/> to the <see cref="T:Microsoft.AspNetCore.Routing.IEndpointRouteBuilder"/> that matches HTTP GET requests to get the OData metadata.
+            It uses the Request.Header.ContentType or $format to identify whether it's CSDL-XML or CSDL-JSON.
+            </summary>
+            <param name="endpoints">The <see cref="T:Microsoft.AspNetCore.Routing.IEndpointRouteBuilder"/> to add the route to.</param>
+            <param name="pattern">The route pattern.</param>
+            <param name="model">The related Edm model.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(Microsoft.AspNetCore.Builder.RouteHandlerBuilder,System.Action{Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings},System.Action{Microsoft.AspNetCore.OData.Query.ODataQuerySettings})">
+            <summary>
+            Registers the default OData query filter onto the route handler.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/>.</param>
+            <param name="validationSetup">The action to configure validataion settings.</param>
+            <param name="querySetup">The action to configure query settings.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(Microsoft.AspNetCore.Routing.RouteGroupBuilder,System.Action{Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings},System.Action{Microsoft.AspNetCore.OData.Query.ODataQuerySettings})">
+            <summary>
+            Registers the default OData query filter onto the route group.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Routing.RouteGroupBuilder"/>.</param>
+            <param name="validationSetup">The action to configure validataion settings.</param>
+            <param name="querySetup">The action to configure query settings.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(Microsoft.AspNetCore.Builder.RouteHandlerBuilder,Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter)">
+            <summary>
+            Registers an OData query filter onto the route handler.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/>.</param>
+            <param name="queryFilter">The <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/>.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(Microsoft.AspNetCore.Routing.RouteGroupBuilder,Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter)">
+            <summary>
+            Registers an OData query filter onto the route group.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Routing.RouteGroupBuilder"/>.</param>
+            <param name="queryFilter">The <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/>.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Routing.RouteGroupBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter``1(Microsoft.AspNetCore.Builder.RouteHandlerBuilder)">
+            <summary>
+            Registers an OData query filter of type <typeparamref name="TFilterType"/> onto the route handler.
+            </summary>
+            <typeparam name="TFilterType">The type of the <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> to register.</typeparam>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/>.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter``1(Microsoft.AspNetCore.Routing.RouteGroupBuilder)">
+            <summary>
+            Registers an OData query filter of type <typeparamref name="TFilterType"/> onto the route group.
+            </summary>
+            <typeparam name="TFilterType">The type of the <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> to register.</typeparam>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Routing.RouteGroupBuilder"/>.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Routing.RouteGroupBuilder"/> that can be used to further customize the route handler.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataResult``1(``0)">
+            <summary>
+            Enables OData response annotation to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataOptions``1(``0,System.Action{Microsoft.AspNetCore.OData.ODataMiniOptions})">
+            <summary>
+            Enables OData options to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="setupAction">The OData minimal options setup.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataServices``1(``0,System.Action{Microsoft.Extensions.DependencyInjection.IServiceCollection})">
+            <summary>
+            Customizes the services used for OData to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="services">The services.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataModel``1(``0,Microsoft.OData.Edm.IEdmModel)">
+            <summary>
+            Adds the OData model to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="model">The Edm model.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataBaseAddressFactory``1(``0,System.Func{Microsoft.AspNetCore.Http.HttpContext,System.Uri})">
+            <summary>
+            Adds the base address factory to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="baseAddressFactory">The base address factory which is used to calculate the base address for OData payload.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataVersion``1(``0,Microsoft.OData.ODataVersion)">
+            <summary>
+            Configures the OData version to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="version">The OData version.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataJsonOptionsSetup">
             <summary>
             Sets up default OData options for <see cref="T:Microsoft.AspNetCore.Mvc.JsonOptions"/>.
@@ -6519,6 +6674,149 @@
              Configure the default <see cref="T:Microsoft.AspNetCore.Mvc.JsonOptions"/>
             </summary>
             <param name="options">The Json Options.</param>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.ODataMiniMetadata">
+            <summary>
+            Metadata that specifies the OData minimal API.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.Model">
+            <summary>
+            Gets or sets the model
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.IsODataFormat">
+            <summary>
+            Gets or sets a boolean value indicating to generate OData response.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.PathFactory">
+            <summary>
+            Gets or sets the path factory.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.Version">
+            <summary>
+            Gets or sets the OData version.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.BaseAddressFactory">
+            <summary>
+            Gets or sets the base address factory.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.Options">
+            <summary>
+            Gets or sets the minimal options.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.Services">
+            <summary>
+            Gets or sets the services
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniMetadata.ServiceProvider">
+            <summary>
+            Gets or sets the service provider associated to this metadata.
+            Be noted, it seems we build and cache the service provider per endpoint.
+            If it's over-built, let's figure out a better solution for this.
+            </summary>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.ODataMiniOptions">
+            <summary>
+            The options for minimal API scenarios
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.QueryConfigurations">
+            <summary>
+            Gets the query configurations. for example, enable '$select' or not.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.Version">
+            <summary>
+            Gets the OData version.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableNoDollarQueryOptions">
+            <summary>
+            Gets whether or not the OData system query options should be prefixed with '$'.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableCaseInsensitive">
+            <summary>
+            Ges whether or not case insensitive.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(System.Boolean)">
+            <summary>
+            Config whether or not no '$' sign query option.
+            </summary>
+            <param name="enableNoDollarQueryOptions">Case insensitive or not.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetCaseInsensitive(System.Boolean)">
+            <summary>
+            Config the case insensitive.
+            </summary>
+            <param name="enableCaseInsensitive">Case insensitive or not.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetVersion(Microsoft.OData.ODataVersion)">
+            <summary>
+            Config the OData version.
+            </summary>
+            <param name="version">The OData version.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableAll(System.Nullable{System.Int32})">
+            <summary>
+            Enables all OData query options.
+            </summary>
+            <param name="maxTopValue"></param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.Expand">
+            <summary>
+            Enable $expand query options.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.Select">
+            <summary>
+            Enable $select query options.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.Filter">
+            <summary>
+            Enable $filter query options.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.OrderBy">
+            <summary>
+            Enable $orderby query options.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.Count">
+            <summary>
+            Enable $count query options.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SkipToken">
+            <summary>
+            Enable $skiptoken query option.
+            </summary>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetMaxTop(System.Nullable{System.Int32})">
+             <summary>
+            Sets the maximum value of $top that a client can request.
+             </summary>
+             <param name="maxTopValue">The maximum value of $top that a client can request.</param>
+             <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataMvcBuilderExtensions">
             <summary>
@@ -6800,6 +7098,22 @@
             <summary>
             Provides extension methods to add OData services.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Adds essential OData services to the specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+            </summary>
+            <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add services to.</param>
+            <returns>A <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> that can be used to further configure the OData services.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.AspNetCore.OData.ODataMiniOptions})">
+            <summary>
+            Adds essential OData services to the specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+            </summary>
+            <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add services to.</param>
+            <param name="setupAction">The OData options to configure the services with,
+            including access to a service provider which you can resolve services from.</param>
+            <returns>A <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> that can be used to further configure the OData services.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddODataQueryFilter(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
@@ -8947,12 +9261,12 @@
             <param name="actionDescriptor">The action descriptor for the action being queried on.</param>
             <returns>The EDM model for the given type and request.</returns>
         </member>
-        <member name="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.RequestQueryData">
+        <member name="T:Microsoft.AspNetCore.OData.Query.RequestQueryData">
             <summary>
             Holds request level query information.
             </summary>
         </member>
-        <member name="P:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.RequestQueryData.QueryValidationRunBeforeActionExecution">
+        <member name="P:Microsoft.AspNetCore.OData.Query.RequestQueryData.QueryValidationRunBeforeActionExecution">
             <summary>
             Gets or sets a value indicating whether query validation was run before action (controller method) is executed.
             </summary>
@@ -8961,7 +9275,7 @@
             For cases where the run failed before action execution. We will run validation on result.
             </remarks>
         </member>
-        <member name="P:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.RequestQueryData.ProcessedQueryOptions">
+        <member name="P:Microsoft.AspNetCore.OData.Query.RequestQueryData.ProcessedQueryOptions">
             <summary>
             Gets or sets the processed query options.
             </summary>
@@ -10727,6 +11041,26 @@
             Gets a value representing the total count of the collection.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter">
+            <summary>
+            Provides an interface for implementing a filter to run codes before and after a route handler.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter.OnFilterExecutingAsync(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Performs the OData query composition before route handler is executing.
+            </summary>
+            <param name="context">The OData query filter invocation context.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter.OnFilterExecutedAsync(System.Object,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Performs the OData query composition after route handler is executed.
+            </summary>
+            <param name="responseValue">The response value from the route handler.</param>
+            <param name="context">The OData query filter invocation context.</param>
+            <returns></returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser">
             <summary>
             Exposes the ability to read and parse the content of a <see cref="T:Microsoft.AspNetCore.Http.HttpRequest" />
@@ -11101,6 +11435,151 @@
             <param name="context">The query context.</param>
             <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.Validator.ISelectExpandQueryValidator"/>.</returns>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter">
+            <summary>
+            The default implementation to <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> to run codes before and after a route handler.
+            This typically is used for minimal api scenario.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ValidationSettings">
+            <summary>
+            Gets the validation settings. Customers can use this to configure the validation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.QuerySettings">
+            <summary>
+            Gets the query settings. Customers can use this to configure each query executing.
+            </summary>
+            <remarks>
+            It could be confusing between DefaultQueryConfigurations and ODataQuerySettings.
+            DefaultQueryConfigurations is used to config the functionalities for query options. For example: is $filter enabled?
+            ODataQuerySettings is used to set options for each query executing.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.InvokeAsync(Microsoft.AspNetCore.Http.EndpointFilterInvocationContext,Microsoft.AspNetCore.Http.EndpointFilterDelegate)">
+            <summary>
+            Implements the core logic associated with the filter given a <see cref="T:Microsoft.AspNetCore.Http.EndpointFilterInvocationContext"/>
+            and the next filter to call in the pipeline.
+            </summary>
+            <param name="invocationContext">The <see cref="T:Microsoft.AspNetCore.Http.EndpointFilterInvocationContext"/> associated with the current request/response.</param>
+            <param name="next">The next filter in the pipeline.</param>
+            <returns>An awaitable result of calling the handler and apply any modifications made by filters in the pipeline.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.OnFilterExecutingAsync(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Performs the query composition before route handler is executing.
+            </summary>
+            <param name="context">The OData query filter invocation context.</param>
+            <returns>The <see cref="T:System.Threading.Tasks.ValueTask"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.OnFilterExecutedAsync(System.Object,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Performs the query composition after route handler is executed.
+            </summary>
+            <param name="responseValue">The response value from the route handler.</param>
+            <param name="context">The OData query filter invocation context.</param>
+            <returns>The <see cref="T:System.Threading.Tasks.ValueTask"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ExecuteQuery(System.Object,System.Linq.IQueryable,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Execute the query.
+            </summary>
+            <param name="responseValue">The response value.</param>
+            <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+            <param name="context">The action context, i.e. action and controller name.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ValidateSelectExpandOnly(Microsoft.AspNetCore.OData.Query.ODataQueryOptions)">
+            <summary>
+            Validate the select and expand options.
+            </summary>
+            <param name="queryOptions">The query options.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.SingleOrDefault(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Get a single or default value from a collection.
+            </summary>
+            <param name="queryable">The response value as <see cref="T:System.Linq.IQueryable"/>.</param>
+            <param name="context">The context.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ApplyQuery(System.Object,Microsoft.AspNetCore.OData.Query.ODataQueryOptions,Microsoft.AspNetCore.OData.Query.ODataQuerySettings)">
+            <summary>
+            Applies the query to the given entity based on incoming query from uri and query settings.
+            </summary>
+            <param name="entity">The original entity from the response message.</param>
+            <param name="queryOptions">
+            The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> instance constructed based on the incoming request.
+            </param>
+            <param name="querySettings">The query settings.</param>
+            <returns>The new entity after the $select and $expand query has been applied to.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ApplyQuery(System.Linq.IQueryable,Microsoft.AspNetCore.OData.Query.ODataQueryOptions,Microsoft.AspNetCore.OData.Query.ODataQuerySettings)">
+            <summary>
+            Applies the query to the given IQueryable based on incoming query from uri and query settings. By default,
+            the implementation supports $top, $skip, $orderby and $filter. Override this method to perform additional
+            query composition of the query.
+            </summary>
+            <param name="queryable">The original queryable instance from the response message.</param>
+            <param name="queryOptions">
+            The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> instance constructed based on the incoming request.
+            </param>
+            <param name="querySettings">The settings.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.GetODataQueryContext(System.Object,System.Linq.IQueryable,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Get the OData query context.
+            </summary>
+            <param name="responseValue">The response value.</param>
+            <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+            <param name="invocationContext">The action context, i.e. action and controller name.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.CreateAndValidateQueryOptions(Microsoft.AspNetCore.Http.HttpContext,Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
+            <summary>
+            Create and validate a new instance of <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> from a query and context during action executed.
+            Developers can override this virtual method to provide its own <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/>.
+            </summary>
+            <param name="httpContext">The http context.</param>
+            <param name="queryContext">The query context.</param>
+            <returns>The created <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/>.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.GetElementType(System.Object,System.Linq.IQueryable,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Get the element type.
+            </summary>
+            <param name="responseValue">The response value.</param>
+            <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+            <param name="context">The context.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ValidateQuery(Microsoft.AspNetCore.Http.HttpContext,Microsoft.AspNetCore.OData.Query.ODataQueryOptions)">
+            <summary>
+            Validates the OData query in the incoming request. By default, the implementation throws an exception if
+            the query contains unsupported query parameters. Override this method to perform additional validation of
+            the query.
+            </summary>
+            <param name="httpContext" />
+            <param name="queryOptions">
+            The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> instance constructed based on the incoming request.
+            </param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.CreateQueryOptionsOnExecuting(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Creates the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> for action executing validation.
+            </summary>
+            <param name="context">The OData query filter invocation context.</param>
+            <returns>The created <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> or null if we can't create it during action executing.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.GetModel(System.Type,Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
+            <summary>
+            Gets the EDM model for the given type and request.Override this method to customize the EDM model used for
+            querying.
+            </summary>
+            <param name="elementClrType">The CLR type to retrieve a model for.</param>
+            <param name="context">The action descriptor for the action being queried on.</param>
+            <returns>The EDM model for the given type and request.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions">
             <summary>
             This defines a composite OData query options that can be used to perform query composition.
@@ -11374,6 +11853,21 @@
             <param name="query">The original <see cref="T:System.Linq.IQueryable"/>.</param>
             <param name="querySettings">The settings to use in query composition.</param>
             <returns>The new <see cref="T:System.Linq.IQueryable"/> after the query has been applied to.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.BindAsync(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)">
+            <summary>
+            Binds the <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> and <see cref="T:System.Reflection.ParameterInfo"/> to generate the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/>.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="parameter">The parameter info.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/></returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.PopulateMetadata(System.Reflection.ParameterInfo,Microsoft.AspNetCore.Builder.EndpointBuilder)">
+            <summary>
+            Populates metadata for the related <see cref="T:Microsoft.AspNetCore.Http.Endpoint"/> and <see cref="T:System.Reflection.ParameterInfo"/>.
+            </summary>
+            <param name="parameter" >The parameter info.</param>
+            <param name="builder">The endpoint builder that we can add metadata into.</param>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ODataQueryParameterBindingAttribute">
             <summary>
@@ -13856,6 +14350,11 @@
             Supports converting <see cref="T:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapper`1"/> types by using a factory pattern.
             </summary>
         </member>
+        <member name="F:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.MapperProvider">
+            <summary>
+            The mapper provider.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CanConvert(System.Type)">
             <summary>
             determines whether the converter instance can convert the specified object type.
@@ -13967,6 +14466,21 @@
             OData error.
             </summary>
         </member>
+        <member name="T:Microsoft.AspNetCore.OData.Results.IODataResult">
+            <summary>
+            A contracts for OData result 
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Results.IODataResult.Value">
+            <summary>
+            Gets the real value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Results.IODataResult.ExpectedType">
+            <summary>
+            Gets the expected type.
+            </summary>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Results.NotFoundODataResult">
             <summary>
             Represents a result that when executed will produce a Not Found (404) response.
@@ -14019,6 +14533,76 @@
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Results.ODataErrorResult.ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext)">
             <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Results.ODataMetadataResult">
+            <summary>
+            Defines a contract that represents the result of OData metadata.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Results.ODataMetadataResult.Instance">
+            <summary>
+            Gets the static instance since we don't need the instance of it.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Results.ODataMetadataResult.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Write an HTTP response reflecting the result.
+            </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <returns>A task that represents the asynchronous execute operation.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Results.ODataResult">
+            <summary>
+            Defines an implementation that represents the result of an OData format result.
+            It's used for minimal API.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Results.ODataResult.#ctor(System.Object)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Results.ODataResult"/> class.
+            </summary>
+            <param name="value">The wrappered real value.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Results.ODataResult.#ctor(System.Object,System.Type)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Results.ODataResult"/> class.
+            </summary>
+            <param name="value">The wrappered real value.</param>
+            <param name="expectedType">The expected type.</param>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Results.ODataResult.Value">
+            <summary>
+            Gets the value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.Results.ODataResult.ExpectedType">
+            <summary>
+            Gets the expected type.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Results.ODataResult.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Writes an HTTP response reflecting the result.
+            </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <returns>A task that represents the asynchronous execute operation.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Results.ODataServiceDocumentResult">
+            <summary>
+            Defines a contract that represents the result of OData service document.
+            </summary>
+        </member>
+        <member name="F:Microsoft.AspNetCore.OData.Results.ODataServiceDocumentResult.Instance">
+            <summary>
+            Gets the static instance since we don't need the instance of it.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Results.ODataServiceDocumentResult.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Write an HTTP response reflecting the result.
+            </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <returns>A task that represents the asynchronous execute operation.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Results.PageResult">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6553,7 +6553,7 @@
         </member>
         <member name="T:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions">
             <summary>
-            Extension methods for adding <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> to a route handler.
+            Extension methods for adding <see cref="T:Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter"/> and metadata to a route handler.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapODataServiceDocument(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder,System.String,Microsoft.OData.Edm.IEdmModel)">
@@ -6756,11 +6756,13 @@
         <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableNoDollarQueryOptions">
             <summary>
             Gets whether or not the OData system query options should be prefixed with '$'.
+            Please call 'SetNoDollarQueryOptions()' to config.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableCaseInsensitive">
             <summary>
             Ges whether or not case insensitive.
+            Please call 'SetCaseInsensitive()' to config.
             </summary>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(System.Boolean)">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1776,6 +1776,14 @@
             </summary>
             <param name="original">The entity to be updated.</param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.BindAsync(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)">
+            <summary>
+            Binds the <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> and <see cref="T:System.Reflection.ParameterInfo"/> to generate the <see cref="T:Microsoft.AspNetCore.OData.Deltas.Delta`1"/>.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="parameter">The parameter info.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Deltas.Delta`1"/></returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.CopyUnchangedValues(`0)">
             <summary>
             Copies the unchanged property values from the underlying entity (accessible via <see cref="M:Microsoft.AspNetCore.OData.Deltas.Delta`1.GetInstance" />)
@@ -6654,6 +6662,14 @@
             </summary>
             <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
             <param name="baseAddressFactory">The base address factory which is used to calculate the base address for OData payload.</param>
+            <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataPathFactory``1(``0,System.Func{Microsoft.AspNetCore.Http.HttpContext,System.Type,Microsoft.OData.UriParser.ODataPath})">
+            <summary>
+            Adds the path factory to <see cref="P:Microsoft.AspNetCore.Http.Endpoint.Metadata" /> associated with the current endpoint.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</param>
+            <param name="pathFactory">The path factory which is used to calculate the OData path associated with current endpoint.</param>
             <returns>A <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataVersion``1(``0,Microsoft.OData.ODataVersion)">

--- a/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
@@ -145,7 +145,7 @@ public static class ODataEndpointConventionBuilderExtensions
             object result = await next(invocationContext);
 
             // If it's null or if it's already the ODataResult, simply do nothing
-            if (result is null || result is ODataResult)
+            if (result is null || result is ODataResult || result is ODataMetadataResult || result is ODataServiceDocumentResult)
             {
                 return result;
             }

--- a/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
@@ -8,21 +8,17 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.OData.Batch;
-using Microsoft.AspNetCore.OData.Edm;
-using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.OData.Results;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNetCore.OData;
 
@@ -237,6 +233,20 @@ public static class ODataEndpointConventionBuilderExtensions
         ArgumentNullException.ThrowIfNull(baseAddressFactory, nameof(baseAddressFactory));
 
         builder.Add(b => ConfigureODataMetadata(b, m => m.BaseAddressFactory = baseAddressFactory));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the path factory to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="pathFactory">The path factory which is used to calculate the OData path associated with current endpoint.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataPathFactory<TBuilder>(this TBuilder builder, Func<HttpContext, Type, ODataPath> pathFactory) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(pathFactory, nameof(pathFactory));
+
+        builder.Add(b => ConfigureODataMetadata(b, m => m.PathFactory = pathFactory));
         return builder;
     }
 

--- a/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
@@ -23,7 +23,7 @@ using Microsoft.OData.UriParser;
 namespace Microsoft.AspNetCore.OData;
 
 /// <summary>
-/// Extension methods for adding <see cref="IODataQueryEndpointFilter"/> to a route handler.
+/// Extension methods for adding <see cref="IODataQueryEndpointFilter"/> and metadata to a route handler.
 /// </summary>
 public static class ODataEndpointConventionBuilderExtensions
 {
@@ -141,7 +141,7 @@ public static class ODataEndpointConventionBuilderExtensions
             object result = await next(invocationContext);
 
             // If it's null or if it's already the ODataResult, simply do nothing
-            if (result is null || result is ODataResult || result is ODataMetadataResult || result is ODataServiceDocumentResult)
+            if (result is null || typeof(IResult).IsAssignableFrom(result.GetType()))
             {
                 return result;
             }

--- a/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,276 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataEndpointConventionBuilderExtensions.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Query.Validator;
+using Microsoft.AspNetCore.OData.Results;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData;
+
+/// <summary>
+/// Extension methods for adding <see cref="IODataQueryEndpointFilter"/> to a route handler.
+/// </summary>
+public static class ODataEndpointConventionBuilderExtensions
+{
+    /// <summary>
+    /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP GET requests to get the OData service document.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="model">The related Edm model used to generate the service document.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static IEndpointConventionBuilder MapODataServiceDocument(
+        this IEndpointRouteBuilder endpoints,
+        [StringSyntax("Route")] string pattern,
+        IEdmModel model)
+        => endpoints.MapGet(pattern, () => ODataServiceDocumentResult.Instance).WithODataModel(model);
+
+    /// <summary>
+    /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP GET requests to get the OData metadata.
+    /// It uses the Request.Header.ContentType or $format to identify whether it's CSDL-XML or CSDL-JSON.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="model">The related Edm model.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static IEndpointConventionBuilder MapODataMetadata(
+        this IEndpointRouteBuilder endpoints,
+        [StringSyntax("Route")] string pattern,
+        IEdmModel model)
+        => endpoints.MapGet(pattern, () => ODataMetadataResult.Instance).WithODataModel(model);
+
+    /// <summary>
+    /// Registers the default OData query filter onto the route handler.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
+    /// <param name="validationSetup">The action to configure validataion settings.</param>
+    /// <param name="querySetup">The action to configure query settings.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
+    public static RouteHandlerBuilder AddODataQueryEndpointFilter(this RouteHandlerBuilder builder,
+        Action<ODataValidationSettings> validationSetup = default,
+        Action<ODataQuerySettings> querySetup = default)
+        => builder.AddODataQueryEndpointFilterInternal(new ODataQueryEndpointFilter(), validationSetup, querySetup);
+
+    /// <summary>
+    /// Registers the default OData query filter onto the route group.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteGroupBuilder"/>.</param>
+    /// <param name="validationSetup">The action to configure validataion settings.</param>
+    /// <param name="querySetup">The action to configure query settings.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
+    public static RouteGroupBuilder AddODataQueryEndpointFilter(this RouteGroupBuilder builder,
+        Action<ODataValidationSettings> validationSetup = default,
+        Action<ODataQuerySettings> querySetup = default) =>
+        builder.AddODataQueryEndpointFilterInternal(new ODataQueryEndpointFilter(), validationSetup, querySetup);
+
+    private static TBuilder AddODataQueryEndpointFilterInternal<TBuilder>(this TBuilder builder, ODataQueryEndpointFilter queryFilter,
+        Action<ODataValidationSettings> validationSetup,
+        Action<ODataQuerySettings> querySetup)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        validationSetup?.Invoke(queryFilter.ValidationSettings);
+        querySetup?.Invoke(queryFilter.QuerySettings);
+        builder.AddEndpointFilter(queryFilter);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an OData query filter onto the route handler.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
+    /// <param name="queryFilter">The <see cref="IODataQueryEndpointFilter"/>.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+    public static RouteHandlerBuilder AddODataQueryEndpointFilter(this RouteHandlerBuilder builder, IODataQueryEndpointFilter queryFilter)=>
+        builder.AddEndpointFilter(queryFilter);
+
+    /// <summary>
+    /// Registers an OData query filter onto the route group.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteGroupBuilder"/>.</param>
+    /// <param name="queryFilter">The <see cref="IODataQueryEndpointFilter"/>.</param>
+    /// <returns>A <see cref="RouteGroupBuilder"/> that can be used to further customize the route handler.</returns>
+    public static RouteGroupBuilder AddODataQueryEndpointFilter(this RouteGroupBuilder builder, IODataQueryEndpointFilter queryFilter) =>
+        builder.AddEndpointFilter(queryFilter);
+
+    /// <summary>
+    /// Registers an OData query filter of type <typeparamref name="TFilterType"/> onto the route handler.
+    /// </summary>
+    /// <typeparam name="TFilterType">The type of the <see cref="IODataQueryEndpointFilter"/> to register.</typeparam>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
+    public static RouteHandlerBuilder AddODataQueryEndpointFilter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFilterType>(this RouteHandlerBuilder builder)
+        where TFilterType : IODataQueryEndpointFilter =>
+        builder.AddEndpointFilter<TFilterType>();
+
+    /// <summary>
+    /// Registers an OData query filter of type <typeparamref name="TFilterType"/> onto the route group.
+    /// </summary>
+    /// <typeparam name="TFilterType">The type of the <see cref="IODataQueryEndpointFilter"/> to register.</typeparam>
+    /// <param name="builder">The <see cref="RouteGroupBuilder"/>.</param>
+    /// <returns>A <see cref="RouteGroupBuilder"/> that can be used to further customize the route handler.</returns>
+    public static RouteGroupBuilder AddODataQueryEndpointFilter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFilterType>(this RouteGroupBuilder builder)
+        where TFilterType : IODataQueryEndpointFilter =>
+        builder.AddEndpointFilter<TFilterType>();
+
+    /// <summary>
+    /// Enables OData response annotation to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataResult<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder
+    {
+        builder.AddEndpointFilter(async (invocationContext, next) =>
+        {
+            object result = await next(invocationContext);
+
+            // If it's null or if it's already the ODataResult, simply do nothing
+            if (result is null || result is ODataResult)
+            {
+                return result;
+            }
+
+            // Maybe we have a scenario like:
+            // First, enable OData result in app.MapGroup(...).WithODataResult(),
+            // Then, disable OData result for a certain Routehandler by cusomizing the metadaga
+            var endpoint = invocationContext.HttpContext.GetEndpoint();
+            ODataMiniMetadata odataMetadata = endpoint?.Metadata?.GetMetadata<ODataMiniMetadata>();
+            if (odataMetadata is not null && odataMetadata.IsODataFormat)
+            {
+                // Now, Let's focus on the POCO data result.
+                // We can figure out more types later, for example, TypedResult<T>, Results<T>, etc.
+                return new ODataResult(result/*, odataMetadata*/);
+            }
+
+            return result;
+        });
+
+        builder.Add(b => ConfigureODataMetadata(b, m => m.IsODataFormat = true));
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables OData options to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="setupAction">The OData minimal options setup.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataOptions<TBuilder>(this TBuilder builder, Action<ODataMiniOptions> setupAction) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(setupAction, nameof(setupAction));
+
+        builder.Add(b => ConfigureODataMetadata(b, m => setupAction.Invoke(m.Options)));
+        return builder;
+    }
+
+    ///// <summary>
+    ///// Enables OData batch to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    ///// </summary>
+    ///// <typeparam name="TBuilder"></typeparam>
+    ///// <param name="builder"></param>
+    ///// <param name="services"></param>
+    ///// <returns></returns>
+    //public static TBuilder WithODataBatch<TBuilder>(this TBuilder builder, ODataBatchHandler handler) where TBuilder : IEndpointConventionBuilder
+    //{
+    //   // builder.Add(b => ConfigureODataMetadata(b, m => m.Services = services));
+    //    return builder;
+    //}
+
+    /// <summary>
+    /// Customizes the services used for OData to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="services">The services.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataServices<TBuilder>(this TBuilder builder, Action<IServiceCollection> services) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(services, nameof(services));
+
+        builder.Add(b => ConfigureODataMetadata(b, m => m.Services = services));
+
+        //builder.Finally(b => { });
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the OData model to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="model">The Edm model.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataModel<TBuilder>(this TBuilder builder, IEdmModel model) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(model, nameof(model));
+
+        builder.Add(b => ConfigureODataMetadata(b, m => m.Model = model));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the base address factory to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="baseAddressFactory">The base address factory which is used to calculate the base address for OData payload.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataBaseAddressFactory<TBuilder>(this TBuilder builder, Func<HttpContext, Uri> baseAddressFactory) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(baseAddressFactory, nameof(baseAddressFactory));
+
+        builder.Add(b => ConfigureODataMetadata(b, m => m.BaseAddressFactory = baseAddressFactory));
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the OData version to <see cref="Endpoint.Metadata" /> associated with the current endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="version">The OData version.</param>
+    /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static TBuilder WithODataVersion<TBuilder>(this TBuilder builder, ODataVersion version) where TBuilder : IEndpointConventionBuilder
+    {
+        builder.Add(b => ConfigureODataMetadata(b, m => m.Version = version));
+        return builder;
+    }
+
+    // Will update the odata metadata if existed.
+    // Otherwise, will create a new metadata and insert into endpoint.
+    internal static void ConfigureODataMetadata(EndpointBuilder endpointBuilder, Action<ODataMiniMetadata> setupAction)
+    {
+        var metadata = endpointBuilder.Metadata.OfType<ODataMiniMetadata>().FirstOrDefault();
+        if (metadata is null)
+        {
+            metadata = new ODataMiniMetadata();
+
+            // retrieve the global minimal API OData configuration
+            ODataMiniOptions options = endpointBuilder.ApplicationServices.GetService<IOptions<ODataMiniOptions>>()?.Value;
+            if (options is not null)
+            {
+                metadata.Options.UpdateFrom(options);
+            }
+
+            endpointBuilder.Metadata.Add(metadata);
+        }
+
+        setupAction?.Invoke(metadata);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/ODataMiniMetadata.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiniMetadata.cs
@@ -1,0 +1,136 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataMiniMetadata.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNetCore.OData;
+
+/// <summary>
+/// Metadata that specifies the OData minimal API.
+/// </summary>
+// Or seperate them into pieces?
+public class ODataMiniMetadata
+{
+    private IServiceProvider _serviceProvider = null;
+
+    /// <summary>
+    /// Gets or sets the model
+    /// </summary>
+    public IEdmModel Model { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value indicating to generate OData response.
+    /// </summary>
+    public bool IsODataFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path factory.
+    /// </summary>
+    public Func<HttpContext, Type, ODataPath> PathFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OData version.
+    /// </summary>
+    public ODataVersion Version
+    {
+        get => Options.Version;
+        set => Options.SetVersion(value);
+    }
+
+    /// <summary>
+    /// Gets or sets the base address factory.
+    /// </summary>
+    public Func<HttpContext, Uri> BaseAddressFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimal options.
+    /// </summary>
+    public ODataMiniOptions Options { get; } = new ODataMiniOptions();
+
+    /// <summary>
+    /// Gets or sets the services
+    /// </summary>
+    public Action<IServiceCollection> Services { get; set; }
+
+    /// <summary>
+    /// Gets or sets the service provider associated to this metadata.
+    /// Be noted, it seems we build and cache the service provider per endpoint.
+    /// If it's over-built, let's figure out a better solution for this.
+    /// </summary>
+    public IServiceProvider ServiceProvider
+    {
+        get
+        {
+            if (_serviceProvider == null)
+            {
+                _serviceProvider = BuildRouteContainer();
+            }
+
+            return _serviceProvider;
+        }
+        set => _serviceProvider = value;
+    }
+
+    internal IServiceProvider BuildRouteContainer()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        // Inject the core odata services.
+        services.AddDefaultODataServices(Version);
+
+        // Inject the default query configuration from this options.
+        services.AddSingleton(sp => this.Options.QueryConfigurations);
+
+        // Inject the default Web API OData services.
+        services.AddDefaultWebApiServices();
+
+        // Set Uri resolver to by default enabling unqualified functions/actions and case insensitive match.
+        services.AddSingleton<ODataUriResolver>(sp =>
+            new UnqualifiedODataUriResolver
+            {
+                EnableCaseInsensitive = this.Options.EnableCaseInsensitive, // by default to enable case insensitive
+                EnableNoDollarQueryOptions = this.Options.EnableNoDollarQueryOptions // retrieve it from global setting
+            });
+
+        // Inject the Edm model.
+        // From Current ODL implement, such injection only be used in reader and writer if the input
+        // model is null.
+        // How about the model is null?
+        services.AddSingleton(sp => Model);
+
+        // Inject the customized services.
+        Services?.Invoke(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    internal static ODataPath DefaultPathFactory(HttpContext context, Type elementType)
+    {
+        IEdmModel model = context.GetOrCreateEdmModel(elementType);
+        IEdmType edmType = model.GetEdmType(elementType);
+
+        var entitySet = model.EntityContainer?.EntitySets().FirstOrDefault(e => e.EntityType == edmType);
+        if (entitySet != null)
+        {
+            return new ODataPath(new EntitySetSegment(entitySet));
+        }
+        else
+        {
+            entitySet = new EdmEntitySet(model.EntityContainer, elementType.Name, edmType as IEdmEntityType);
+            return new ODataPath(new EntitySetSegment(entitySet));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
@@ -33,11 +33,13 @@ public class ODataMiniOptions
 
     /// <summary>
     /// Gets whether or not the OData system query options should be prefixed with '$'.
+    /// Please call 'SetNoDollarQueryOptions()' to config.
     /// </summary>
     public bool EnableNoDollarQueryOptions { get => _enableNoDollarQueryOptions; }
 
     /// <summary>
     /// Ges whether or not case insensitive.
+    /// Please call 'SetCaseInsensitive()' to config.
     /// </summary>
     public bool EnableCaseInsensitive { get => _enableCaseInsensitive; }
 

--- a/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
@@ -1,0 +1,177 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataMiniOptions.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData;
+
+namespace Microsoft.AspNetCore.OData;
+
+/// <summary>
+/// The options for minimal API scenarios
+/// </summary>
+public class ODataMiniOptions
+{
+    private DefaultQueryConfigurations _queryConfigurations = new DefaultQueryConfigurations();
+    private bool _enableNoDollarQueryOptions = true;
+    private bool _enableCaseInsensitive = true;
+    private ODataVersion _version = ODataVersionConstraint.DefaultODataVersion;
+
+    /// <summary>
+    /// Gets the query configurations. for example, enable '$select' or not.
+    /// </summary>
+    public DefaultQueryConfigurations QueryConfigurations { get => _queryConfigurations; }
+
+    /// <summary>
+    /// Gets the OData version.
+    /// </summary>
+    public ODataVersion Version { get => _version; }
+
+    /// <summary>
+    /// Gets whether or not the OData system query options should be prefixed with '$'.
+    /// </summary>
+    public bool EnableNoDollarQueryOptions { get => _enableNoDollarQueryOptions; }
+
+    /// <summary>
+    /// Ges whether or not case insensitive.
+    /// </summary>
+    public bool EnableCaseInsensitive { get => _enableCaseInsensitive; }
+
+    /// <summary>
+    /// Config whether or not no '$' sign query option.
+    /// </summary>
+    /// <param name="enableNoDollarQueryOptions">Case insensitive or not.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetNoDollarQueryOptions(bool enableNoDollarQueryOptions)
+    {
+        _enableNoDollarQueryOptions = enableNoDollarQueryOptions;
+        return this;
+    }
+
+    /// <summary>
+    /// Config the case insensitive.
+    /// </summary>
+    /// <param name="enableCaseInsensitive">Case insensitive or not.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetCaseInsensitive(bool enableCaseInsensitive)
+    {
+        _enableCaseInsensitive = enableCaseInsensitive;
+        return this;
+    }
+
+    /// <summary>
+    /// Config the OData version.
+    /// </summary>
+    /// <param name="version">The OData version.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetVersion(ODataVersion version)
+    {
+        _version = version;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables all OData query options.
+    /// </summary>
+    /// <param name="maxTopValue"></param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions EnableAll(int? maxTopValue = null)
+    {
+        _queryConfigurations.EnableExpand = true;
+        _queryConfigurations.EnableSelect = true;
+        _queryConfigurations.EnableFilter = true;
+        _queryConfigurations.EnableOrderBy = true;
+        _queryConfigurations.EnableCount = true;
+        _queryConfigurations.EnableSkipToken = true;
+        SetMaxTop(maxTopValue);
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $expand query options.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions Expand()
+    {
+        _queryConfigurations.EnableExpand = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $select query options.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions Select()
+    {
+        _queryConfigurations.EnableSelect = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $filter query options.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions Filter()
+    {
+        _queryConfigurations.EnableFilter = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $orderby query options.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions OrderBy()
+    {
+        _queryConfigurations.EnableOrderBy = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $count query options.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions Count()
+    {
+        _queryConfigurations.EnableCount = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable $skiptoken query option.
+    /// </summary>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SkipToken()
+    {
+        _queryConfigurations.EnableSkipToken = true;
+        return this;
+    }
+
+    /// <summary>
+    ///Sets the maximum value of $top that a client can request.
+    /// </summary>
+    /// <param name="maxTopValue">The maximum value of $top that a client can request.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetMaxTop(int? maxTopValue)
+    {
+        if (maxTopValue.HasValue && maxTopValue.Value < 0)
+        {
+            throw Error.ArgumentMustBeGreaterThanOrEqualTo(nameof(maxTopValue), maxTopValue, 0);
+        }
+
+        _queryConfigurations.MaxTop = maxTopValue;
+        return this;
+    }
+
+    internal void UpdateFrom(ODataMiniOptions otherOptions)
+    {
+        this._queryConfigurations.UpdateAll(otherOptions.QueryConfigurations);
+        this._version = otherOptions.Version;
+        this._enableNoDollarQueryOptions = otherOptions.EnableNoDollarQueryOptions;
+        this._enableCaseInsensitive = otherOptions.EnableCaseInsensitive;
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1,0 +1,87 @@
+Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration
+Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration.Apply(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.OData.ModelBuilder.ODataModelBuilder builder, System.Type clrType) -> Microsoft.OData.ModelBuilder.ODataModelBuilder
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.InvocationContext.get -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.InvocationContext.init -> void
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.MethodInfo.get -> System.Reflection.MethodInfo
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.MethodInfo.init -> void
+Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext.ODataQueryFilterInvocationContext() -> void
+Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions
+Microsoft.AspNetCore.OData.ODataMiniMetadata
+Microsoft.AspNetCore.OData.ODataMiniMetadata.BaseAddressFactory.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Uri>
+Microsoft.AspNetCore.OData.ODataMiniMetadata.BaseAddressFactory.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.IsODataFormat.get -> bool
+Microsoft.AspNetCore.OData.ODataMiniMetadata.IsODataFormat.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Model.get -> Microsoft.OData.Edm.IEdmModel
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Model.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.ODataMiniMetadata() -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Options.get -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniMetadata.PathFactory.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Type, Microsoft.OData.UriParser.ODataPath>
+Microsoft.AspNetCore.OData.ODataMiniMetadata.PathFactory.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.ServiceProvider.get -> System.IServiceProvider
+Microsoft.AspNetCore.OData.ODataMiniMetadata.ServiceProvider.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Services.get -> System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection>
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Services.set -> void
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Version.get -> Microsoft.OData.ODataVersion
+Microsoft.AspNetCore.OData.ODataMiniMetadata.Version.set -> void
+Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.Count() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.EnableAll(int? maxTopValue = null) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.EnableCaseInsensitive.get -> bool
+Microsoft.AspNetCore.OData.ODataMiniOptions.EnableNoDollarQueryOptions.get -> bool
+Microsoft.AspNetCore.OData.ODataMiniOptions.Expand() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.Filter() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.ODataMiniOptions() -> void
+Microsoft.AspNetCore.OData.ODataMiniOptions.OrderBy() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.QueryConfigurations.get -> Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations
+Microsoft.AspNetCore.OData.ODataMiniOptions.Select() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetCaseInsensitive(bool enableCaseInsensitive) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetMaxTop(int? maxTopValue) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(bool enableNoDollarQueryOptions) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetVersion(Microsoft.OData.ODataVersion version) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SkipToken() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.Version.get -> Microsoft.OData.ODataVersion
+Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter
+Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter.OnFilterExecutedAsync(object responseValue, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> System.Threading.Tasks.ValueTask<object>
+Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter.OnFilterExecutingAsync(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter
+Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ODataQueryEndpointFilter() -> void
+Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.QuerySettings.get -> Microsoft.AspNetCore.OData.Query.ODataQuerySettings
+Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ValidationSettings.get -> Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings
+Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter
+Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.SelectExpandWrapperConverter() -> void
+Microsoft.AspNetCore.OData.Results.IODataResult
+Microsoft.AspNetCore.OData.Results.IODataResult.ExpectedType.get -> System.Type
+Microsoft.AspNetCore.OData.Results.IODataResult.Value.get -> object
+override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CanConvert(System.Type typeToConvert) -> bool
+override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CreateConverter(System.Type type, System.Text.Json.JsonSerializerOptions options) -> System.Text.Json.Serialization.JsonConverter
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, System.Action<Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings> validationSetup = null, System.Action<Microsoft.AspNetCore.OData.Query.ODataQuerySettings> querySetup = null) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Routing.RouteGroupBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter) -> Microsoft.AspNetCore.Routing.RouteGroupBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Routing.RouteGroupBuilder builder, System.Action<Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings> validationSetup = null, System.Action<Microsoft.AspNetCore.OData.Query.ODataQuerySettings> querySetup = null) -> Microsoft.AspNetCore.Routing.RouteGroupBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter<TFilterType>(this Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter<TFilterType>(this Microsoft.AspNetCore.Routing.RouteGroupBuilder builder) -> Microsoft.AspNetCore.Routing.RouteGroupBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapODataMetadata(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern, Microsoft.OData.Edm.IEdmModel model) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapODataServiceDocument(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern, Microsoft.OData.Edm.IEdmModel model) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataBaseAddressFactory<TBuilder>(this TBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Uri> baseAddressFactory) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataModel<TBuilder>(this TBuilder builder, Microsoft.OData.Edm.IEdmModel model) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataOptions<TBuilder>(this TBuilder builder, System.Action<Microsoft.AspNetCore.OData.ODataMiniOptions> setupAction) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataResult<TBuilder>(this TBuilder builder) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataServices<TBuilder>(this TBuilder builder, System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> services) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataVersion<TBuilder>(this TBuilder builder, Microsoft.OData.ODataVersion version) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions.AddOData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.OData.ODataMiniOptions> setupAction) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.BindAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>>
+static Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.PopulateMetadata(System.Reflection.ParameterInfo parameter, Microsoft.AspNetCore.Builder.EndpointBuilder builder) -> void
+static readonly Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.MapperProvider -> System.Func<Microsoft.OData.Edm.IEdmModel, Microsoft.OData.Edm.IEdmStructuredType, Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper>
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ApplyQuery(object entity, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> object
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ApplyQuery(System.Linq.IQueryable queryable, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings) -> System.Linq.IQueryable
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.CreateAndValidateQueryOptions(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.OData.Query.ODataQueryContext queryContext) -> Microsoft.AspNetCore.OData.Query.ODataQueryOptions
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.CreateQueryOptionsOnExecuting(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> Microsoft.AspNetCore.OData.Query.ODataQueryOptions
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ExecuteQuery(object responseValue, System.Linq.IQueryable singleResultCollection, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> object
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.GetModel(System.Type elementClrType, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> Microsoft.OData.Edm.IEdmModel
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.InvokeAsync(Microsoft.AspNetCore.Http.EndpointFilterInvocationContext invocationContext, Microsoft.AspNetCore.Http.EndpointFilterDelegate next) -> System.Threading.Tasks.ValueTask<object>
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.OnFilterExecutedAsync(object responseValue, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> System.Threading.Tasks.ValueTask<object>
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.OnFilterExecutingAsync(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> System.Threading.Tasks.ValueTask
+virtual Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.ValidateQuery(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions) -> void

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -67,6 +67,7 @@ static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.MapOD
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataBaseAddressFactory<TBuilder>(this TBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Uri> baseAddressFactory) -> TBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataModel<TBuilder>(this TBuilder builder, Microsoft.OData.Edm.IEdmModel model) -> TBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataOptions<TBuilder>(this TBuilder builder, System.Action<Microsoft.AspNetCore.OData.ODataMiniOptions> setupAction) -> TBuilder
+static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataPathFactory<TBuilder>(this TBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Type, Microsoft.OData.UriParser.ODataPath> pathFactory) -> TBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataResult<TBuilder>(this TBuilder builder) -> TBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataServices<TBuilder>(this TBuilder builder, System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> services) -> TBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.WithODataVersion<TBuilder>(this TBuilder builder, Microsoft.OData.ODataVersion version) -> TBuilder

--- a/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/DefaultQueryConfigurations.cs
@@ -16,4 +16,16 @@ public class DefaultQueryConfigurations : DefaultQuerySettings
 {
     // We will add other query settings, for example, $compute, $search here
     // In the next major release, we should remove the inheritance from 'DefaultQuerySettings'.
+
+    internal DefaultQueryConfigurations UpdateAll(DefaultQueryConfigurations options)
+    {
+        EnableExpand = options.EnableExpand;
+        EnableSelect = options.EnableSelect;
+        EnableFilter = options.EnableFilter;
+        EnableOrderBy = options.EnableOrderBy;
+        EnableCount = options.EnableCount;
+        EnableSkipToken = options.EnableSkipToken;
+        MaxTop = options.MaxTop;
+        return this;
+    }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -827,28 +827,28 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         Contract.Assert(model != null);
         return model;
     }
+}
+
+/// <summary>
+/// Holds request level query information.
+/// </summary>
+internal class RequestQueryData
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether query validation was run before action (controller method) is executed.
+    /// </summary>
+    /// <remarks>
+    /// Marks if the query validation was run before the action execution. This is not always possible.
+    /// For cases where the run failed before action execution. We will run validation on result.
+    /// </remarks>
+    public bool QueryValidationRunBeforeActionExecution { get; set; }
 
     /// <summary>
-    /// Holds request level query information.
+    /// Gets or sets the processed query options.
     /// </summary>
-    private class RequestQueryData
-    {
-        /// <summary>
-        /// Gets or sets a value indicating whether query validation was run before action (controller method) is executed.
-        /// </summary>
-        /// <remarks>
-        /// Marks if the query validation was run before the action execution. This is not always possible.
-        /// For cases where the run failed before action execution. We will run validation on result.
-        /// </remarks>
-        public bool QueryValidationRunBeforeActionExecution { get; set; }
-
-        /// <summary>
-        /// Gets or sets the processed query options.
-        /// </summary>
-        /// <remarks>
-        /// Stores the processed query options to be used later if OnActionExecuting was able to verify the query.
-        /// This is because ValidateQuery internally modifies query options (expands are prime example of this).
-        /// </remarks>
-        public ODataQueryOptions ProcessedQueryOptions { get; set; }
-    }
+    /// <remarks>
+    /// Stores the processed query options to be used later if OnActionExecuting was able to verify the query.
+    /// This is because ValidateQuery internally modifies query options (expands are prime example of this).
+    /// </remarks>
+    public ODataQueryOptions ProcessedQueryOptions { get; set; }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/IODataQueryEndpointFilter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/IODataQueryEndpointFilter.cs
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="IODataQueryEndpointFilter.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Extensions;
+
+namespace Microsoft.AspNetCore.OData.Query;
+
+/// <summary>
+/// Provides an interface for implementing a filter to run codes before and after a route handler.
+/// </summary>
+public interface IODataQueryEndpointFilter : IEndpointFilter
+{
+    /// <summary>
+    /// Performs the OData query composition before route handler is executing.
+    /// </summary>
+    /// <param name="context">The OData query filter invocation context.</param>
+    /// <returns></returns>
+    ValueTask OnFilterExecutingAsync(ODataQueryFilterInvocationContext context);
+
+    /// <summary>
+    /// Performs the OData query composition after route handler is executed.
+    /// </summary>
+    /// <param name="responseValue">The response value from the route handler.</param>
+    /// <param name="context">The OData query filter invocation context.</param>
+    /// <returns></returns>
+    ValueTask<object> OnFilterExecutedAsync(object responseValue, ODataQueryFilterInvocationContext context);
+}

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
@@ -116,9 +116,7 @@ public class ODataQueryContext
         {
             if (_defaultQueryConfigurations == null)
             {
-                _defaultQueryConfigurations = RequestContainer == null
-                    ? GetDefaultQuerySettings()
-                    : RequestContainer.GetRequiredService<DefaultQueryConfigurations>();
+                _defaultQueryConfigurations = GetDefaultQueryConfigurations();
             }
 
             return _defaultQueryConfigurations;
@@ -202,6 +200,31 @@ public class ODataQueryContext
         {
             TargetStructuredType = ElementType as IEdmStructuredType;
         }
+    }
+
+    private DefaultQueryConfigurations GetDefaultQueryConfigurations()
+    {
+        if (RequestContainer != null)
+        {
+            DefaultQueryConfigurations configurations = RequestContainer.GetService<DefaultQueryConfigurations>();
+            if (configurations is not null)
+            {
+                return configurations;
+            }
+        }
+
+        if (Request is null)
+        {
+            return new DefaultQueryConfigurations();
+        }
+
+        IOptions<ODataOptions> odataOptions = Request.HttpContext?.RequestServices?.GetService<IOptions<ODataOptions>>();
+        if (odataOptions is null || odataOptions.Value is null)
+        {
+            return new DefaultQueryConfigurations();
+        }
+
+        return odataOptions.Value.QueryConfigurations;
     }
 
     private DefaultQueryConfigurations GetDefaultQuerySettings()

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContextExtensions.cs
@@ -19,7 +19,7 @@ internal static class ODataQueryContextExtensions
     public static ODataQuerySettings GetODataQuerySettings(this ODataQueryContext context)
     {
         ODataQuerySettings returnSettings = new ODataQuerySettings();
-        ODataQuerySettings settings = context?.RequestContainer?.GetRequiredService<ODataQuerySettings>();
+        ODataQuerySettings settings = context?.RequestContainer?.GetService<ODataQuerySettings>();
         if (settings != null)
         {
             returnSettings.CopyFrom(settings);
@@ -31,7 +31,7 @@ internal static class ODataQueryContextExtensions
     public static ODataQuerySettings UpdateQuerySettings(this ODataQueryContext context, ODataQuerySettings querySettings, IQueryable query)
     {
         ODataQuerySettings updatedSettings = new ODataQuerySettings();
-        ODataQuerySettings settings = context?.RequestContainer?.GetRequiredService<ODataQuerySettings>();
+        ODataQuerySettings settings = context?.RequestContainer?.GetService<ODataQuerySettings>();
         if (settings != null)
         {
             updatedSettings.CopyFrom(settings);

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryEndpointFilter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryEndpointFilter.cs
@@ -1,0 +1,535 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataQueryEndpointFilter.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Query.Validator;
+using Microsoft.AspNetCore.OData.Results;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder.Config;
+
+namespace Microsoft.AspNetCore.OData.Query;
+
+/// <summary>
+/// The default implementation to <see cref="IODataQueryEndpointFilter"/> to run codes before and after a route handler.
+/// This typically is used for minimal api scenario.
+/// </summary>
+public class ODataQueryEndpointFilter : IODataQueryEndpointFilter
+{
+    /// <summary>
+    /// Gets the validation settings. Customers can use this to configure the validation.
+    /// </summary>
+    public ODataValidationSettings ValidationSettings { get; } = new ODataValidationSettings();
+
+    /// <summary>
+    /// Gets the query settings. Customers can use this to configure each query executing.
+    /// </summary>
+    /// <remarks>
+    /// It could be confusing between DefaultQueryConfigurations and ODataQuerySettings.
+    /// DefaultQueryConfigurations is used to config the functionalities for query options. For example: is $filter enabled?
+    /// ODataQuerySettings is used to set options for each query executing.
+    /// </remarks>
+    public ODataQuerySettings QuerySettings { get; } = new ODataQuerySettings();
+
+    /// <summary>
+    /// Implements the core logic associated with the filter given a <see cref="EndpointFilterInvocationContext"/>
+    /// and the next filter to call in the pipeline.
+    /// </summary>
+    /// <param name="invocationContext">The <see cref="EndpointFilterInvocationContext"/> associated with the current request/response.</param>
+    /// <param name="next">The next filter in the pipeline.</param>
+    /// <returns>An awaitable result of calling the handler and apply any modifications made by filters in the pipeline.</returns>
+    public virtual async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext invocationContext, EndpointFilterDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(invocationContext);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var endpoint = invocationContext.HttpContext.GetEndpoint();
+        if (endpoint is null)
+        {
+            return await next(invocationContext);
+        }
+
+        // https://github.com/dotnet/aspnetcore/blob/main/src/Http/Routing/src/RouteEndpointDataSource.cs#L171
+        // Add MethodInfo and HttpMethodMetadata(if any) as first metadata items as they are intrinsic to the route much like
+        // the pattern or default display name. This gives visibility to conventions like WithOpenApi() to intrinsic route details
+        // (namely the MethodInfo) even when applied early as group conventions.
+        MethodInfo methodInfo = endpoint.Metadata.OfType<MethodInfo>().FirstOrDefault();
+
+        // If the endpoint metadata doesn't contain 'MethodInfo', it's a 'RequestDelegate' method.
+        // Maybe we should not take this into consideration? since the RequestDelegate return type is 'Task', we cannot idendify the real return type from Task?
+        methodInfo = methodInfo ?? endpoint.RequestDelegate.Method;
+
+        if (methodInfo is null)
+        {
+            return await next(invocationContext);
+        }
+
+        var odataFilterContext = new ODataQueryFilterInvocationContext { MethodInfo = methodInfo, InvocationContext = invocationContext };
+
+        await OnFilterExecutingAsync(odataFilterContext);
+
+        // calling into next filter or the route handler.
+        var result = await next(invocationContext);
+
+        return await OnFilterExecutedAsync(result, odataFilterContext);
+    }
+
+    /// <summary>
+    /// Performs the query composition before route handler is executing.
+    /// </summary>
+    /// <param name="context">The OData query filter invocation context.</param>
+    /// <returns>The <see cref="ValueTask"/>.</returns>
+    public virtual async ValueTask OnFilterExecutingAsync(ODataQueryFilterInvocationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        HttpContext httpContext = context.HttpContext;
+
+        // Use RequestQueryData to save the query validatation before route handler executing.
+        // This is same logic as EnableQueryAttribute. This is not required. However, it can give a better perf.
+        RequestQueryData requestQueryData = new RequestQueryData()
+        {
+            QueryValidationRunBeforeActionExecution = false,
+        };
+
+        httpContext.Items.TryAdd(nameof(RequestQueryData), requestQueryData);
+
+        ODataQueryOptions queryOptions = CreateQueryOptionsOnExecuting(context);
+        if (queryOptions == null)
+        {
+            return; // skip validation if we cannot create the query option on executing.
+        }
+
+        // Create and validate the query options.
+        requestQueryData.QueryValidationRunBeforeActionExecution = true;
+        requestQueryData.ProcessedQueryOptions = queryOptions;
+
+        // We should add async version for the Valiator then we can call them here again to waive the ValueTask.CompletedTask.
+        ValidateQuery(httpContext, requestQueryData.ProcessedQueryOptions);
+
+        await ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Performs the query composition after route handler is executed.
+    /// </summary>
+    /// <param name="responseValue">The response value from the route handler.</param>
+    /// <param name="context">The OData query filter invocation context.</param>
+    /// <returns>The <see cref="ValueTask"/>.</returns>
+    public virtual async ValueTask<object> OnFilterExecutedAsync(object responseValue, ODataQueryFilterInvocationContext context)
+    {
+        if (responseValue == null)
+        {
+            return null;
+        }
+
+        ArgumentNullException.ThrowIfNull(context);
+        object originalValue = responseValue;
+
+        // TODO: Process the SingleResult<T> and PageResult<T> as return type later
+        IQueryable singleResultCollection = null;
+
+        bool isODataResult = false;
+        if (responseValue is ODataResult odataResult)
+        {
+            isODataResult = true;
+            responseValue = odataResult.Value;
+        }
+
+        if (!QuerySettings.PageSize.HasValue && responseValue != null)
+        {
+            GetModelBoundPageSize(context, responseValue, singleResultCollection);
+        }
+
+        HttpRequest request = context.HttpContext.Request;
+        bool shouldApplyQuery = responseValue != null &&
+           request.GetEncodedUrl() != null &&
+           (!string.IsNullOrWhiteSpace(request.QueryString.Value) ||
+           QuerySettings.PageSize.HasValue ||
+           QuerySettings.ModelBoundPageSize.HasValue ||
+           singleResultCollection != null);
+
+        if (!shouldApplyQuery)
+        {
+            return await ValueTask.FromResult(originalValue);
+        }
+
+        object queryResult = ExecuteQuery(responseValue, singleResultCollection, context);
+
+        if (isODataResult)
+        {
+            return await ValueTask.FromResult(new ODataResult(queryResult));
+        }
+
+        return await ValueTask.FromResult(queryResult);
+    }
+
+    private void GetModelBoundPageSize(ODataQueryFilterInvocationContext context, object responseValue, IQueryable singleResultCollection)
+    {
+        ODataQueryContext queryContext;
+
+        try
+        {
+            queryContext = GetODataQueryContext(responseValue, singleResultCollection, context);
+        }
+        catch (InvalidOperationException e)
+        {
+            throw new InvalidOperationException(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+        }
+
+        ModelBoundQuerySettings querySettings = queryContext.Model.GetModelBoundQuerySettings(queryContext.TargetProperty,
+            queryContext.TargetStructuredType);
+        if (querySettings != null && querySettings.PageSize.HasValue)
+        {
+            QuerySettings.ModelBoundPageSize = querySettings.PageSize;
+        }
+    }
+
+    /// <summary>
+    /// Execute the query.
+    /// </summary>
+    /// <param name="responseValue">The response value.</param>
+    /// <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+    /// <param name="context">The action context, i.e. action and controller name.</param>
+    /// <returns></returns>
+    protected virtual object ExecuteQuery(object responseValue, IQueryable singleResultCollection,
+         ODataQueryFilterInvocationContext context)
+    {
+        ODataQueryContext queryContext = GetODataQueryContext(responseValue, singleResultCollection, context);
+
+        // Create and validate the query options.
+        ODataQueryOptions queryOptions = CreateAndValidateQueryOptions(context.HttpContext, queryContext);
+
+        ODataQuerySettings querySettings = QuerySettings;
+
+        // apply the query
+        IEnumerable enumerable = responseValue as IEnumerable;
+        if (enumerable == null || responseValue is string || responseValue is byte[])
+        {
+            // response is not a collection; we only support $select and $expand on single entities.
+            ValidateSelectExpandOnly(queryOptions);
+
+            if (singleResultCollection == null)
+            {
+                // response is a single entity.
+                return ApplyQuery(entity: responseValue, queryOptions: queryOptions, querySettings);
+            }
+            else
+            {
+                IQueryable queryable = singleResultCollection as IQueryable;
+                queryable = ApplyQuery(queryable, queryOptions, querySettings);
+                return SingleOrDefault(queryable, context);
+            }
+        }
+        else
+        {
+            // response is a collection.
+            IQueryable queryable = enumerable as IQueryable ?? enumerable.AsQueryable();
+            queryable = ApplyQuery(queryable, queryOptions, querySettings);
+
+            return queryable;
+        }
+    }
+
+    /// <summary>
+    /// Validate the select and expand options.
+    /// </summary>
+    /// <param name="queryOptions">The query options.</param>
+    internal static void ValidateSelectExpandOnly(ODataQueryOptions queryOptions)
+    {
+        if (queryOptions.Filter != null || queryOptions.Count != null || queryOptions.OrderBy != null
+            || queryOptions.Skip != null || queryOptions.Top != null)
+        {
+            throw new ODataException(Error.Format(SRResources.NonSelectExpandOnSingleEntity));
+        }
+    }
+
+    /// <summary>
+    /// Get a single or default value from a collection.
+    /// </summary>
+    /// <param name="queryable">The response value as <see cref="IQueryable"/>.</param>
+    /// <param name="context">The context.</param>
+    /// <returns></returns>
+    internal static object SingleOrDefault(IQueryable queryable, ODataQueryFilterInvocationContext context)
+    {
+        var enumerator = queryable.GetEnumerator();
+        try
+        {
+            var result = enumerator.MoveNext() ? enumerator.Current : null;
+
+            if (enumerator.MoveNext())
+            {
+                throw new InvalidOperationException(Error.Format(
+                    SRResources.SingleResultHasMoreThanOneEntity,
+                    context.MethodInfo.Name,
+                    "MinimalAPI",
+                    "SingleResult"));
+            }
+
+            return result;
+        }
+        finally
+        {
+            // Ensure any active/open database objects that were created
+            // iterating over the IQueryable object are properly closed.
+            var disposable = enumerator as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies the query to the given entity based on incoming query from uri and query settings.
+    /// </summary>
+    /// <param name="entity">The original entity from the response message.</param>
+    /// <param name="queryOptions">
+    /// The <see cref="ODataQueryOptions"/> instance constructed based on the incoming request.
+    /// </param>
+    /// <param name="querySettings">The query settings.</param>
+    /// <returns>The new entity after the $select and $expand query has been applied to.</returns>
+    public virtual object ApplyQuery(object entity, ODataQueryOptions queryOptions, ODataQuerySettings querySettings)
+    {
+        if (entity == null)
+        {
+            throw Error.ArgumentNull("entity");
+        }
+        if (queryOptions == null)
+        {
+            throw Error.ArgumentNull("queryOptions");
+        }
+
+        return queryOptions.ApplyTo(entity, querySettings);
+    }
+
+    /// <summary>
+    /// Applies the query to the given IQueryable based on incoming query from uri and query settings. By default,
+    /// the implementation supports $top, $skip, $orderby and $filter. Override this method to perform additional
+    /// query composition of the query.
+    /// </summary>
+    /// <param name="queryable">The original queryable instance from the response message.</param>
+    /// <param name="queryOptions">
+    /// The <see cref="ODataQueryOptions"/> instance constructed based on the incoming request.
+    /// </param>
+    /// <param name="querySettings">The settings.</param>
+    public virtual IQueryable ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions, ODataQuerySettings querySettings)
+    {
+        ArgumentNullException.ThrowIfNull(queryable, nameof(queryable));
+        ArgumentNullException.ThrowIfNull(queryOptions, nameof(queryOptions));
+
+        return queryOptions.ApplyTo(queryable, querySettings);
+    }
+
+    /// <summary>
+    /// Get the OData query context.
+    /// </summary>
+    /// <param name="responseValue">The response value.</param>
+    /// <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+    /// <param name="invocationContext">The action context, i.e. action and controller name.</param>
+    /// <returns></returns>
+    private ODataQueryContext GetODataQueryContext(object responseValue,
+        IQueryable singleResultCollection,
+        ODataQueryFilterInvocationContext invocationContext)
+    {
+        Type elementClrType = GetElementType(responseValue, singleResultCollection, invocationContext);
+
+        IEdmModel model = GetModel(elementClrType, invocationContext);
+        if (model == null)
+        {
+            throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
+        }
+
+        return new ODataQueryContext(model, elementClrType/*, request.ODataFeature().Path*/);
+    }
+
+    /// <summary>
+    /// Create and validate a new instance of <see cref="ODataQueryOptions"/> from a query and context during action executed.
+    /// Developers can override this virtual method to provide its own <see cref="ODataQueryOptions"/>.
+    /// </summary>
+    /// <param name="httpContext">The http context.</param>
+    /// <param name="queryContext">The query context.</param>
+    /// <returns>The created <see cref="ODataQueryOptions"/>.</returns>
+    protected virtual ODataQueryOptions CreateAndValidateQueryOptions(HttpContext httpContext, ODataQueryContext queryContext)
+    {
+        if (httpContext == null)
+        {
+            throw Error.ArgumentNull("httpContext");
+        }
+
+        if (queryContext == null)
+        {
+            throw Error.ArgumentNull("queryContext");
+        }
+
+        RequestQueryData requestQueryData = httpContext.Items[nameof(RequestQueryData)] as RequestQueryData;
+
+        if (requestQueryData != null && requestQueryData.QueryValidationRunBeforeActionExecution)
+        {
+            // processed, just return the query option and skip validation.
+            return requestQueryData.ProcessedQueryOptions;
+        }
+
+        ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, httpContext.Request);
+
+        ValidateQuery(httpContext, queryOptions);
+
+        return queryOptions;
+    }
+
+    /// <summary>
+    /// Get the element type.
+    /// </summary>
+    /// <param name="responseValue">The response value.</param>
+    /// <param name="singleResultCollection">The content as SingleResult.Queryable.</param>
+    /// <param name="context">The context.</param>
+    /// <returns></returns>
+    internal static Type GetElementType(
+        object responseValue,
+        IQueryable singleResultCollection,
+        ODataQueryFilterInvocationContext context)
+    {
+        Contract.Assert(responseValue != null);
+
+        IEnumerable enumerable = responseValue as IEnumerable;
+        if (enumerable == null)
+        {
+            if (singleResultCollection == null)
+            {
+                return responseValue.GetType();
+            }
+
+            enumerable = singleResultCollection;
+        }
+
+        Type elementClrType = TypeHelper.GetImplementedIEnumerableType(enumerable.GetType());
+        if (elementClrType == null)
+        {
+            throw Error.InvalidOperation("The element type cannot be determined because the type of the content is not IEnumerable<T> or IQueryable<T>.");
+        }
+
+        return elementClrType;
+    }
+
+    /// <summary>
+    /// Validates the OData query in the incoming request. By default, the implementation throws an exception if
+    /// the query contains unsupported query parameters. Override this method to perform additional validation of
+    /// the query.
+    /// </summary>
+    /// <param name="httpContext" />
+    /// <param name="queryOptions">
+    /// The <see cref="ODataQueryOptions"/> instance constructed based on the incoming request.
+    /// </param>
+    protected virtual void ValidateQuery(HttpContext httpContext, ODataQueryOptions queryOptions)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext, nameof(httpContext));
+        ArgumentNullException.ThrowIfNull(queryOptions, nameof(queryOptions));
+
+        IQueryCollection queryParameters = httpContext.Request.Query;
+        foreach (var kvp in queryParameters)
+        {
+            if (!queryOptions.IsSupportedQueryOption(kvp.Key) &&
+                 kvp.Key.StartsWith("$", StringComparison.Ordinal))
+            {
+                // we don't support any custom query options that start with $
+                throw new ODataException(Error.Format(SRResources.CustomQueryOptionNotSupportedWithDollarSign, kvp.Key));
+            }
+        }
+
+        queryOptions.Validate(ValidationSettings);
+    }
+
+    /// <summary>
+    /// Creates the <see cref="ODataQueryOptions"/> for action executing validation.
+    /// </summary>
+    /// <param name="context">The OData query filter invocation context.</param>
+    /// <returns>The created <see cref="ODataQueryOptions"/> or null if we can't create it during action executing.</returns>
+    protected virtual ODataQueryOptions CreateQueryOptionsOnExecuting(ODataQueryFilterInvocationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        ODataQueryContext queryContext;
+
+        // For these cases few options are supported like IEnumerable<T>, Task<IEnumerable<T>>, T, Task<T>
+        // Other cases where we cannot determine the return type upfront, are not supported
+        // Like IActionResult, SingleResult. For such cases, the validation is run in OnActionExecuted
+        // When we have the result.
+
+        // From Minimal API doc
+        // Minimal endpoints support the following types of return values:
+        // 1. string -This includes Task<string> and ValueTask<string>.
+        // 2. T(Any other type) - This includes Task<T> and ValueTask<T>.
+        // 3. IResult based -This includes Task<IResult> and ValueTask<IResult>
+
+        Type returnType = context.MethodInfo.ReturnType;
+        if (returnType is null)
+        {
+            return null;
+        }
+
+        if (returnType.IsGenericType)
+        {
+            Type genericTypeDef = returnType.GetGenericTypeDefinition();
+            if (genericTypeDef == typeof(Task<>) || genericTypeDef == typeof(ValueTask<>))
+            {
+                returnType = returnType.GetGenericArguments().First();
+            }
+        }
+
+        if (returnType == typeof(ODataResult))
+        {
+            return null;
+        }
+
+        TypeHelper.IsCollection(returnType, out Type elementType);
+
+        IEdmModel edmModel = GetModel(elementType, context);
+
+        queryContext = new ODataQueryContext(edmModel, elementType);
+
+        // Get or create the service provider based on the model. It should save into the ODataFeature() in the method.
+        context.HttpContext.GetOrCreateServiceProvider();
+        IODataFeature odataFeature = context.HttpContext.ODataFeature();
+
+        if (odataFeature.Services is null)
+        {
+            // Why? For example, developer overwrites 'GetModel', and in his version, he didn't create the ServiceProvider.
+            odataFeature.Services = context.HttpContext.BuildDefaultServiceProvider(edmModel);
+        }
+
+        // Create the query options.
+        return new ODataQueryOptions(queryContext, context.HttpContext.Request);
+    }
+
+    /// <summary>
+    /// Gets the EDM model for the given type and request.Override this method to customize the EDM model used for
+    /// querying.
+    /// </summary>
+    /// <param name="elementClrType">The CLR type to retrieve a model for.</param>
+    /// <param name="context">The action descriptor for the action being queried on.</param>
+    /// <returns>The EDM model for the given type and request.</returns>
+    protected virtual IEdmModel GetModel(Type elementClrType, ODataQueryFilterInvocationContext context)
+    {
+        HttpContext httpContext = context.HttpContext;
+
+        return httpContext.GetOrCreateEdmModel(elementClrType);
+    }
+}
+

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/AggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/AggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class AggregationWrapper : GroupByWrapper
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/ComputeWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/ComputeWrapperOfT.cs
@@ -19,6 +19,7 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
 /// <inheritdoc/>
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class ComputeWrapper<T> : GroupByWrapper, IGroupByWrapper<AggregationPropertyContainer, GroupByWrapper>, IComputeWrapper<T>, IEdmEntityObject
 {
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/EntitySetAggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/EntitySetAggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class EntitySetAggregationWrapper : GroupByWrapper
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/FlatteningWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/FlatteningWrapperOfT.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.OData.Query.Container;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class FlatteningWrapper<T> : GroupByWrapper, IGroupByWrapper<AggregationPropertyContainer, GroupByWrapper>, IFlatteningWrapper<T>
 {
     public T Source { get; set; }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/GroupByWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/GroupByWrapper.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.OData.Query.Container;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class GroupByWrapper : DynamicTypeWrapper, IGroupByWrapper<AggregationPropertyContainer, GroupByWrapper>
 {
     private Dictionary<string, object> _values;

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByAggregationWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByAggregationWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class NoGroupByAggregationWrapper : GroupByWrapper
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/NoGroupByWrapper.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(DynamicTypeWrapperConverter))]
 internal class NoGroupByWrapper : GroupByWrapper
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllAndExpandOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllAndExpandOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal class SelectAllAndExpand<TEntity> : SelectExpandWrapper<TEntity>
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectAllOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal class SelectAll<TEntity> : SelectExpandWrapper<TEntity>
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapper.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Formatter.Value;
 using Microsoft.AspNetCore.OData.Query.Container;
@@ -14,6 +15,7 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal abstract class SelectExpandWrapper : IEdmEntityObject, ISelectExpandWrapper
 {
     private static readonly IPropertyMapper DefaultPropertyMapper = new IdentityPropertyMapper();

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperConverter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperConverter.cs
@@ -16,8 +16,11 @@ namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 /// <summary>
 /// Supports converting <see cref="SelectExpandWrapper{T}"/> types by using a factory pattern.
 /// </summary>
-internal class SelectExpandWrapperConverter : JsonConverterFactory
+public class SelectExpandWrapperConverter : JsonConverterFactory
 {
+    /// <summary>
+    /// The mapper provider.
+    /// </summary>
     public static readonly Func<IEdmModel, IEdmStructuredType, IPropertyMapper> MapperProvider =
         (IEdmModel model, IEdmStructuredType type) => new JsonPropertyNameMapper(model, type);
 

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectExpandWrapperOfT.cs
@@ -25,6 +25,7 @@ property selection combination possible. */
 /// Represents a container class that contains properties that are either selected or expanded using $select and $expand.
 /// </summary>
 /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
 {
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeAndInheritanceOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeAndInheritanceOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal class SelectSomeAndInheritance<TEntity> : SelectExpandWrapper<TEntity>
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Wrapper/SelectSomeOfT.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Query.Wrapper;
 
+[JsonConverter(typeof(SelectExpandWrapperConverter))]
 internal class SelectSome<TEntity> : SelectAllAndExpand<TEntity>
 {
 }

--- a/src/Microsoft.AspNetCore.OData/Results/IODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/IODataResult.cs
@@ -1,0 +1,27 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="IODataResult.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.AspNetCore.OData.Results;
+
+/// <summary>
+/// A contracts for OData result 
+/// </summary>
+public interface IODataResult
+{
+    /// <summary>
+    /// Gets the real value.
+    /// </summary>
+    object Value { get; }
+
+    /// <summary>
+    /// Gets the expected type.
+    /// </summary>
+    Type ExpectedType { get; }
+}
+

--- a/src/Microsoft.AspNetCore.OData/Results/ODataMetadataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ODataMetadataResult.cs
@@ -1,0 +1,133 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataMetadataResult.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Results;
+
+/// <summary>
+/// Defines a contract that represents the result of OData metadata.
+/// </summary>
+internal class ODataMetadataResult : IResult
+{
+    /// <summary>
+    /// Gets the static instance since we don't need the instance of it.
+    /// </summary>
+    public static ODataMetadataResult Instance = new ODataMetadataResult();
+
+    /// <summary>
+    /// Write an HTTP response reflecting the result.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <returns>A task that represents the asynchronous execute operation.</returns>
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext, nameof(httpContext));
+
+        var endpoint = httpContext.GetEndpoint();
+        ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
+        IEdmModel model = metadata.Model;
+
+        IServiceProvider sp = GetServiceProvider(httpContext);
+        ODataMetadataSerializer serializer = sp.GetService<ODataMetadataSerializer>() ?? new ODataMetadataSerializer();
+
+        ODataMessageWriterSettings writerSettings = sp.GetService<ODataMessageWriterSettings>() ?? new ODataMessageWriterSettings();
+        writerSettings.BaseUri = GetBaseAddress(httpContext, metadata);
+
+        writerSettings.ODataUri = new ODataUri
+        {
+            ServiceRoot = writerSettings.BaseUri,
+        };
+        writerSettings.Version = metadata.Version;
+
+        HttpResponse response = httpContext.Response;
+
+        SetResponseHeader(httpContext, metadata);
+
+        IODataResponseMessageAsync responseMessage = ODataMessageWrapperHelper.Create(response.Body, response.Headers, sp);
+
+        await using (ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, writerSettings, model))
+        {
+            ODataSerializerContext writeContext = new ODataSerializerContext();
+            await serializer.WriteObjectAsync(model, typeof(IEdmModel), messageWriter, writeContext).ConfigureAwait(false);
+        }
+    }
+
+    private IServiceProvider GetServiceProvider(HttpContext httpContext)
+    {
+        var endpoint = httpContext.GetEndpoint();
+        ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
+        return metadata.ServiceProvider;
+    }
+
+    private static void SetResponseHeader(HttpContext httpContext, ODataMiniMetadata metadata)
+    {
+        ODataVersion version = ODataResult.GetODataVersion(httpContext.Request, metadata);
+
+        // Add version header.
+        httpContext.Response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(version);
+
+        if (IsJson(httpContext))
+        {
+            httpContext.Response.ContentType = "application/json";
+        }
+        else
+        {
+            httpContext.Response.ContentType = "application/xml";
+        }
+    }
+
+    internal static bool IsJson(HttpContext context)
+    {
+        var acceptHeaders = context.Request.Headers.Accept;
+        if (acceptHeaders.Any(h => h.Contains("application/json", StringComparison.OrdinalIgnoreCase)))
+        {
+            // If Accept header set on Request, we use it.
+            return true;
+        }
+        else if (acceptHeaders.Any(h => h.Contains("application/xml", StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        StringValues formatValues;
+        bool dollarFormat = context.Request.Query.TryGetValue("$format", out formatValues) || context.Request.Query.TryGetValue("format", out formatValues);
+        if (dollarFormat)
+        {
+            if (formatValues.Any(h => h.Contains("application/json", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+            else if (formatValues.Any(h => h.Contains("application/xml", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private Uri GetBaseAddress(HttpContext httpContext, ODataMiniMetadata metadata)
+    {
+        if (metadata.BaseAddressFactory is not null)
+        {
+            return metadata.BaseAddressFactory(httpContext);
+        }
+
+        return ODataOutputFormatter.GetDefaultBaseAddress(httpContext.Request);
+    }
+}
+

--- a/src/Microsoft.AspNetCore.OData/Results/ODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ODataResult.cs
@@ -1,0 +1,173 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataResult.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Results;
+
+/// <summary>
+/// Defines an implementation that represents the result of an OData format result.
+/// It's used for minimal API.
+/// </summary>
+internal class ODataResult : IODataResult, IResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ODataResult"/> class.
+    /// </summary>
+    /// <param name="value">The wrappered real value.</param>
+    public ODataResult(object value)
+        : this(value, value?.GetType())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ODataResult"/> class.
+    /// </summary>
+    /// <param name="value">The wrappered real value.</param>
+    /// <param name="expectedType">The expected type.</param>
+    public ODataResult(object value, Type expectedType)
+    {
+        Value = value;
+        ExpectedType = expectedType;
+    }
+
+    /// <summary>
+    /// Gets the value.
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// Gets the expected type.
+    /// </summary>
+    public Type ExpectedType { get; }
+
+    /// <summary>
+    /// Writes an HTTP response reflecting the result.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <returns>A task that represents the asynchronous execute operation.</returns>
+    public virtual async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        Type type = Value.GetType();
+        if (type == null)
+        {
+            throw Error.ArgumentNull(nameof(type));
+        }
+        type = TypeHelper.GetTaskInnerTypeOrSelf(type);
+
+        if (!TypeHelper.IsCollection(type, out Type elementType))
+        {
+            elementType = type;
+        }
+
+        HttpRequest request = httpContext.Request;
+        if (request == null)
+        {
+            throw Error.InvalidOperation(SRResources.WriteToResponseAsyncMustHaveRequest);
+        }
+
+        IEdmModel model = httpContext.GetOrCreateEdmModel(elementType);
+
+        if (elementType.IsSelectExpandWrapper(out Type elementType1))
+        {
+            elementType = elementType1;
+        }
+
+        IEdmType edmType = model.GetEdmType(elementType);
+
+        var endpoint = httpContext.GetEndpoint();
+        ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
+
+        var pathFactory = metadata?.PathFactory ?? ODataMiniMetadata.DefaultPathFactory;
+
+        IODataFeature odataFeature = httpContext.ODataFeature();
+        odataFeature.Path = pathFactory(httpContext, elementType);
+
+        HttpResponse response = httpContext.Response;
+        Uri baseAddress = GetBaseAddress(httpContext, metadata);
+        MediaTypeHeaderValue contentType = GetContentType(response.Headers[HeaderNames.ContentType].FirstOrDefault());
+
+        if (odataFeature.Services is null)
+        {
+            odataFeature.Services = metadata.ServiceProvider;
+        }
+
+        IODataSerializerProvider serializerProvider = odataFeature.Services.GetRequiredService<IODataSerializerProvider>();
+
+        ODataVersion version = GetODataVersion(request, metadata);
+
+        // Add version header.
+        response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(version);
+
+        await ODataOutputFormatterHelper.WriteToStreamAsync(
+            type,
+            Value,
+            model,
+            version,
+            baseAddress,
+            contentType,
+            request,
+            request.Headers,
+            serializerProvider).ConfigureAwait(false);
+    }
+
+    private Uri GetBaseAddress(HttpContext httpContext, ODataMiniMetadata options)
+    {
+        if (options.BaseAddressFactory is not null)
+        {
+            return options.BaseAddressFactory(httpContext);
+        }
+
+        return ODataOutputFormatter.GetDefaultBaseAddress(httpContext.Request);
+    }
+
+    internal static ODataVersion GetODataVersion(HttpRequest request, ODataMiniMetadata options)
+    {
+        ODataVersion? version = request.ODataMaxServiceVersion() ??
+            request.ODataMinServiceVersion() ??
+            request.ODataServiceVersion();
+
+        if (version is not null)
+        {
+            return version.Value;
+        }
+
+        if (options is not null)
+        {
+            return options.Version;
+        }
+
+        return ODataVersionConstraint.DefaultODataVersion;
+    }
+
+    private MediaTypeHeaderValue GetContentType(string contentTypeValue)
+    {
+        MediaTypeHeaderValue contentType = null;
+        if (!string.IsNullOrEmpty(contentTypeValue))
+        {
+            MediaTypeHeaderValue.TryParse(contentTypeValue, out contentType);
+        }
+
+        return contentType;
+    }
+}
+

--- a/src/Microsoft.AspNetCore.OData/Results/ODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ODataResult.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Edm;
@@ -116,7 +117,7 @@ internal class ODataResult : IODataResult, IResult
         ODataVersion version = GetODataVersion(request, metadata);
 
         // Add version header.
-        response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(version);
+        WriteResponseHeaders(httpContext, metadata, version);
 
         await ODataOutputFormatterHelper.WriteToStreamAsync(
             type,
@@ -128,6 +129,12 @@ internal class ODataResult : IODataResult, IResult
             request,
             request.Headers,
             serializerProvider).ConfigureAwait(false);
+    }
+
+    private void WriteResponseHeaders(HttpContext context, ODataMiniMetadata metadata, ODataVersion version)
+    {
+        context.Response.Headers[HeaderNames.ContentType] = "application/json";
+        context.Response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(version);
     }
 
     private Uri GetBaseAddress(HttpContext httpContext, ODataMiniMetadata options)

--- a/src/Microsoft.AspNetCore.OData/Results/ODataServiceDocumentResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ODataServiceDocumentResult.cs
@@ -1,0 +1,82 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataServiceDocumentResult.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Results;
+
+/// <summary>
+/// Defines a contract that represents the result of OData service document.
+/// </summary>
+internal class ODataServiceDocumentResult : IResult
+{
+    /// <summary>
+    /// Gets the static instance since we don't need the instance of it.
+    /// </summary>
+    public static ODataServiceDocumentResult Instance = new ODataServiceDocumentResult();
+
+    /// <summary>
+    /// Write an HTTP response reflecting the result.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <returns>A task that represents the asynchronous execute operation.</returns>
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext, nameof(httpContext));
+
+        var endpoint = httpContext.GetEndpoint();
+        ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
+        IServiceProvider sp = metadata.ServiceProvider;
+        IEdmModel model = metadata.Model;
+
+        ODataServiceDocument serviceDocument = model.GenerateServiceDocument();
+
+        ODataServiceDocumentSerializer serializer = sp.GetService<ODataServiceDocumentSerializer>() ?? new ODataServiceDocumentSerializer();
+
+        ODataMessageWriterSettings writerSettings = sp.GetService<ODataMessageWriterSettings>() ?? new ODataMessageWriterSettings();
+        writerSettings.BaseUri = GetBaseAddress(httpContext, metadata);
+
+        writerSettings.ODataUri = new ODataUri
+        {
+            ServiceRoot = writerSettings.BaseUri,
+        };
+
+        HttpResponse response = httpContext.Response;
+
+        ODataVersion version = ODataResult.GetODataVersion(httpContext.Request, metadata);
+        httpContext.Response.ContentType = "application/json";
+
+        // Add version header.
+        httpContext.Response.Headers["OData-Version"] = ODataUtils.ODataVersionToString(version);
+
+        IODataResponseMessageAsync responseMessage = ODataMessageWrapperHelper.Create(response.Body, response.Headers, sp);
+
+        await using (ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, writerSettings, model))
+        {
+            ODataSerializerContext writeContext = new ODataSerializerContext();
+            await serializer.WriteObjectAsync(serviceDocument, typeof(ODataServiceDocument), messageWriter, writeContext).ConfigureAwait(false);
+        }
+    }
+
+    private Uri GetBaseAddress(HttpContext httpContext, ODataMiniMetadata metadata)
+    {
+        if (metadata.BaseAddressFactory is not null)
+        {
+            return metadata.BaseAddressFactory(httpContext);
+        }
+
+        return ODataOutputFormatter.GetDefaultBaseAddress(httpContext.Request);
+    }
+}
+

--- a/src/Microsoft.AspNetCore.OData/Results/PageResultOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/PageResultOfT.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Results;
 
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.OData.Results;
 /// </remarks>
 [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "Collection suffix not appropriate")]
 [DataContract]
+[JsonConverter(typeof(PageResultValueConverter))]
 public class PageResult<T> : PageResult, IEnumerable<T>
 {
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Results/SingleResultOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/SingleResultOfT.cs
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.OData.Results;
 
@@ -14,6 +15,7 @@ namespace Microsoft.AspNetCore.OData.Results;
 /// <c>[EnableQuery]</c>.
 /// </summary>
 /// <typeparam name="T">The type of the data in the data source.</typeparam>
+[JsonConverter(typeof(SingleResultValueConverter))]
 public sealed class SingleResult<T> : SingleResult
 {
     /// <summary>

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MetadataEndpointsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MetadataEndpointsTests.cs
@@ -1,0 +1,209 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MetadataEndpointsTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public class MetadataEndpointsTests : IClassFixture<MinimalTestFixture<MetadataEndpointsTests>>
+{
+    private readonly MinimalTestFixture<MetadataEndpointsTests> _factory;
+
+    public MetadataEndpointsTests(MinimalTestFixture<MetadataEndpointsTests> factory)
+    {
+        _factory = factory;
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        app.MapODataServiceDocument("v1/$document", model);
+
+        app.MapODataServiceDocument("v2/$document", model)
+            .WithODataBaseAddressFactory(h => new Uri("http://localhost/v2"));
+
+        app.MapODataMetadata("v1/$metadata", model);
+    }
+
+    [Fact]
+    public async Task ServiceDocumentEndpointV1_ShouldReturn_CorrectJsonResult()
+    {
+        // Arrange
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        var result = await client.GetAsync("/v1/$document");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var content = await result.Content.ReadAsStringAsync();
+
+        Assert.Equal("{\"@odata.context\":\"http://localhost/$metadata\"," +
+            "\"value\":[" +
+              "{\"name\":\"Todos\",\"kind\":\"EntitySet\",\"url\":\"Todos\"}" +
+            "]}",
+            content);
+    }
+
+    [Fact]
+    public async Task ServiceDocumentEndpointV2_ShouldReturn_CorrectJsonResult()
+    {
+        // Arrange
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        var result = await client.GetAsync("/v2/$document");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var content = await result.Content.ReadAsStringAsync();
+
+        Assert.Equal("{\"@odata.context\":\"http://localhost/v2/$metadata\"," +
+            "\"value\":[" +
+              "{\"name\":\"Todos\",\"kind\":\"EntitySet\",\"url\":\"Todos\"}" +
+            "]}",
+            content);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("?$format=application/xml")]
+    public async Task MetadataEndpointForCsdlXml_ShouldReturn_CorrectXmlResult(string query)
+    {
+        // Arrange
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        var result = await client.GetAsync($"/v1/$metadata{query}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var content = await result.Content.ReadAsStringAsync();
+
+        Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<EntityType Name=\"MiniTodo\">" +
+                    "<Key>" +
+                      "<PropertyRef Name=\"Id\" />" +
+                    "</Key>" +
+                    "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                    "<Property Name=\"Owner\" Type=\"Edm.String\" />" +
+                    "<Property Name=\"Title\" Type=\"Edm.String\" />" +
+                    "<Property Name=\"IsDone\" Type=\"Edm.Boolean\" Nullable=\"false\" />" +
+                    "<Property Name=\"Tasks\" Type=\"Collection(Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis.MiniTask)\" />" +
+                  "</EntityType>" +
+                  "<ComplexType Name=\"MiniTask\">" +
+                    "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                    "<Property Name=\"Description\" Type=\"Edm.String\" />" +
+                    "<Property Name=\"Created\" Type=\"Edm.Date\" Nullable=\"false\" />" +
+                    "<Property Name=\"IsComplete\" Type=\"Edm.Boolean\" Nullable=\"false\" />" +
+                    "<Property Name=\"Priority\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                  "</ComplexType>" +
+                "</Schema>" +
+                "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<EntityContainer Name=\"Container\">" +
+                    "<EntitySet Name=\"Todos\" EntityType=\"Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis.MiniTodo\" />" +
+                  "</EntityContainer>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>", content);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("?$format=application/json")]
+    public async Task MetadataEndpointForCsdlJson_ShouldReturn_CorrectJsonResult(string query)
+    {
+        // Arrange
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response;
+        if (query == null)
+        {
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/v1/$metadata");
+            httpRequestMessage.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            response = await client.SendAsync(httpRequestMessage);
+        }
+        else
+        {
+            response = await client.GetAsync($"/v1/$metadata{query}");
+        }
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(@"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""Default.Container"",
+  ""Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis"": {
+    ""MiniTodo"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Owner"": {
+        ""$Nullable"": true
+      },
+      ""Title"": {
+        ""$Nullable"": true
+      },
+      ""IsDone"": {
+        ""$Type"": ""Edm.Boolean""
+      },
+      ""Tasks"": {
+        ""$Collection"": true,
+        ""$Type"": ""Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis.MiniTask"",
+        ""$Nullable"": true
+      }
+    },
+    ""MiniTask"": {
+      ""$Kind"": ""ComplexType"",
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Description"": {
+        ""$Nullable"": true
+      },
+      ""Created"": {
+        ""$Type"": ""Edm.Date""
+      },
+      ""IsComplete"": {
+        ""$Type"": ""Edm.Boolean""
+      },
+      ""Priority"": {
+        ""$Type"": ""Edm.Int32""
+      }
+    }
+  },
+  ""Default"": {
+    ""Container"": {
+      ""$Kind"": ""EntityContainer"",
+      ""Todos"": {
+        ""$Collection"": true,
+        ""$Type"": ""Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis.MiniTodo""
+      }
+    }
+  }
+}", content);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalAPITasksEndpointsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalAPITasksEndpointsTest.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MinimalAPITasksEndpointsTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public class MinimalAPITasksEndpointsTest : IClassFixture<MinimalTestFixture<MinimalAPITasksEndpointsTest>>
+{
+    private readonly MinimalTestFixture<MinimalAPITasksEndpointsTest> _factory;
+
+    public MinimalAPITasksEndpointsTest(MinimalTestFixture<MinimalAPITasksEndpointsTest> factory)
+    {
+        _factory = factory;
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddOData(opt => opt.EnableAll());// global configuration.
+        services.AddSingleton<IMiniTodoTaskRepository, MiniTodoTaskInMemoryRepository>();
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        var model = MinimalEdmModel.GetAllEntitySetEdmModel();
+
+        // Use Group to config
+        var group = app.MapGroup("odata")
+            .WithODataModel(model)
+            .WithODataResult()
+            .AddODataQueryEndpointFilter(querySetup: s => s.PageSize = 2);
+
+        group.MapGet("tasks", (IMiniTodoTaskRepository db) => db.GetTasks());
+    }
+
+    [Fact]
+    public async Task QueryTasks_WithODataOnGroup_ReturnsODataPayload()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var result = await client.GetAsync("/odata/tasks?$orderby=Created&$select=Description");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"@odata.context\":\"http://localhost/$metadata#Tasks(Description)\"," +
+            "\"value\":[" +
+              "{\"Description\":\"Boil Rice\"}," +
+              "{\"Description\":\"Cook Pizza\"}" +
+            "]," +
+            "\"@odata.nextLink\":\"http://localhost/odata/tasks?$orderby=Created&$select=Description&$skiptoken=Created-2021-04-22,Id-13\"}",
+            content);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalAPITodoEndpointsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalAPITodoEndpointsTest.cs
@@ -1,0 +1,154 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MinimalAPITodoEndpointsTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public class MinimalAPITodoEndpointsTest : IClassFixture<MinimalTestFixture<MinimalAPITodoEndpointsTest>>
+{
+    private MinimalTestFixture<MinimalAPITodoEndpointsTest> _factory;
+    private HttpClient _client;
+
+    public MinimalAPITodoEndpointsTest(MinimalTestFixture<MinimalAPITodoEndpointsTest> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<IMiniTodoTaskRepository, MiniTodoTaskInMemoryRepository>();
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        app.MapGet("v0/todos", (IMiniTodoTaskRepository db) => db.GetTodos());
+
+        app.MapGet("v1/todos", (IMiniTodoTaskRepository db) => db.GetTodos())
+            .WithODataResult();
+
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        app.MapGet("v0/todos/{id}", (IMiniTodoTaskRepository db, int id) => db.GetTodo(id));
+
+        app.MapGet("v1/todos/{id}", (IMiniTodoTaskRepository db, int id) => db.GetTodo(id))
+            .WithODataResult()
+            .WithODataModel(model);
+
+        // Use ODataQueryOptions<T>
+        app.MapGet("v2/todos", (IMiniTodoTaskRepository db, ODataQueryOptions<MiniTodo> queryOptions)
+            => queryOptions.ApplyTo(db.GetTodos().AsQueryable(), new ODataQuerySettings()))
+            .WithODataResult()
+            .WithODataModel(model);
+
+        // Use Filter
+        app.MapGet("v2/todos/{id}", (IMiniTodoTaskRepository db, int id) => db.GetTodo(id))
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model)
+            .WithODataVersion(Microsoft.OData.ODataVersion.V401)
+            .WithODataBaseAddressFactory(h => new Uri("http://localhost/v2"))
+            .WithODataOptions(opt => opt.EnableAll().SetCaseInsensitive(true));
+    }
+
+    [Fact]
+    public async Task QueryTodos_ReturnsNormalJsonPayload()
+    {
+        // Arrange & Act
+        var result = await _client.GetAsync("/v0/todos");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("[{\"id\":1,\"owner\":\"Peter\",\"title\":\"Cooking\",\"isDone\":false,\"tasks\":[{\"id\":11,\"description\":\"Boil Rice\",\"created\":\"2021-04-22\",\"isComplete\":true,\"priority\":1},{\"id\":12,\"description\":\"Cook Potate\",\"created\":\"2022-04-22\",\"isComplete\":false,\"priority\":1},{\"id\":13,\"description\":\"Cook Pizza\",\"created\":\"2021-04-22\",\"isComplete\":false,\"priority\":2}]}," +
+            "{\"id\":2,\"owner\":\"Wu\",\"title\":\"English Practice\",\"isDone\":true,\"tasks\":[{\"id\":21,\"description\":\"Read English book\",\"created\":\"2024-02-11\",\"isComplete\":true,\"priority\":1},{\"id\":22,\"description\":\"Watch video\",\"created\":\"2022-03-04\",\"isComplete\":false,\"priority\":2}]}," +
+            "{\"id\":3,\"owner\":\"John\",\"title\":\"Shopping\",\"isDone\":true,\"tasks\":[{\"id\":31,\"description\":\"Buy bread\",\"created\":\"2022-02-11\",\"isComplete\":false,\"priority\":3},{\"id\":32,\"description\":\"Buy washing machine\",\"created\":\"2023-12-14\",\"isComplete\":true,\"priority\":2}]}," +
+            "{\"id\":4,\"owner\":\"Sam\",\"title\":\"Clean House\",\"isDone\":false,\"tasks\":[{\"id\":41,\"description\":\"Clean carpet\",\"created\":\"2025-02-11\",\"isComplete\":false,\"priority\":2},{\"id\":42,\"description\":\"Clean bathroom\",\"created\":\"2025-12-14\",\"isComplete\":true,\"priority\":1}]}]", content);
+    }
+
+    [Fact]
+    public async Task QueryTodos_WithODataResult_ReturnsODataJsonPayload()
+    {
+        // Arrange & Act
+        var result = await _client.GetAsync("/v1/todos");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"@odata.context\":\"http://localhost/$metadata#MiniTodo\"," +
+            "\"value\":[" +
+            "{\"Id\":1,\"Owner\":\"Peter\",\"Title\":\"Cooking\",\"IsDone\":false}," +
+            "{\"Id\":2,\"Owner\":\"Wu\",\"Title\":\"English Practice\",\"IsDone\":true}," +
+            "{\"Id\":3,\"Owner\":\"John\",\"Title\":\"Shopping\",\"IsDone\":true}," +
+            "{\"Id\":4,\"Owner\":\"Sam\",\"Title\":\"Clean House\",\"IsDone\":false}" +
+          "]}", content);
+    }
+
+    [Fact]
+    public async Task QueryTodo_WithODataResult_WithModel_ReturnsODataJsonPayload()
+    {
+        // Arrange & Act
+        var result = await _client.GetAsync("/v1/todos/3");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"@odata.context\":\"http://localhost/$metadata#Todos/$entity\"," +
+            "\"Id\":3," +
+            "\"Owner\":\"John\"," +
+            "\"Title\":\"Shopping\"," +
+            "\"IsDone\":true," +
+            "\"Tasks\":[" +
+               "{\"Id\":31,\"Description\":\"Buy bread\",\"Created\":\"2022-02-11\",\"IsComplete\":false,\"Priority\":3}," +
+               "{\"Id\":32,\"Description\":\"Buy washing machine\",\"Created\":\"2023-12-14\",\"IsComplete\":true,\"Priority\":2}]}",
+            content);
+    }
+
+    [Fact]
+    public async Task QueryTodos_WithODataResult_WithModel_UsingODataQuery_ReturnsODataJsonPayload()
+    {
+        // Arrange & Act
+        var result = await _client.GetAsync("/v2/todos?$select=Owner,Tasks($select=Description)");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"@odata.context\":\"http://localhost/$metadata#Todos(Owner,Tasks/Description)\"," +
+            "\"value\":[" +
+              "{\"Owner\":\"Peter\",\"Tasks\":[{\"Description\":\"Boil Rice\"},{\"Description\":\"Cook Potate\"},{\"Description\":\"Cook Pizza\"}]}," +
+              "{\"Owner\":\"Wu\",\"Tasks\":[{\"Description\":\"Read English book\"},{\"Description\":\"Watch video\"}]}," +
+              "{\"Owner\":\"John\",\"Tasks\":[{\"Description\":\"Buy bread\"},{\"Description\":\"Buy washing machine\"}]}," +
+              "{\"Owner\":\"Sam\",\"Tasks\":[{\"Description\":\"Clean carpet\"},{\"Description\":\"Clean bathroom\"}]}]}",
+            content);
+    }
+
+    [Fact]
+    public async Task QueryTodos_WithODataResult_WithModel_UsingFilter_ReturnsODataJsonPayload()
+    {
+        // Arrange & Act
+        var result = await _client.GetAsync("/v2/todos/4?$select=title,Tasks($select=Description;$orderby=id desc)");
+        var content = await result.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"@context\":\"http://localhost/v2/$metadata#Todos(Title,Tasks/Description)/$entity\"," +
+            "\"Title\":\"Clean House\"," +
+            "\"Tasks\":[{\"Description\":\"Clean bathroom\"},{\"Description\":\"Clean carpet\"}]}",
+            content);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalDataModel.cs
@@ -1,0 +1,38 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MinimalDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public class MiniTodo
+{
+    public int Id { get; set; }
+
+    public string Owner { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public bool IsDone { get; set; }
+
+    public IList<MiniTask> Tasks { get; set; }
+}
+
+public class MiniTask
+{
+    public int Id { get; set; }
+
+    public string Description { get; set; }
+
+    public DateOnly Created { get; set; }
+
+    public bool IsComplete { get; set; }
+
+    public int Priority { get; set; }
+}
+

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalDataSource.cs
@@ -1,0 +1,91 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MinimalDataSource.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public interface IMiniTodoTaskRepository
+{
+    IEnumerable<MiniTodo> GetTodos();
+
+    IEnumerable<MiniTask> GetTasks();
+
+    MiniTodo GetTodo(int id);
+
+    MiniTask GetTask(int id);
+}
+
+public class MiniTodoTaskInMemoryRepository : IMiniTodoTaskRepository
+{
+    private static IList<MiniTodo> _todos;
+    private static IList<MiniTask> _tasks;
+
+    public IEnumerable<MiniTodo> GetTodos() => _todos;
+
+    public IEnumerable<MiniTask> GetTasks() => _tasks;
+
+    public MiniTodo GetTodo(int id) => _todos.FirstOrDefault(t => t.Id == id);
+
+    public MiniTask GetTask(int id) => _tasks.FirstOrDefault(t => t.Id == id);
+
+    #region TodoTasks
+    static MiniTodoTaskInMemoryRepository()
+    {
+        _todos = new List<MiniTodo>
+        {
+            new MiniTodo
+            {
+                Id = 1, Owner = "Peter", Title = "Cooking", IsDone = false,
+                Tasks =
+                [
+                    new MiniTask { Id = 11, Created = new DateOnly(2021, 4, 22), Description = "Boil Rice", IsComplete = true, Priority = 1 },
+                    new MiniTask { Id = 12, Created = new DateOnly(2022, 4, 22), Description = "Cook Potate", IsComplete = false, Priority = 1 },
+                    new MiniTask { Id = 13, Created = new DateOnly(2021, 4, 22), Description = "Cook Pizza", IsComplete = false, Priority = 2 },
+                ]
+            },
+            new MiniTodo
+            {
+                Id = 2, Owner = "Wu", Title = "English Practice", IsDone = true,
+                Tasks =
+                [
+                    new MiniTask { Id = 21, Created = new DateOnly(2024, 2, 11), Description = "Read English book", IsComplete = true, Priority = 1 },
+                    new MiniTask { Id = 22, Created = new DateOnly(2022, 3, 4), Description = "Watch video", IsComplete = false, Priority = 2 },
+                ]
+            },
+            new MiniTodo
+            {
+                Id = 3, Owner = "John", Title = "Shopping", IsDone = true,
+                Tasks =
+                [
+                    new MiniTask { Id = 31, Created = new DateOnly(2022, 2, 11), Description = "Buy bread", IsComplete = false, Priority = 3 },
+                    new MiniTask { Id = 32, Created = new DateOnly(2023, 12, 14), Description = "Buy washing machine", IsComplete = true, Priority = 2 },
+                ]
+            },
+            new MiniTodo
+            {
+                Id = 4, Owner = "Sam", Title = "Clean House", IsDone = false,
+                Tasks =
+                [
+                    new MiniTask { Id = 41, Created = new DateOnly(2025, 2, 11), Description = "Clean carpet", IsComplete = false, Priority = 2 },
+                    new MiniTask { Id = 42, Created = new DateOnly(2025, 12, 14), Description = "Clean bathroom", IsComplete = true, Priority = 1 },
+                ]
+            }
+        };
+
+        List<MiniTask> tasks = new List<MiniTask>();
+        foreach (var todo in _todos)
+        {
+            tasks.AddRange(todo.Tasks);
+        }
+
+        _tasks = tasks;
+    }
+    #endregion
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalEdmModel.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="MinimalEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+public class MinimalEdmModel
+{
+    private static IEdmModel _model;
+
+    public static IEdmModel GetEdmModel()
+    {
+        if (_model == null)
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<MiniTodo>("Todos");
+            builder.ComplexType<MiniTask>(); // by default to make it as complex type
+            _model = builder.GetEdmModel();
+        }
+
+        return _model;
+    }
+
+    private static IEdmModel _entitySetModel;
+    public static IEdmModel GetAllEntitySetEdmModel()
+    {
+        if (_entitySetModel == null)
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<MiniTodo>("Todos");
+            builder.EntitySet<MiniTask>("Tasks");
+            _entitySetModel = builder.GetEdmModel();
+        }
+
+        return _entitySetModel;
+    }
+}
+
+

--- a/test/Microsoft.AspNetCore.OData.TestCommon/Utils/MinimalTestFixtureOfT.cs
+++ b/test/Microsoft.AspNetCore.OData.TestCommon/Utils/MinimalTestFixtureOfT.cs
@@ -1,0 +1,99 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MinimalTestFixtureOfT.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.OData.TestCommon;
+
+public class MinimalTestFixture<T> : IDisposable where T : class
+{
+    /// <summary>
+    /// The test server.
+    /// </summary>
+    private TestServer _server;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebApiTestFixture{T}"/> class
+    /// </summary>
+    public MinimalTestFixture()
+    {
+        Initialize();
+    }
+
+    /// <summary>
+    /// Create the <see cref="HttpClient"/>.
+    /// </summary>
+    /// <returns>The created HttpClient.</returns>
+    public HttpClient CreateClient()
+    {
+        return _server.CreateClient();
+    }
+
+    /// <summary>
+    /// Cleanup the server.
+    /// </summary>
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        Dispose(true);
+    }
+
+    /// <summary>
+    /// Cleanup the server.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (_server != null)
+            {
+                _server.Dispose();
+                _server = null;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// Initialize the fixture.
+    /// </summary>
+    private async void Initialize()
+    {
+        Type testType = typeof(T);
+
+        // Be noted:
+        // We use the convention as follows
+        // 1) if you want to configure the service, add "protected static void ConfigureServices(IServiceCollection)" method into your test class.
+        MethodInfo configureServicesMethod = testType.GetMethod("ConfigureServices", BindingFlags.NonPublic | BindingFlags.Static);
+
+        // 2) if you want to configure the routing, add "protected static void ConfigureAPIs(WebApplication)" method into your test class.
+        MethodInfo configureMethod = testType.GetMethod("ConfigureAPIs", BindingFlags.NonPublic | BindingFlags.Static);
+        // Owing that this is used in Test only, I assume every developer can following the convention.
+        // So I skip the method parameter checking.
+
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.UseTestServer();
+
+        configureServicesMethod?.Invoke(null, [builder.Services]);
+
+        var app = builder.Build();
+
+        _server = (TestServer)app.Services.GetRequiredService<IServer>();
+
+        configureMethod?.Invoke(null, [app]);
+
+        await app.RunAsync();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -85,6 +85,11 @@ public sealed class Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExt
 	[
 	ExtensionAttribute(),
 	]
+	public static TBuilder WithODataPathFactory (TBuilder builder, System.Func`3[[Microsoft.AspNetCore.Http.HttpContext],[System.Type],[Microsoft.OData.UriParser.ODataPath]] pathFactory)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static TBuilder WithODataResult (TBuilder builder)
 
 	[
@@ -635,6 +640,11 @@ public class Microsoft.AspNetCore.OData.Deltas.Delta`1 : Microsoft.AspNetCore.OD
 	Microsoft.AspNetCore.OData.Deltas.DeltaItemKind Kind  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static ValueTask`1 BindAsync (Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter)
 
 	public virtual void Clear ()
 	public void CopyChangedValues (T original)

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -26,6 +26,81 @@ public sealed class Microsoft.AspNetCore.OData.ODataApplicationBuilderExtensions
 [
 ExtensionAttribute(),
 ]
+public sealed class Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.RouteHandlerBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Routing.RouteGroupBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Routing.RouteGroupBuilder builder)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.RouteHandlerBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Routing.RouteGroupBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Routing.RouteGroupBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.RouteHandlerBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, params System.Action`1[[Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings]] validationSetup, params System.Action`1[[Microsoft.AspNetCore.OData.Query.ODataQuerySettings]] querySetup)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Routing.RouteGroupBuilder AddODataQueryEndpointFilter (Microsoft.AspNetCore.Routing.RouteGroupBuilder builder, params System.Action`1[[Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings]] validationSetup, params System.Action`1[[Microsoft.AspNetCore.OData.Query.ODataQuerySettings]] querySetup)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapODataMetadata (Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern, Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapODataServiceDocument (Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern, Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataBaseAddressFactory (TBuilder builder, System.Func`2[[Microsoft.AspNetCore.Http.HttpContext],[System.Uri]] baseAddressFactory)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataModel (TBuilder builder, Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataOptions (TBuilder builder, System.Action`1[[Microsoft.AspNetCore.OData.ODataMiniOptions]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataResult (TBuilder builder)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataServices (TBuilder builder, System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] services)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static TBuilder WithODataVersion (TBuilder builder, Microsoft.OData.ODataVersion version)
+}
+
+[
+ExtensionAttribute(),
+]
 public sealed class Microsoft.AspNetCore.OData.ODataMvcBuilderExtensions {
 	[
 	ExtensionAttribute(),
@@ -70,6 +145,16 @@ public sealed class Microsoft.AspNetCore.OData.ODataServiceCollectionExtensions 
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOData (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action`1[[Microsoft.AspNetCore.OData.ODataMiniOptions]] setupAction)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddODataQueryFilter (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
@@ -87,6 +172,40 @@ public class Microsoft.AspNetCore.OData.ODataJsonOptionsSetup : IConfigureOption
 	public ODataJsonOptionsSetup ()
 
 	public virtual void Configure (Microsoft.AspNetCore.Mvc.JsonOptions options)
+}
+
+public class Microsoft.AspNetCore.OData.ODataMiniMetadata {
+	public ODataMiniMetadata ()
+
+	System.Func`2[[Microsoft.AspNetCore.Http.HttpContext],[System.Uri]] BaseAddressFactory  { public get; public set; }
+	bool IsODataFormat  { public get; public set; }
+	Microsoft.OData.Edm.IEdmModel Model  { public get; public set; }
+	Microsoft.AspNetCore.OData.ODataMiniOptions Options  { public get; }
+	System.Func`3[[Microsoft.AspNetCore.Http.HttpContext],[System.Type],[Microsoft.OData.UriParser.ODataPath]] PathFactory  { public get; public set; }
+	System.IServiceProvider ServiceProvider  { public get; public set; }
+	System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] Services  { public get; public set; }
+	Microsoft.OData.ODataVersion Version  { public get; public set; }
+}
+
+public class Microsoft.AspNetCore.OData.ODataMiniOptions {
+	public ODataMiniOptions ()
+
+	bool EnableCaseInsensitive  { public get; }
+	bool EnableNoDollarQueryOptions  { public get; }
+	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
+	Microsoft.OData.ODataVersion Version  { public get; }
+
+	public Microsoft.AspNetCore.OData.ODataMiniOptions Count ()
+	public Microsoft.AspNetCore.OData.ODataMiniOptions EnableAll (params System.Nullable`1[[System.Int32]] maxTopValue)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions Expand ()
+	public Microsoft.AspNetCore.OData.ODataMiniOptions Filter ()
+	public Microsoft.AspNetCore.OData.ODataMiniOptions OrderBy ()
+	public Microsoft.AspNetCore.OData.ODataMiniOptions Select ()
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetCaseInsensitive (bool enableCaseInsensitive)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetMaxTop (System.Nullable`1[[System.Int32]] maxTopValue)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetNoDollarQueryOptions (bool enableNoDollarQueryOptions)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetVersion (Microsoft.OData.ODataVersion version)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SkipToken ()
 }
 
 public class Microsoft.AspNetCore.OData.ODataMvcOptionsSetup : IConfigureOptions`1 {
@@ -553,6 +672,10 @@ public class Microsoft.AspNetCore.OData.Deltas.DeltaSet`1 : System.Collections.O
 	System.Type StructuredType  { public virtual get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Edm.IODataModelConfiguration {
+	Microsoft.OData.ModelBuilder.ODataModelBuilder Apply (Microsoft.AspNetCore.Http.HttpContext context, Microsoft.OData.ModelBuilder.ODataModelBuilder builder, System.Type clrType)
+}
+
 public interface Microsoft.AspNetCore.OData.Edm.IODataTypeMapper {
 	System.Type GetClrPrimitiveType (Microsoft.OData.Edm.IEdmPrimitiveType primitiveType, bool nullable)
 	System.Type GetClrType (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmType edmType, bool nullable, Microsoft.OData.ModelBuilder.IAssemblyResolver assembliesResolver)
@@ -958,6 +1081,14 @@ public sealed class Microsoft.AspNetCore.OData.Extensions.SerializableErrorKeys 
 	public static readonly string StackTraceKey = "stacktrace"
 }
 
+public class Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext {
+	public ODataQueryFilterInvocationContext ()
+
+	Microsoft.AspNetCore.Http.HttpContext HttpContext  { public get; }
+	Microsoft.AspNetCore.Http.EndpointFilterInvocationContext InvocationContext  { public get; public set; }
+	System.Reflection.MethodInfo MethodInfo  { public get; public set; }
+}
+
 public enum Microsoft.AspNetCore.OData.Formatter.ODataMetadataLevel : int {
 	Full = 1
 	Minimal = 0
@@ -1208,6 +1339,11 @@ public interface Microsoft.AspNetCore.OData.Query.ICountOptionCollection : IEnum
 	System.Nullable`1[[System.Int64]] TotalCount  { public abstract get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter : IEndpointFilter {
+	System.Threading.Tasks.ValueTask`1[[System.Object]] OnFilterExecutedAsync (object responseValue, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+	System.Threading.Tasks.ValueTask OnFilterExecutingAsync (Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+}
+
 public interface Microsoft.AspNetCore.OData.Query.IODataQueryRequestParser {
 	bool CanParse (Microsoft.AspNetCore.Http.HttpRequest request)
 	System.Threading.Tasks.Task`1[[System.String]] ParseAsync (Microsoft.AspNetCore.Http.HttpRequest request)
@@ -1387,6 +1523,36 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryContext {
 	System.IServiceProvider RequestContainer  { public get; }
 }
 
+public class Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter : IEndpointFilter, IODataQueryEndpointFilter {
+	public ODataQueryEndpointFilter ()
+
+	Microsoft.AspNetCore.OData.Query.ODataQuerySettings QuerySettings  { public get; }
+	Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings ValidationSettings  { public get; }
+
+	public virtual System.Linq.IQueryable ApplyQuery (System.Linq.IQueryable queryable, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
+	public virtual object ApplyQuery (object entity, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
+	protected virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions CreateAndValidateQueryOptions (Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.OData.Query.ODataQueryContext queryContext)
+	protected virtual Microsoft.AspNetCore.OData.Query.ODataQueryOptions CreateQueryOptionsOnExecuting (Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+	protected virtual object ExecuteQuery (object responseValue, System.Linq.IQueryable singleResultCollection, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+	protected virtual Microsoft.OData.Edm.IEdmModel GetModel (System.Type elementClrType, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public virtual System.Threading.Tasks.ValueTask`1[[System.Object]] InvokeAsync (Microsoft.AspNetCore.Http.EndpointFilterInvocationContext invocationContext, Microsoft.AspNetCore.Http.EndpointFilterDelegate next)
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public virtual System.Threading.Tasks.ValueTask`1[[System.Object]] OnFilterExecutedAsync (object responseValue, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public virtual System.Threading.Tasks.ValueTask OnFilterExecutingAsync (Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context)
+
+	protected virtual void ValidateQuery (Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.OData.Query.ODataQueryOptions queryOptions)
+}
+
 [
 NonValidatingParameterBindingAttribute(),
 ODataQueryParameterBindingAttribute(),
@@ -1430,7 +1596,7 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions {
 [
 ODataQueryParameterBindingAttribute(),
 ]
-public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.AspNetCore.OData.Query.ODataQueryOptions {
+public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.AspNetCore.OData.Query.ODataQueryOptions, IEndpointParameterMetadataProvider {
 	public ODataQueryOptions`1 (Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.AspNetCore.Http.HttpRequest request)
 
 	ETag`1 IfMatch  { public get; }
@@ -1438,7 +1604,13 @@ public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.As
 
 	public virtual System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query)
 	public virtual System.Linq.IQueryable ApplyTo (System.Linq.IQueryable query, Microsoft.AspNetCore.OData.Query.ODataQuerySettings querySettings)
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static ValueTask`1 BindAsync (Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter)
+
 	internal virtual Microsoft.AspNetCore.OData.Query.ETag GetETag (Microsoft.Net.Http.Headers.EntityTagHeaderValue etagHeaderValue)
+	public static void PopulateMetadata (System.Reflection.ParameterInfo parameter, Microsoft.AspNetCore.Builder.EndpointBuilder builder)
 }
 
 public class Microsoft.AspNetCore.OData.Query.ODataQueryRequestMiddleware {
@@ -1621,6 +1793,11 @@ public interface Microsoft.AspNetCore.OData.Results.IODataErrorResult {
 	Microsoft.OData.ODataError Error  { public abstract get; }
 }
 
+public interface Microsoft.AspNetCore.OData.Results.IODataResult {
+	System.Type ExpectedType  { public abstract get; }
+	object Value  { public abstract get; }
+}
+
 [
 DataContractAttribute(),
 ]
@@ -1709,6 +1886,7 @@ public class Microsoft.AspNetCore.OData.Results.ODataErrorResult : Microsoft.Asp
 
 [
 DataContractAttribute(),
+JsonConverterAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Results.PageResult`1 : Microsoft.AspNetCore.OData.Results.PageResult, IEnumerable`1, IEnumerable {
 	public PageResult`1 (IEnumerable`1 items, System.Uri nextPageLink, System.Nullable`1[[System.Int64]] count)
@@ -1758,6 +1936,9 @@ public class Microsoft.AspNetCore.OData.Results.UpdatedODataResult`1 : Microsoft
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 
+[
+JsonConverterAttribute(),
+]
 public sealed class Microsoft.AspNetCore.OData.Results.SingleResult`1 : Microsoft.AspNetCore.OData.Results.SingleResult {
 	public SingleResult`1 (IQueryable`1 queryable)
 
@@ -3274,6 +3455,15 @@ public abstract class Microsoft.AspNetCore.OData.Query.Wrapper.DynamicTypeWrappe
 	System.Collections.Generic.Dictionary`2[[System.String],[System.Object]] Values  { public abstract get; }
 
 	public virtual bool TryGetPropertyValue (string propertyName, out System.Object& value)
+}
+
+public class Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter : System.Text.Json.Serialization.JsonConverterFactory {
+	public static readonly System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]] MapperProvider = System.Func`3[Microsoft.OData.Edm.IEdmModel,Microsoft.OData.Edm.IEdmStructuredType,Microsoft.AspNetCore.OData.Query.Container.IPropertyMapper]
+
+	public SelectExpandWrapperConverter ()
+
+	public virtual bool CanConvert (System.Type typeToConvert)
+	public virtual System.Text.Json.Serialization.JsonConverter CreateConverter (System.Type type, System.Text.Json.JsonSerializerOptions options)
 }
 
 [


### PR DESCRIPTION
Enable minimal API OData.

Fixes #578

Minimal APIs are a simplified approach for building fast HTTP APIs with ASP.NET Core. You can build fully functioning REST endpoints with minimal code and configuration. Skip traditional scaffolding and avoid unnecessary controllers by fluently declaring API routes and actions. For example, the following code creates an API at the root of the web app that returns the text, "Hello World!".

```C#
var app = WebApplication.Create(args);
app.MapGet("/", () => "Hello World!");
app.Run();
```

Customer want to get the OData query options functionalities.  We can provide couple solutions

1) Get OData JSON payload for minimal API

2) Enable customer to apply OData query to IQueryable explicitly.

3) Enable customers to apply OData query to IQueryable implicitly.


