### PR TITLE
Fixes #1483: Regression with computed in $orderby with 'Could not find a property named xxx on ....'

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -697,7 +697,7 @@ public class ODataQueryOptions
         if (applySortOptions != null)
         {
             orderByRaw = String.Join(",", applySortOptions);
-            return new OrderByQueryOption(orderByRaw, context, Apply.RawValue);
+            return new OrderByQueryOption(orderByRaw, context, Apply.RawValue, Compute?.RawValue);
         }
         else
         {
@@ -749,7 +749,7 @@ public class ODataQueryOptions
             if (propertyPathsToAdd.Any())
             {
                 var orderByRaw = orderBy.RawValue + "," + String.Join(",", propertyPathsToAdd);
-                orderBy = new OrderByQueryOption(orderByRaw, context, Apply.RawValue);
+                orderBy = new OrderByQueryOption(orderByRaw, context, Apply.RawValue, Compute?.RawValue);
             }
         }
         else
@@ -762,7 +762,7 @@ public class ODataQueryOptions
                 // the sort stable but preserving the user's original intent for the major
                 // sort order.
                 var orderByRaw = orderBy.RawValue + "," + string.Join(",", propertiesToAdd.Select(p => p.Name));
-                orderBy = new OrderByQueryOption(orderByRaw, context);
+                orderBy = new OrderByQueryOption(orderByRaw, context, null, Compute?.RawValue);
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
@@ -56,7 +56,7 @@ public class OrderByQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
-    internal OrderByQueryOption(string rawValue, ODataQueryContext context, string applyRaw)
+    internal OrderByQueryOption(string rawValue, ODataQueryContext context, string applyRaw, string computeRaw)
     {
         if (context == null)
         {
@@ -68,19 +68,27 @@ public class OrderByQueryOption
             throw Error.ArgumentNullOrEmpty("rawValue");
         }
 
-        if (applyRaw == null)
-        {
-            throw Error.ArgumentNullOrEmpty("applyRaw");
-        }
-
         Context = context;
         RawValue = rawValue;
         Validator = context.GetOrderByQueryValidator();
+
+        Dictionary<string, string> queryOptions = new Dictionary<string, string>();
+        queryOptions["$orderby"] = rawValue;
+        if (applyRaw != null)
+        {
+            queryOptions["$apply"] = applyRaw;
+        }
+
+        if (computeRaw != null)
+        {
+            queryOptions["$compute"] = computeRaw;
+        }
+
         _queryOptionParser = new ODataQueryOptionParser(
             context.Model,
             context.ElementType,
             context.NavigationSource,
-            new Dictionary<string, string> { { "$orderby", rawValue }, { "$apply", applyRaw } },
+            queryOptions,
             context.RequestContainer);
 
         if (context.RequestContainer == null)
@@ -89,7 +97,15 @@ public class OrderByQueryOption
             _queryOptionParser.Resolver = ODataQueryContext.DefaultCaseInsensitiveResolver;
         }
 
-        _queryOptionParser.ParseApply();
+        if (computeRaw != null)
+        {
+            _queryOptionParser.ParseCompute();
+        }
+
+        if (applyRaw != null)
+        {
+            _queryOptionParser.ParseApply();
+        }
     }
 
     // This constructor is intended for unit testing only.

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeController.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -49,5 +50,17 @@ public class CustomersController : ODataController
     public IActionResult GetSales()
     {
         return Ok();
+    }
+
+    [HttpGet("odata/Shoppers")]
+    public IQueryable Get(ODataQueryOptions<ComputeShopper> queryOptions)
+    {
+        var queryable = DollarComputeDataSource.Shoppers.AsQueryable();
+
+        return queryOptions.ApplyTo(queryable, new ODataQuerySettings
+        {
+            PageSize = 3,
+            TimeZone = TimeZoneInfo.Utc
+        });
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataModel.cs
@@ -49,3 +49,12 @@ public class ComputeSale
 
     public IDictionary<string, object> Dynamics { get; set; } = new Dictionary<string, object>();
 }
+
+public class ComputeShopper
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public int Age { get; set; }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataSource.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeDataSource.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.DollarCompute;
 public class DollarComputeDataSource
 {
     private static IList<ComputeCustomer> _customers;
+    private static IList<ComputeShopper> _shoppers;
 
     static DollarComputeDataSource()
     {
@@ -20,6 +21,8 @@ public class DollarComputeDataSource
     }
 
     public static IList<ComputeCustomer> Customers => _customers;
+
+    public static IList<ComputeShopper> Shoppers => _shoppers;
 
     private static void GenerateCustomers()
     {
@@ -43,6 +46,12 @@ public class DollarComputeDataSource
 
             _customers[i - 1].Sales = Enumerable.Range(0, i + 3)
                 .Select(idx => new ComputeSale { Id = 100 * i + idx, Amount = idx + i, Price = (3.1 + idx) * i, TaxRate = (0.1 + idx + i) / 10.0 }).ToList();
+        }
+
+        _shoppers = new List<ComputeShopper>(_customers.Count);
+        foreach (var c in _customers)
+        {
+            _shoppers.Add(new ComputeShopper { Id = c.Id, Name = c.Name, Age = c.Age });
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeEdmModel.cs
@@ -17,6 +17,8 @@ public class DollarComputeEdmModel
         var builder = new ODataConventionModelBuilder();
         builder.EntitySet<ComputeCustomer>("Customers");
         builder.EntitySet<ComputeSale>("Sales");
+
+        builder.EntitySet<ComputeShopper>("Shoppers");
         IEdmModel model = builder.GetEdmModel();
         return model;
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarCompute/DollarComputeTests.cs
@@ -365,4 +365,57 @@ public class DollarComputeTests : WebApiTestBase<DollarComputeTests>
             "Query option 'Compute' is not allowed. To allow it, set the 'AllowedQueryOptions' property on EnableQueryAttribute or QueryValidationSettings", payload);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
+
+    [Fact]
+    public async Task QueryShoppers_UsingQueryOptionsWithQuerySettings_IncludesDollarCompute_WorksWithDollarSelect()
+    {
+        // Arrange
+        string queryUrl = "odata/shoppers?$compute=age add 10 as agePlusTen&$select=id,name,agePlusTen";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        HttpClient client = CreateClient();
+        HttpResponseMessage response;
+
+        // Act
+        response = await client.SendAsync(request);
+
+        // Assert
+        string payload = await response.Content.ReadAsStringAsync();
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        // It returns 3 entities because there's a `pagesize=3` setting in the controller/action
+        Assert.Equal("[{\"Id\":1,\"Name\":\"Peter\",\"agePlusTen\":29}," +
+            "{\"Id\":2,\"Name\":\"Sam\",\"agePlusTen\":50}," +
+            "{\"Id\":3,\"Name\":\"John\",\"agePlusTen\":44}]", payload);
+    }
+
+    [Fact]
+    public async Task QueryShoppers_UsingQueryOptionsWithQuerySettings_IncludesDollarCompute_WorksWithDollorOrderby()
+    {
+        // Arrange
+        string queryUrl = "odata/shoppers?$compute=age add 10 as agePlusTen&$orderby=agePlusTen desc&$select=id,name,agePlusTen&$filter=agePlusTen ge 21";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+        HttpClient client = CreateClient();
+        HttpResponseMessage response;
+
+        // Act
+        response = await client.SendAsync(request);
+
+        // Assert
+        string payload = await response.Content.ReadAsStringAsync();
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        // It returns 3 entities because there's a `pagesize=3` setting in the controller/action
+        // But the payload returns the ordered list.
+        Assert.Equal("[" +
+            "{\"Id\":2,\"Name\":\"Sam\",\"agePlusTen\":50}," +
+            "{\"Id\":3,\"Name\":\"John\",\"agePlusTen\":44}," +
+            "{\"Id\":4,\"Name\":\"Kerry\",\"agePlusTen\":39}]",
+            payload);
+    }
 }

--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">9</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">3</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">1</VersionBuild>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">2</VersionBuild>
     <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
   </PropertyGroup>
   


### PR DESCRIPTION
Fixes #1483.

Let's focus on the 9.3.x version. Since it's regression, let's release it as 9.3.2.

After that, I will port it to the main branch.