### PR TITLE
Fixes #1490: Remove useless Expression.Condition when parsing IsOf

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderBase.cs
@@ -337,8 +337,8 @@ public abstract class ExpressionBinderBase
             }
         }
 
-        // Be caution: Type method of LINQ to Entities only supports entity type.
-        return Expression.Condition(Expression.TypeIs(source, clrType), TrueConstant, FalseConstant);
+        // Be caution: Type method of LINQ to Entities only supports entity types.
+        return Expression.TypeIs(source, clrType);
     }
 
     private Expression BindCeiling(SingleValueFunctionCallNode node)

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.SingleValueFunctionCall.cs
@@ -680,8 +680,8 @@ public abstract partial class QueryBinder
             }
         }
 
-        // Be caution: Type method of LINQ to Entities only supports entity type.
-        return Expression.Condition(Expression.TypeIs(source, clrType), TrueConstant, FalseConstant);
+        // Be caution: Type method of LINQ to Entities only supports entity types.
+        return Expression.TypeIs(source, clrType);
     }
 
     /// <summary>

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
@@ -2493,12 +2493,12 @@ public class FilterBinderTests
     #region 'isof' in query option
 
     [Theory]
-    [InlineData("isof(Edm.Int16)", "$it => IIF(($it Is System.Int16), True, False)")]
-    [InlineData("isof('Microsoft.AspNetCore.OData.Tests.Models.Product')", "$it => IIF(($it Is Microsoft.AspNetCore.OData.Tests.Models.Product), True, False)")]
-    [InlineData("isof(ProductName,Edm.String)", "$it => IIF(($it.ProductName Is System.String), True, False)")]
-    [InlineData("isof(Category,'Microsoft.AspNetCore.OData.Tests.Models.Category')", "$it => IIF(($it.Category Is Microsoft.AspNetCore.OData.Tests.Models.Category), True, False)")]
-    [InlineData("isof(Category,'Microsoft.AspNetCore.OData.Tests.Models.DerivedCategory')", "$it => IIF(($it.Category Is Microsoft.AspNetCore.OData.Tests.Models.DerivedCategory), True, False)")]
-    [InlineData("isof(Ranking, 'Microsoft.AspNetCore.OData.Tests.Models.SimpleEnum')", "$it => IIF(($it.Ranking Is Microsoft.AspNetCore.OData.Tests.Models.SimpleEnum), True, False)")]
+    [InlineData("isof(Edm.Int16)", "$it => ($it Is System.Int16)")]
+    [InlineData("isof('Microsoft.AspNetCore.OData.Tests.Models.Product')", "$it => ($it Is Microsoft.AspNetCore.OData.Tests.Models.Product)")]
+    [InlineData("isof(ProductName,Edm.String)", "$it => ($it.ProductName Is System.String)")]
+    [InlineData("isof(Category,'Microsoft.AspNetCore.OData.Tests.Models.Category')", "$it => ($it.Category Is Microsoft.AspNetCore.OData.Tests.Models.Category)")]
+    [InlineData("isof(Category,'Microsoft.AspNetCore.OData.Tests.Models.DerivedCategory')", "$it => ($it.Category Is Microsoft.AspNetCore.OData.Tests.Models.DerivedCategory)")]
+    [InlineData("isof(Ranking, 'Microsoft.AspNetCore.OData.Tests.Models.SimpleEnum')", "$it => ($it.Ranking Is Microsoft.AspNetCore.OData.Tests.Models.SimpleEnum)")]
     public void IsofMethod_Succeeds(string filter, string expectedResult)
     {
         // Arrange & Act & Assert


### PR DESCRIPTION
Fixes #1490 Useless Expression.Condition when parsing IsOf

This PR just remove the useless expression and adapt tests.  

I don't really see what should be done additionally.  
A cherry picking to v 8.x would be appreciated