### PR TITLE
Fix #1518: Add additional check in IsMinimalEndpoint to prevent false positives

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Formatter;
@@ -97,7 +98,8 @@ public static class HttpContextExtensions
 
         // Check if the endpoint is a minimal endpoint.
         var endpoint = httpContext.GetEndpoint();
-        return endpoint?.Metadata.GetMetadata<ODataMiniMetadata>() != null;
+        return endpoint?.Metadata.GetMetadata<HttpMethodAttribute>() == null
+               && endpoint?.Metadata.GetMetadata<ODataMiniMetadata>() != null;
     }
 
     internal static IEdmModel GetOrCreateEdmModel(this HttpContext httpContext, Type clrType, ParameterInfo parameter = null)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarSearch/DollarSearchDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/DollarSearch/DollarSearchDataModel.cs
@@ -23,7 +23,7 @@ public class SearchProduct
 
     public SearchCategory Category { get; set; }
 
-    public List<SearchTag> Tags { get; set; } // List of tags
+    public List<SearchTag> Tags { get; set; } // List of tags
 }
 
 public class SearchCategory


### PR DESCRIPTION
When Minimal Apis are not used, and controllers are, `ODataQueryOptions<TEntity>` always calls `PopulateMetadata()`, which will always add metadata of type `ODataMiniMetadata` to the endpoint.

Currently, when `httpContext.IsMinimalEndpoint()` is called, it checks whether `ODataMiniMetadata` exists which is always the case.

This commits makes it additionally check for an `HttpMethodAttribute` in the endpoint metadata.

Additionally, when `PopulateMetadata()` was called, the endpointBuilder.Metadata list was empty, so it was not possible to check for other attributes.