### PR TITLE
Fixes #1487 : Minimal API TimeZoneInfo for Serialization

### DIFF
--- a/sample/ODataMiniApi/AppModels.cs
+++ b/sample/ODataMiniApi/AppModels.cs
@@ -23,6 +23,14 @@ public class EdmModelBuilder
         builder.EntitySet<Customer>("Customers");
         builder.EntitySet<Order>("Orders");
         builder.ComplexType<Info>();
+
+        var action = builder.EntityType<Customer>().Action("RateByName");
+        action.Parameter<string>("name");
+        action.Parameter<int>("age");
+        action.Returns<string>();
+
+        builder.EntityType<Customer>().Collection.Action("Rating").Parameter<int>("p");
+
         return builder.GetEdmModel();
     }
 }

--- a/sample/ODataMiniApi/CustomersAndOrders.http
+++ b/sample/ODataMiniApi/CustomersAndOrders.http
@@ -62,3 +62,31 @@ Content-Type: application/json
 { 
   "name": "kerry"
 } 
+
+###
+
+POST {{ODataMiniApi_HostAddress}}/v1/customers/1/rateByName
+Content-Type: application/json 
+
+{ 
+  "name": "kerry",
+  "age":16
+}
+
+###
+
+# You will get the following response:
+#
+#{
+#  "@odata.context": "http://localhost:5177/$metadata#Edm.String",
+#  "value": "EdmActionName: 'Rating': rate based on '8'"
+#}
+
+POST {{ODataMiniApi_HostAddress}}/v1/customers/rating
+Content-Type: application/json 
+
+{ 
+  "p": 8
+}
+
+###

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
@@ -223,7 +223,7 @@ public static class HttpContextExtensions
         ODataMiniMetadata metadata = endpoint.Metadata.GetMetadata<ODataMiniMetadata>();
         if (metadata is null || metadata.Model is null || metadata.PathFactory is null)
         {
-            throw new ODataException($"Please call WithODataModel() and WithODataPathFactory() for the endpoint");
+            throw new ODataException(SRResources.ODataMustBeSetOnMinimalAPIEndpoint);
         }
 
         Type parameterType = parameter.ParameterType;
@@ -258,7 +258,7 @@ public static class HttpContextExtensions
         }
         catch (Exception ex)
         {
-            throw new ODataException($"Cannot bind parameter '{parameter.Name}'. the error is: {ex.Message}");
+            throw new ODataException(Error.Format(SRResources.BindParameterFailedOnMinimalAPIEndpoint, parameter.Name, ex.Message));
         }
 
         return result as T;

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Formatter.Deserialization;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
@@ -98,6 +99,19 @@ public static class HttpRequestExtensions
             throw Error.ArgumentNull(nameof(request));
         }
 
+        bool isMinimalApi = request.HttpContext.IsMinimalEndpoint();
+        if (isMinimalApi)
+        {
+            // In minimal API, we don't have ODataOptions, so we check the ODataMiniOptions directly.
+            ODataMiniOptions miniOptions = request.HttpContext.RequestServices?.GetService<IOptions<ODataMiniOptions>>()?.Value;
+            if (miniOptions is not null)
+            {
+                return miniOptions.TimeZone;
+            }
+
+            return null;
+        }
+
         return request.ODataOptions()?.TimeZone;
     }
 
@@ -111,6 +125,19 @@ public static class HttpRequestExtensions
         if (request == null)
         {
             throw Error.ArgumentNull(nameof(request));
+        }
+
+        bool isMinimalApi = request.HttpContext.IsMinimalEndpoint();
+        if (isMinimalApi)
+        {
+            // In minimal API, we don't have ODataOptions, so we check the ODataMiniOptions directly.
+            ODataMiniOptions miniOptions = request.HttpContext.RequestServices?.GetService<IOptions<ODataMiniOptions>>()?.Value;
+            if (miniOptions is not null)
+            {
+                return miniOptions.EnableNoDollarQueryOptions;
+            }
+
+            return false;
         }
 
         return request.ODataOptions()?.EnableNoDollarQueryOptions ?? false;

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataActionParameters.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataActionParameters.cs
@@ -7,7 +7,12 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Extensions;
 
 namespace Microsoft.AspNetCore.OData.Formatter;
 
@@ -19,4 +24,14 @@ namespace Microsoft.AspNetCore.OData.Formatter;
 [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "ODataActionParameters is more appropriate here.")]
 public class ODataActionParameters : Dictionary<string, object>
 {
+    /// <summary>
+    /// Binds the <see cref="HttpContext"/> and <see cref="ParameterInfo"/> to generate the <see cref="Delta{T}"/>.
+    /// </summary>
+    /// <param name="context">The HttpContext.</param>
+    /// <param name="parameter">The parameter info.</param>
+    /// <returns>The built <see cref="ODataActionParameters"/></returns>
+    public static async ValueTask<ODataActionParameters> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+         return await context.BindODataParameterAsync<ODataActionParameters>(parameter);
+    }
 }

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataUntypedActionParameters.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataUntypedActionParameters.cs
@@ -10,6 +10,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using Microsoft.OData.Edm;
 using Microsoft.AspNetCore.OData.Abstracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Deltas;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Extensions;
 
 namespace Microsoft.AspNetCore.OData.Formatter;
 
@@ -34,4 +39,15 @@ public class ODataUntypedActionParameters : Dictionary<string, object>
     /// Gets the OData action of this parameters.
     /// </summary>
     public IEdmAction Action { get; }
+
+    /// <summary>
+    /// Binds the <see cref="HttpContext"/> and <see cref="ParameterInfo"/> to generate the <see cref="Delta{T}"/>.
+    /// </summary>
+    /// <param name="context">The HttpContext.</param>
+    /// <param name="parameter">The parameter info.</param>
+    /// <returns>The built <see cref="ODataUntypedActionParameters"/></returns>
+    public static async ValueTask<ODataUntypedActionParameters> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        return await context.BindODataParameterAsync<ODataUntypedActionParameters>(parameter);
+    }
 }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -4092,6 +4092,14 @@
             to invoke a particular Action. The Parameter values are stored in the dictionary keyed using the Parameter name.
             </summary>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.ODataActionParameters.BindAsync(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)">
+            <summary>
+            Binds the <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> and <see cref="T:System.Reflection.ParameterInfo"/> to generate the <see cref="T:Microsoft.AspNetCore.OData.Deltas.Delta`1"/>.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="parameter">The parameter info.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Formatter.ODataActionParameters"/></returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.ODataBodyModelBinder">
             <summary>
             A model binder for ODataParameterValue values.
@@ -4333,6 +4341,14 @@
             <summary>
             Gets the OData action of this parameters.
             </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters.BindAsync(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)">
+            <summary>
+            Binds the <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> and <see cref="T:System.Reflection.ParameterInfo"/> to generate the <see cref="T:Microsoft.AspNetCore.OData.Deltas.Delta`1"/>.
+            </summary>
+            <param name="context">The HttpContext.</param>
+            <param name="parameter">The parameter info.</param>
+            <returns>The built <see cref="T:Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters"/></returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Formatter.ResourceContext">
             <summary>
@@ -6751,6 +6767,7 @@
         <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.Version">
             <summary>
             Gets the OData version.
+            Please call 'SetVersion()' to config.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableNoDollarQueryOptions">
@@ -6765,6 +6782,12 @@
             Please call 'SetCaseInsensitive()' to config.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.TimeZone">
+            <summary>
+            Gets TimeZoneInfo for the <see cref="T:System.DateTime"/> serialization and deserialization.
+            Please call 'SetTimeZoneInfo()' to config.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(System.Boolean)">
             <summary>
             Config whether or not no '$' sign query option.
@@ -6777,6 +6800,13 @@
             Config the case insensitive.
             </summary>
             <param name="enableCaseInsensitive">Case insensitive or not.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetTimeZoneInfo(System.TimeZoneInfo)">
+            <summary>
+            Config the time zone information.
+            </summary>
+            <param name="tzi">Case insensitive or not.</param>
             <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetVersion(Microsoft.OData.ODataVersion)">

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -7346,6 +7346,11 @@
               Looks up a localized string similar to A binary operator with incompatible types was detected. Found operand types &apos;{0}&apos; and &apos;{1}&apos; for operator kind &apos;{2}&apos;..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.BindParameterFailedOnMinimalAPIEndpoint">
+            <summary>
+              Looks up a localized string similar to Cannot bind parameter &apos;{0}&apos;. the error is: {1}..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.CannotAddToNullCollection">
             <summary>
               Looks up a localized string similar to The property &apos;{0}&apos; on type &apos;{1}&apos; returned a null value. The input stream contains collection items which cannot be added if the instance is null..
@@ -7919,6 +7924,11 @@
         <member name="P:Microsoft.AspNetCore.OData.SRResources.ODataFunctionNotSupported">
             <summary>
               Looks up a localized string similar to Unknown function &apos;{0}&apos;..
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.ODataMustBeSetOnMinimalAPIEndpoint">
+            <summary>
+              Looks up a localized string similar to The OData configuration is missing for the minimal API. Please call WithODataModel() and WithODataPathFactory() for the endpoint..
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.ODataPathMissing">

--- a/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.OData;
@@ -19,6 +20,7 @@ public class ODataMiniOptions
     private DefaultQueryConfigurations _queryConfigurations = new DefaultQueryConfigurations();
     private bool _enableNoDollarQueryOptions = true;
     private bool _enableCaseInsensitive = true;
+    private TimeZoneInfo _timeZone = TimeZoneInfo.Local;
     private ODataVersion _version = ODataVersionConstraint.DefaultODataVersion;
 
     /// <summary>
@@ -28,6 +30,7 @@ public class ODataMiniOptions
 
     /// <summary>
     /// Gets the OData version.
+    /// Please call 'SetVersion()' to config.
     /// </summary>
     public ODataVersion Version { get => _version; }
 
@@ -42,6 +45,12 @@ public class ODataMiniOptions
     /// Please call 'SetCaseInsensitive()' to config.
     /// </summary>
     public bool EnableCaseInsensitive { get => _enableCaseInsensitive; }
+
+    /// <summary>
+    /// Gets TimeZoneInfo for the <see cref="DateTime"/> serialization and deserialization.
+    /// Please call 'SetTimeZoneInfo()' to config.
+    /// </summary>
+    public TimeZoneInfo TimeZone { get => _timeZone; }
 
     /// <summary>
     /// Config whether or not no '$' sign query option.
@@ -62,6 +71,17 @@ public class ODataMiniOptions
     public ODataMiniOptions SetCaseInsensitive(bool enableCaseInsensitive)
     {
         _enableCaseInsensitive = enableCaseInsensitive;
+        return this;
+    }
+
+    /// <summary>
+    /// Config the time zone information.
+    /// </summary>
+    /// <param name="tzi">Case insensitive or not.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetTimeZoneInfo(TimeZoneInfo tzi)
+    {
+        _timeZone = tzi;
         return this;
     }
 
@@ -175,5 +195,6 @@ public class ODataMiniOptions
         this._version = otherOptions.Version;
         this._enableNoDollarQueryOptions = otherOptions.EnableNoDollarQueryOptions;
         this._enableCaseInsensitive = otherOptions.EnableCaseInsensitive;
+        this._timeZone = otherOptions.TimeZone;
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -259,6 +259,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot bind parameter &apos;{0}&apos;. the error is: {1}..
+        /// </summary>
+        internal static string BindParameterFailedOnMinimalAPIEndpoint {
+            get {
+                return ResourceManager.GetString("BindParameterFailedOnMinimalAPIEndpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The property &apos;{0}&apos; on type &apos;{1}&apos; returned a null value. The input stream contains collection items which cannot be added if the instance is null..
         /// </summary>
         internal static string CannotAddToNullCollection {
@@ -1294,6 +1303,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The OData configuration is missing for the minimal API. Please call WithODataModel() and WithODataPathFactory() for the endpoint..
+        /// </summary>
+        internal static string ODataMustBeSetOnMinimalAPIEndpoint {
+            get {
+                return ResourceManager.GetString("ODataMustBeSetOnMinimalAPIEndpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The operation cannot be completed because no ODataPath is available for the request..
         /// </summary>
         internal static string ODataPathMissing {
@@ -1841,7 +1859,7 @@ namespace Microsoft.AspNetCore.OData {
                 return ResourceManager.GetString("TypeMustBeRelated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a resource set type. Only resource set are supported..
         /// </summary>
@@ -1850,7 +1868,7 @@ namespace Microsoft.AspNetCore.OData {
                 return ResourceManager.GetString("TypeMustBeResourceSet", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; does not implement &apos;{1}&apos; interface..
         /// </summary>
@@ -1859,7 +1877,7 @@ namespace Microsoft.AspNetCore.OData {
                 return ResourceManager.GetString("TypeMustImplementInterface", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; does not inherit from &apos;{1}&apos;..
         /// </summary>
@@ -1868,7 +1886,7 @@ namespace Microsoft.AspNetCore.OData {
                 return ResourceManager.GetString("TypeMustInheritFromType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The type &apos;{0}&apos; of dynamic property &apos;{1}&apos; is not supported..
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -763,4 +763,10 @@
   <data name="PropertyMustBeSet" xml:space="preserve">
     <value>The '{0}' property must be set.</value>
   </data>
+  <data name="ODataMustBeSetOnMinimalAPIEndpoint" xml:space="preserve">
+    <value>The OData configuration is missing for the minimal API. Please call WithODataModel() and WithODataPathFactory() for the endpoint.</value>
+  </data>
+  <data name="BindParameterFailedOnMinimalAPIEndpoint" xml:space="preserve">
+    <value>Cannot bind parameter '{0}'. the error is: {1}.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -39,8 +39,10 @@ Microsoft.AspNetCore.OData.ODataMiniOptions.Select() -> Microsoft.AspNetCore.ODa
 Microsoft.AspNetCore.OData.ODataMiniOptions.SetCaseInsensitive(bool enableCaseInsensitive) -> Microsoft.AspNetCore.OData.ODataMiniOptions
 Microsoft.AspNetCore.OData.ODataMiniOptions.SetMaxTop(int? maxTopValue) -> Microsoft.AspNetCore.OData.ODataMiniOptions
 Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(bool enableNoDollarQueryOptions) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetTimeZoneInfo(System.TimeZoneInfo tzi) -> Microsoft.AspNetCore.OData.ODataMiniOptions
 Microsoft.AspNetCore.OData.ODataMiniOptions.SetVersion(Microsoft.OData.ODataVersion version) -> Microsoft.AspNetCore.OData.ODataMiniOptions
 Microsoft.AspNetCore.OData.ODataMiniOptions.SkipToken() -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.TimeZone.get -> System.TimeZoneInfo
 Microsoft.AspNetCore.OData.ODataMiniOptions.Version.get -> Microsoft.OData.ODataVersion
 Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter
 Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter.OnFilterExecutedAsync(object responseValue, Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext context) -> System.Threading.Tasks.ValueTask<object>
@@ -56,6 +58,9 @@ Microsoft.AspNetCore.OData.Results.IODataResult.ExpectedType.get -> System.Type
 Microsoft.AspNetCore.OData.Results.IODataResult.Value.get -> object
 override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CanConvert(System.Type typeToConvert) -> bool
 override Microsoft.AspNetCore.OData.Query.Wrapper.SelectExpandWrapperConverter.CreateConverter(System.Type type, System.Text.Json.JsonSerializerOptions options) -> System.Text.Json.Serialization.JsonConverter
+static Microsoft.AspNetCore.OData.Deltas.Delta<T>.BindAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.OData.Deltas.Delta<T>>
+static Microsoft.AspNetCore.OData.Formatter.ODataActionParameters.BindAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.OData.Formatter.ODataActionParameters>
+static Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters.BindAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters>
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Builder.RouteHandlerBuilder builder, System.Action<Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings> validationSetup = null, System.Action<Microsoft.AspNetCore.OData.Query.ODataQuerySettings> querySetup = null) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder
 static Microsoft.AspNetCore.OData.ODataEndpointConventionBuilderExtensions.AddODataQueryEndpointFilter(this Microsoft.AspNetCore.Routing.RouteGroupBuilder builder, Microsoft.AspNetCore.OData.Query.IODataQueryEndpointFilter queryFilter) -> Microsoft.AspNetCore.Routing.RouteGroupBuilder

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryContext.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 
@@ -220,22 +219,6 @@ public class ODataQueryContext
 
         IOptions<ODataOptions> odataOptions = Request.HttpContext?.RequestServices?.GetService<IOptions<ODataOptions>>();
         if (odataOptions is null || odataOptions.Value is null)
-        {
-            return new DefaultQueryConfigurations();
-        }
-
-        return odataOptions.Value.QueryConfigurations;
-    }
-
-    private DefaultQueryConfigurations GetDefaultQuerySettings()
-    {
-        if (Request is null)
-        {
-            return new DefaultQueryConfigurations();
-        }
-
-        IOptions<ODataOptions> odataOptions = Request.HttpContext?.RequestServices?.GetService<IOptions<ODataOptions>>();
-        if (odataOptions is  null || odataOptions.Value is null)
         {
             return new DefaultQueryConfigurations();
         }

--- a/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
@@ -5,6 +5,13 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.AspNetCore.OData.Tests.Commons;
+using Microsoft.AspNetCore.OData.Tests.Models;
+using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -12,11 +19,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using Microsoft.AspNetCore.OData.Deltas;
-using Microsoft.AspNetCore.OData.TestCommon;
-using Microsoft.AspNetCore.OData.Tests.Commons;
-using Microsoft.AspNetCore.OData.Tests.Models;
-using Microsoft.OData.Edm;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Deltas;
@@ -58,6 +61,19 @@ public class DeltaTest
                 new object[] { "CollectionProperty", new Collection<int> { 1, 2, 3 }}
             });
         }
+    }
+
+    [Fact]
+    public async ValueTask BindAsync_ThrowsArgumentNull_ForInputs()
+    {
+        // Arrange & Act & Assert
+        ArgumentNullException exception = await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await Delta<Base>.BindAsync(null, null), "httpContext", false, true);
+        Assert.Equal("The parameter cannot be null. (Parameter 'httpContext')", exception.Message);
+
+        // Arrange & Act & Assert
+        HttpContext httpContext = new DefaultHttpContext();
+        await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await Delta<Base>.BindAsync(httpContext, null));
+        Assert.Equal("The parameter cannot be null. (Parameter 'parameter')", exception.Message);
     }
 
     [Fact]

--- a/test/Microsoft.AspNetCore.OData.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using Xunit;
@@ -29,4 +31,84 @@ public class HttpContextExtensionsTests
         HttpContext httpContext = null;
         ExceptionAssert.ThrowsArgumentNull(() => httpContext.ODataBatchFeature(), "httpContext");
     }
+
+    [Fact]
+    public void ODataOptions_ThrowsArgumentNull_HttpContext()
+    {
+        // Arrange & Act & Assert
+        HttpContext httpContext = null;
+        ExceptionAssert.ThrowsArgumentNull(() => httpContext.ODataOptions(), "httpContext");
+    }
+
+    [Fact]
+    public void ODataFeature_ReturnsODataFeature()
+    {
+        // Arrange
+        HttpContext httpContext = new DefaultHttpContext();
+        IODataFeature odataFeature = new ODataFeature();
+        httpContext.Features.Set(odataFeature);
+
+        // Act
+        IODataFeature result = httpContext.ODataFeature();
+
+        // Assert
+        Assert.Same(odataFeature, result);
+    }
+
+    [Fact]
+    public void IsMinimalEndpoint_ThrowsArgumentNull_HttpContext()
+    {
+        // Arrange & Act & Assert
+        HttpContext httpContext = null;
+        ExceptionAssert.ThrowsArgumentNull(() => httpContext.IsMinimalEndpoint(), "httpContext");
+    }
+
+    [Fact]
+    public void IsMinimalEndpoint_ReturnsFalse_WhenEndpointIsNull()
+    {
+        // Arrange
+        HttpContext httpContext = new DefaultHttpContext();
+        httpContext.SetEndpoint(null);
+
+        // Act
+        bool result = httpContext.IsMinimalEndpoint();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsMinimalEndpoint_ReturnsFalse_WhenEndpointIsNotNull_WithoutMetadata()
+    {
+        // Arrange
+        HttpContext httpContext = new DefaultHttpContext();
+        Endpoint endpoint = new Endpoint((context) => Task.CompletedTask, EndpointMetadataCollection.Empty, "TestEndpoint");
+        httpContext.SetEndpoint(endpoint);
+
+        // Act
+        bool result = httpContext.IsMinimalEndpoint();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsMinimalEndpoint_ReturnsTrue_WhenEndpointHasMetadata()
+    {
+        // Arrange
+        HttpContext httpContext = new DefaultHttpContext();
+        Endpoint endpoint = new Endpoint(
+            (context) => Task.CompletedTask,
+            new EndpointMetadataCollection([new ODataMiniMetadata()]),
+            "TestEndpoint");
+
+        httpContext.SetEndpoint(endpoint);
+
+        // Act
+        bool result = httpContext.IsMinimalEndpoint();
+
+        // Assert
+        Assert.True(result);
+    }
+
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataActionParametersTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Formatter/ODataActionParametersTests.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// <copyright file="ODataUntypedActionParametersTests.cs" company=".NET Foundation">
+// <copyright file="ODataActionParametersTests.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
@@ -22,38 +22,31 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Formatter;
 
-public class ODataUntypedActionParametersTests
+public class ODataActionParametersTests
 {
-    [Fact]
-    public void Ctor_ThrowsArgumentNull_Action()
-    {
-        // Arrange & Act & Assert
-        ExceptionAssert.ThrowsArgumentNull(() => new ODataUntypedActionParameters(null), "action");
-    }
-
     [Fact]
     public async ValueTask BindAsync_ThrowsArgumentNull_ForInputs()
     {
         // Arrange & Act & Assert
-        ArgumentNullException exception = await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await ODataUntypedActionParameters.BindAsync(null, null), "httpContext", false, true);
+        ArgumentNullException exception = await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await ODataActionParameters.BindAsync(null, null), "httpContext", false, true);
         Assert.Equal("The parameter cannot be null. (Parameter 'httpContext')", exception.Message);
 
         // Arrange & Act & Assert
         HttpContext httpContext = new DefaultHttpContext();
-        await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await ODataUntypedActionParameters.BindAsync(httpContext, null));
+        await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => await ODataActionParameters.BindAsync(httpContext, null));
         Assert.Equal("The parameter cannot be null. (Parameter 'parameter')", exception.Message);
     }
 
     [Fact]
-    public async ValueTask BindAsync_Returns_ValidODataUntypedActionParameter()
+    public async ValueTask BindAsync_Returns_ValidODataActionParameter()
     {
         // Arrange
         Mock<IODataDeserializerProvider> deserializerProviderMock = new Mock<IODataDeserializerProvider>();
         Mock<ODataActionPayloadDeserializer> mock = new Mock<ODataActionPayloadDeserializer>(deserializerProviderMock.Object);
 
-        ODataUntypedActionParameters expectedParameters = new ODataUntypedActionParameters(new Mock<IEdmAction>().Object);
+        ODataActionParameters expectedParameters = new ODataActionParameters();
 
-        mock.Setup(m => m.ReadAsync(It.IsAny<ODataMessageReader>(), typeof(ODataUntypedActionParameters), It.IsAny<ODataDeserializerContext>()))
+        mock.Setup(m => m.ReadAsync(It.IsAny<ODataMessageReader>(), typeof(ODataActionParameters), It.IsAny<ODataDeserializerContext>()))
             .ReturnsAsync(expectedParameters);
 
         HttpContext httpContext = new DefaultHttpContext();
@@ -72,12 +65,12 @@ public class ODataUntypedActionParametersTests
         httpContext.SetEndpoint(endpoint);
         ParameterInfo parameter = typeof(ODataActionParametersTests).GetMethod("TestMethod", BindingFlags.NonPublic | BindingFlags.Static).GetParameters().First();
 
-        ODataUntypedActionParameters actualParameter = await ODataUntypedActionParameters.BindAsync(httpContext, parameter);
+        ODataActionParameters actualParameter = await ODataActionParameters.BindAsync(httpContext, parameter);
 
         // Act & Assert
         Assert.Same(expectedParameters, actualParameter);
     }
 
     // This empty method is used to provide a parameter for the BindAsync test.
-    private static void TestMethod(ODataUntypedActionParameters parameters) { }
+    private static void TestMethod(ODataActionParameters parameters) { }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -198,6 +198,7 @@ public class Microsoft.AspNetCore.OData.ODataMiniOptions {
 	bool EnableCaseInsensitive  { public get; }
 	bool EnableNoDollarQueryOptions  { public get; }
 	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
+	System.TimeZoneInfo TimeZone  { public get; }
 	Microsoft.OData.ODataVersion Version  { public get; }
 
 	public Microsoft.AspNetCore.OData.ODataMiniOptions Count ()
@@ -209,6 +210,7 @@ public class Microsoft.AspNetCore.OData.ODataMiniOptions {
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetCaseInsensitive (bool enableCaseInsensitive)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetMaxTop (System.Nullable`1[[System.Int32]] maxTopValue)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetNoDollarQueryOptions (bool enableNoDollarQueryOptions)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetTimeZoneInfo (System.TimeZoneInfo tzi)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetVersion (Microsoft.OData.ODataVersion version)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SkipToken ()
 }
@@ -1157,6 +1159,11 @@ NonValidatingParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Formatter.ODataActionParameters : System.Collections.Generic.Dictionary`2[[System.String],[System.Object]], ICollection, IDictionary, IEnumerable, IDeserializationCallback, ISerializable, IDictionary`2, IReadOnlyDictionary`2, ICollection`1, IEnumerable`1, IReadOnlyCollection`1 {
 	public ODataActionParameters ()
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static System.Threading.Tasks.ValueTask`1[[Microsoft.AspNetCore.OData.Formatter.ODataActionParameters]] BindAsync (Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter)
 }
 
 public class Microsoft.AspNetCore.OData.Formatter.ODataInputFormatter : Microsoft.AspNetCore.Mvc.Formatters.TextInputFormatter, IApiRequestFormatMetadataProvider, IInputFormatter {
@@ -1206,6 +1213,11 @@ public class Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters :
 	public ODataUntypedActionParameters (Microsoft.OData.Edm.IEdmAction action)
 
 	Microsoft.OData.Edm.IEdmAction Action  { public get; }
+
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static System.Threading.Tasks.ValueTask`1[[Microsoft.AspNetCore.OData.Formatter.ODataUntypedActionParameters]] BindAsync (Microsoft.AspNetCore.Http.HttpContext context, System.Reflection.ParameterInfo parameter)
 }
 
 public class Microsoft.AspNetCore.OData.Formatter.ResourceContext {


### PR DESCRIPTION
1. Fixes #1487 : Minimal API TimeZoneInfo for Serialization in minimal APi
2. Enable ODataActionParameter and ODataUntypedActionParameter binding