### PR TITLE
Fix vulnerable dependencies in newtonsoft.json

### DIFF
--- a/src/Microsoft.AspNetCore.OData.NewtonsoftJson/Microsoft.AspNetCore.OData.NewtonsoftJson.csproj
+++ b/src/Microsoft.AspNetCore.OData.NewtonsoftJson/Microsoft.AspNetCore.OData.NewtonsoftJson.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.17" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.AspNetCore.OData.NewtonsoftJson/Microsoft.AspNetCore.OData.NewtonsoftJson.csproj
+++ b/src/Microsoft.AspNetCore.OData.NewtonsoftJson/Microsoft.AspNetCore.OData.NewtonsoftJson.csproj
@@ -16,8 +16,8 @@
   <Import Project="..\..\tool\build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.17" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -2,9 +2,9 @@
   <!-- Set the version number: major, minor, build and release (i.e. alpha, beta or blank for RTM)-->
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">9</VersionMajor>
-    <VersionMinor Condition="'$(VersionMinor)' == ''">3</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">1</VersionBuild>
-    <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
+    <VersionMinor Condition="'$(VersionMinor)' == ''">4</VersionMinor>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">0</VersionBuild>
+    <VersionRelease Condition="'$(VersionRelease)' == ''">preview</VersionRelease>
   </PropertyGroup>
   
     <!-- For NuGet Package Dependencies -->


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

`Newtonsoft.Json` prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage.

This PR handles this security vulnerabilities by updating affected dependencies:
- [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
