### PR TITLE
Add Constructor to ODataQueryOptions and ODataQueryOptions<TEntity> for Dictionary-Based Initialization Without HttpRequest and optional IEdmModel

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -151,7 +151,7 @@ public static class HttpRequestExtensions
     {
         if (request == null)
         {
-            throw Error.ArgumentNull(nameof(request));
+            return false;
         }
 
         ODataPath path = request.ODataFeature().Path;

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -151,7 +151,7 @@ public static class HttpRequestExtensions
     {
         if (request == null)
         {
-            return false;
+            throw Error.ArgumentNull(nameof(request));
         }
 
         ODataPath path = request.ODataFeature().Path;

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -7356,6 +7356,11 @@
               Looks up a localized string similar to The HttpActionContext.ActionDescriptor is null..
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.SRResources.ApplyToRequiresModel">
+            <summary>
+              Looks up a localized string similar to The query options were created from query parameters without an IEdmModel and therefore cannot be applied to an IQueryable. Provide an IEdmModel when constructing the ODataQueryOptions to enable ApplyTo..
+            </summary>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.SRResources.ActionDescriptorNotControllerActionDescriptor">
             <summary>
               Looks up a localized string similar to ActionDescriptor is not ControllerActionDescriptor..
@@ -11852,15 +11857,20 @@
             <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information.</param>
             <param name="request">The incoming request message.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},System.Type,Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},System.Type,Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath,System.IServiceProvider)">
             <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> class based on the given query parameters and context.
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> class based on the given query parameters,
+            without requiring an <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/>. This is useful for stand-alone scenarios such as deserializing
+            query options from JSON, testing, or tooling.
             </summary>
             <param name="queryParameters">The OData query parameters as a dictionary.</param>
-            <param name="model">The EdmModel that includes the <see cref="T:Microsoft.OData.Edm.IEdmType"/> corresponding to
-            the given <paramref name="elementClrType"/>.</param>
             <param name="elementClrType">The CLR type of the element of the collection being queried.</param>
-            <param name="path">The parsed <see cref="T:Microsoft.OData.UriParser.ODataPath"/>.</param>
+            <param name="model">The <see cref="T:Microsoft.OData.Edm.IEdmModel"/> that includes the <see cref="T:Microsoft.OData.Edm.IEdmType"/> corresponding to
+            the given <paramref name="elementClrType"/>. When <c>null</c>, only the raw query values are captured and the
+            options cannot be applied to an <see cref="T:System.Linq.IQueryable"/>.</param>
+            <param name="path">The parsed <see cref="T:Microsoft.OData.UriParser.ODataPath"/>. Optional.</param>
+            <param name="serviceProvider">The <see cref="T:System.IServiceProvider"/> used to resolve OData services such as custom
+            binders, validators, or an <see cref="T:Microsoft.OData.UriParser.ODataUriResolver"/>. Optional; sensible defaults are used when it is <c>null</c>.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.Request">
             <summary>
@@ -12001,6 +12011,15 @@
             <param name="querySettings">The settings to use in query composition.</param>
             <returns>The new <see cref="T:System.Linq.IQueryable"/> after the query has been applied to.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.GetOrCreateODataFeature">
+            <summary>
+            Gets the <see cref="T:Microsoft.AspNetCore.OData.Abstracts.IODataFeature"/> used to carry the computed query state (select/expand clause,
+            total count, page size, next link, etc.). Uses the request's feature when an <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/>
+            is associated with this instance; otherwise a detached feature is used so the query options can be
+            applied without an <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/> (stand-alone scenarios).
+            </summary>
+            <returns>The <see cref="T:Microsoft.AspNetCore.OData.Abstracts.IODataFeature"/> to use.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.GenerateStableOrder">
             <summary>
             Generates the Stable OrderBy query option based on the existing OrderBy and other query options. 
@@ -12091,13 +12110,17 @@
             <param name="request">The incoming request message</param>
             <remarks>This signature uses types that are AspNetCore-specific.</remarks>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath,System.IServiceProvider)">
             <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/> class based on the given query parameters and context.
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/> class based on the given query
+            parameters, without requiring an <see cref="T:Microsoft.AspNetCore.Http.HttpRequest"/>.
             </summary>
-            <param name="model">The EDM model (can be null for non-model scenarios).</param>
             <param name="queryParameters">The OData query parameters as a dictionary.</param>
-            <param name="path">The ODataPath (optional, can be null).</param>
+            <param name="model">The EDM model. When <c>null</c> only the raw query values are captured and the options
+            cannot be applied to an <see cref="T:System.Linq.IQueryable"/>.</param>
+            <param name="path">The <see cref="T:Microsoft.OData.UriParser.ODataPath"/>. Optional.</param>
+            <param name="serviceProvider">The <see cref="T:System.IServiceProvider"/> used to resolve OData services such as custom
+            binders, validators, or an <see cref="T:Microsoft.OData.UriParser.ODataUriResolver"/>. Optional; sensible defaults are used when it is <c>null</c>.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.IfMatch">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -12020,6 +12020,13 @@
             </summary>
             <returns>The <see cref="T:Microsoft.AspNetCore.OData.Abstracts.IODataFeature"/> to use.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.EnsureContextForQueryComposition">
+            <summary>
+            Ensures that this instance has an <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> (i.e. it was created with an
+            <see cref="T:Microsoft.OData.Edm.IEdmModel"/>). Instances created from query parameters without a model only capture the raw
+            query values and cannot parse, validate, or apply the query options to an <see cref="T:System.Linq.IQueryable"/> or entity.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.GenerateStableOrder">
             <summary>
             Generates the Stable OrderBy query option based on the existing OrderBy and other query options. 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -11852,12 +11852,15 @@
             <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information.</param>
             <param name="request">The incoming request message.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},System.Type,Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> class based on the given query parameters and context.
             </summary>
             <param name="queryParameters">The OData query parameters as a dictionary.</param>
-            <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and type information.</param>
+            <param name="model">The EdmModel that includes the <see cref="T:Microsoft.OData.Edm.IEdmType"/> corresponding to
+            the given <paramref name="elementClrType"/>.</param>
+            <param name="elementClrType">The CLR type of the element of the collection being queried.</param>
+            <param name="path">The parsed <see cref="T:Microsoft.OData.UriParser.ODataPath"/>.</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.Request">
             <summary>
@@ -12088,7 +12091,7 @@
             <param name="request">The incoming request message</param>
             <remarks>This signature uses types that are AspNetCore-specific.</remarks>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.#ctor(Microsoft.OData.Edm.IEdmModel,System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.OData.UriParser.ODataPath)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.OData.Edm.IEdmModel,Microsoft.OData.UriParser.ODataPath)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/> class based on the given query parameters and context.
             </summary>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -11852,6 +11852,13 @@
             <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information.</param>
             <param name="request">The incoming request message.</param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.#ctor(System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.AspNetCore.OData.Query.ODataQueryContext)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> class based on the given query parameters and context.
+            </summary>
+            <param name="queryParameters">The OData query parameters as a dictionary.</param>
+            <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and type information.</param>
+        </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryOptions.Request">
             <summary>
             Gets the request message associated with this instance.
@@ -12080,6 +12087,14 @@
             <param name="context">The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryContext"/> which contains the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> and some type information</param>
             <param name="request">The incoming request message</param>
             <remarks>This signature uses types that are AspNetCore-specific.</remarks>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.#ctor(Microsoft.OData.Edm.IEdmModel,System.Collections.Generic.IDictionary{System.String,System.String},Microsoft.OData.UriParser.ODataPath)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1"/> class based on the given query parameters and context.
+            </summary>
+            <param name="model">The EDM model (can be null for non-model scenarios).</param>
+            <param name="queryParameters">The OData query parameters as a dictionary.</param>
+            <param name="path">The ODataPath (optional, can be null).</param>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1.IfMatch">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.AspNetCore.OData {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The query options were created from query parameters without an IEdmModel and therefore cannot be applied to an IQueryable. Provide an IEdmModel when constructing the ODataQueryOptions to enable ApplyTo..
+        /// </summary>
+        internal static string ApplyToRequiresModel {
+            get {
+                return ResourceManager.GetString("ApplyToRequiresModel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ActionDescriptor is not ControllerActionDescriptor..
         /// </summary>
         internal static string ActionDescriptorNotControllerActionDescriptor {

--- a/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
+++ b/src/Microsoft.AspNetCore.OData/Properties/SRResources.resx
@@ -135,6 +135,9 @@
   <data name="ArgumentMustBeGreaterThanOrEqualTo" xml:space="preserve">
     <value>Value must be greater than or equal to {0}.</value>
   </data>
+  <data name="ApplyToRequiresModel" xml:space="preserve">
+    <value>The query options were created from query parameters without an IEdmModel and therefore cannot be applied to an IQueryable. Provide an IEdmModel when constructing the ODataQueryOptions to enable ApplyTo.</value>
+  </data>
   <data name="ArgumentMustBeLessThanOrEqualTo" xml:space="preserve">
     <value>Value must be less than or equal to {0}.</value>
   </data>

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1,2 +1,23 @@
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.get -> System.TimeSpan?
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.set -> void
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.get -> int
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.set -> void
+Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validate(Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
+Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validator.get -> Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator
+Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validator.set -> void
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MaxFunctionCallDepth.get -> int
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MaxFunctionCallDepth.set -> void
+Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.get -> System.TimeSpan?
+Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.set -> void
+Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator
+Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator.ApplyQueryValidator() -> void
+Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.CurrentFunctionCallDepth.get -> int
+Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.EnterFunctionCall() -> void
+Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.ExitFunctionCall() -> void
+Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator
+Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.ApplyQueryOption applyQueryOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
+Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.MaxFunctionCallDepth.get -> int
+Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.MaxFunctionCallDepth.set -> void
+virtual Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.ApplyQueryOption applyQueryOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
 Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ODataQueryOptions(System.Collections.Generic.IDictionary<string, string> queryParameters, System.Type elementClrType, Microsoft.OData.Edm.IEdmModel model = null, Microsoft.OData.UriParser.ODataPath path = null, System.IServiceProvider serviceProvider = null) -> void
 Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.ODataQueryOptions(System.Collections.Generic.IDictionary<string, string> queryParameters, Microsoft.OData.Edm.IEdmModel model = null, Microsoft.OData.UriParser.ODataPath path = null, System.IServiceProvider serviceProvider = null) -> void

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -1,21 +1,2 @@
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.get -> System.TimeSpan?
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.set -> void
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.get -> int
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.set -> void
-Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validate(Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
-Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validator.get -> Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator
-Microsoft.AspNetCore.OData.Query.ApplyQueryOption.Validator.set -> void
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MaxFunctionCallDepth.get -> int
-Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MaxFunctionCallDepth.set -> void
-Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.get -> System.TimeSpan?
-Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.set -> void
-Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator
-Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator.ApplyQueryValidator() -> void
-Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.CurrentFunctionCallDepth.get -> int
-Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.EnterFunctionCall() -> void
-Microsoft.AspNetCore.OData.Query.Validator.FilterValidatorContext.ExitFunctionCall() -> void
-Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator
-Microsoft.AspNetCore.OData.Query.Validator.IApplyQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.ApplyQueryOption applyQueryOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
-Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.MaxFunctionCallDepth.get -> int
-Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings.MaxFunctionCallDepth.set -> void
-virtual Microsoft.AspNetCore.OData.Query.Validator.ApplyQueryValidator.Validate(Microsoft.AspNetCore.OData.Query.ApplyQueryOption applyQueryOption, Microsoft.AspNetCore.OData.Query.Validator.ODataValidationSettings validationSettings) -> void
+Microsoft.AspNetCore.OData.Query.ODataQueryOptions.ODataQueryOptions(System.Collections.Generic.IDictionary<string, string> queryParameters, System.Type elementClrType, Microsoft.OData.Edm.IEdmModel model = null, Microsoft.OData.UriParser.ODataPath path = null, System.IServiceProvider serviceProvider = null) -> void
+Microsoft.AspNetCore.OData.Query.ODataQueryOptions<TEntity>.ODataQueryOptions(System.Collections.Generic.IDictionary<string, string> queryParameters, Microsoft.OData.Edm.IEdmModel model = null, Microsoft.OData.UriParser.ODataPath path = null, System.IServiceProvider serviceProvider = null) -> void

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -87,18 +87,31 @@ public class ODataQueryOptions
     /// Initializes a new instance of the <see cref="ODataQueryOptions"/> class based on the given query parameters and context.
     /// </summary>
     /// <param name="queryParameters">The OData query parameters as a dictionary.</param>
-    /// <param name="context">The <see cref="ODataQueryContext"/> which contains the <see cref="IEdmModel"/> and type information.</param>
-    public ODataQueryOptions(IDictionary<string, string> queryParameters, ODataQueryContext context)
+    /// <param name="model">The EdmModel that includes the <see cref="IEdmType"/> corresponding to
+    /// the given <paramref name="elementClrType"/>.</param>
+    /// <param name="elementClrType">The CLR type of the element of the collection being queried.</param>
+    /// <param name="path">The parsed <see cref="ODataPath"/>.</param>
+    public ODataQueryOptions(IDictionary<string, string> queryParameters, Type elementClrType, IEdmModel model = null, ODataPath path = null)
     {
         if (queryParameters == null)
         {
             throw Error.ArgumentNull(nameof(queryParameters));
         }
 
-        if (context == null)
+        if (elementClrType == null)
         {
-            throw Error.ArgumentNull(nameof(context));
+            throw Error.ArgumentNull(nameof(elementClrType));
         }
+
+        if (model == null)
+        {
+            RawValues = new ODataRawQueryOptions();
+
+            BuildOnlyQueryOptions(queryParameters);
+            return;
+        }
+
+        ODataQueryContext context = new ODataQueryContext(model ?? EdmCoreModel.Instance, elementClrType, path);
 
         Context = context;
         Request = context.Request;
@@ -1127,6 +1140,80 @@ public class ODataQueryOptions
                     Context.NavigationSource,
                     new Dictionary<string, string> { { "$count", "true" } },
                     Context.RequestContainer));
+        }
+    }
+
+    private void BuildOnlyQueryOptions(IDictionary<string, string> queryParameters)
+    {
+        foreach (KeyValuePair<string, string> kvp in queryParameters)
+        {
+            switch (kvp.Key.ToLowerInvariant())
+            {
+                case "$filter":
+                    ThrowIfEmpty(kvp.Value, "$filter");
+                    RawValues.Filter = kvp.Value;
+                    Filter = new FilterQueryOption(kvp.Value);
+                    break;
+                case "$orderby":
+                    ThrowIfEmpty(kvp.Value, "$orderby");
+                    RawValues.OrderBy = kvp.Value;
+                    OrderBy = new OrderByQueryOption(kvp.Value);
+                    break;
+                case "$top":
+                    ThrowIfEmpty(kvp.Value, "$top");
+                    RawValues.Top = kvp.Value;
+                    Top = new TopQueryOption(kvp.Value);
+                    break;
+                case "$skip":
+                    ThrowIfEmpty(kvp.Value, "$skip");
+                    RawValues.Skip = kvp.Value;
+                    Skip = new SkipQueryOption(kvp.Value);
+                    break;
+                case "$select":
+                    RawValues.Select = kvp.Value;
+                    break;
+                case "$count":
+                    ThrowIfEmpty(kvp.Value, "$count");
+                    RawValues.Count = kvp.Value;
+                    Count = new CountQueryOption(kvp.Value);
+                    break;
+                case "$expand":
+                    RawValues.Expand = kvp.Value;
+                    break;
+                case "$format":
+                    RawValues.Format = kvp.Value;
+                    break;
+                case "$skiptoken":
+                    RawValues.SkipToken = kvp.Value;
+                    SkipToken = new SkipTokenQueryOption(kvp.Value);
+                    break;
+                case "$deltatoken":
+                    RawValues.DeltaToken = kvp.Value;
+                    break;
+                case "$apply":
+                    ThrowIfEmpty(kvp.Value, "$apply");
+                    RawValues.Apply = kvp.Value;
+                    Apply = new ApplyQueryOption(kvp.Value);
+                    break;
+                case "$compute":
+                    ThrowIfEmpty(kvp.Value, "$compute");
+                    RawValues.Compute = kvp.Value;
+                    Compute = new ComputeQueryOption(kvp.Value);
+                    break;
+                case "$search":
+                    ThrowIfEmpty(kvp.Value, "$search");
+                    RawValues.Search = kvp.Value;
+                    Search = new SearchQueryOption(kvp.Value);
+                    break;
+                default:
+                    // we don't throw if we can't recognize the query
+                    break;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(RawValues.Select) || !string.IsNullOrWhiteSpace(RawValues.Expand))
+        {
+            SelectExpand = new SelectExpandQueryOption(RawValues.Select, RawValues.Expand);
         }
     }
 

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -107,7 +107,7 @@ public class ODataQueryOptions
         {
             RawValues = new ODataRawQueryOptions();
 
-            BuildOnlyQueryOptions(queryParameters);
+            BuildQueryOptionsOnly(queryParameters);
             return;
         }
 
@@ -1143,7 +1143,7 @@ public class ODataQueryOptions
         }
     }
 
-    private void BuildOnlyQueryOptions(IDictionary<string, string> queryParameters)
+    private void BuildQueryOptionsOnly(IDictionary<string, string> queryParameters)
     {
         foreach (KeyValuePair<string, string> kvp in queryParameters)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -134,26 +134,24 @@ public class ODataQueryOptions
         Context = context;
         _queryParameters = queryParameters;
 
+        ODataUriResolver uriResolver = serviceProvider?.GetService<ODataUriResolver>();
+        _enableNoDollarSignQueryOptions = uriResolver != null && uriResolver.EnableNoDollarQueryOptions;
+
+        // Normalize the query parameters the same way the HttpRequest-based path (Initialize) does:
+        // trim keys and, when EnableNoDollarQueryOptions is set on the resolver, add the '$'-prefix to
+        // no-dollar system query options so inputs such as "filter" are recognized.
+        IDictionary<string, string> normalizedQueryParameters = GetODataQueryParameters();
+
         _queryOptionParser = new ODataQueryOptionParser(
             context.Model,
             context.ElementType,
             context.NavigationSource,
-            queryParameters,
+            normalizedQueryParameters,
             serviceProvider);
 
-        ODataUriResolver uriResolver = serviceProvider?.GetService<ODataUriResolver>();
-        if (uriResolver != null)
-        {
-            _queryOptionParser.Resolver = uriResolver;
-            _enableNoDollarSignQueryOptions = uriResolver.EnableNoDollarQueryOptions;
-        }
-        else
-        {
-            _queryOptionParser.Resolver = ODataQueryContext.DefaultCaseInsensitiveResolver;
-            _enableNoDollarSignQueryOptions = false;
-        }
+        _queryOptionParser.Resolver = uriResolver ?? ODataQueryContext.DefaultCaseInsensitiveResolver;
 
-        BuildQueryOptions(queryParameters);
+        BuildQueryOptions(normalizedQueryParameters);
 
         Validator = context.GetODataQueryValidator();
     }
@@ -1209,6 +1207,10 @@ public class ODataQueryOptions
 
     private void BuildQueryOptionsOnly(IDictionary<string, string> queryParameters)
     {
+        // Raw-values-only mode (no IEdmModel): capture only the raw query values. The strongly-typed
+        // query option objects (Filter, OrderBy, SelectExpand, etc.) require a model/parser to be usable
+        // (e.g. Filter.FilterClause parses via the parser), so they are intentionally left null here.
+        // Consumers read the values from RawValues instead.
         foreach (KeyValuePair<string, string> kvp in queryParameters)
         {
             switch (kvp.Key.ToLowerInvariant())
@@ -1216,22 +1218,18 @@ public class ODataQueryOptions
                 case "$filter":
                     ThrowIfEmpty(kvp.Value, "$filter");
                     RawValues.Filter = kvp.Value;
-                    Filter = new FilterQueryOption(kvp.Value);
                     break;
                 case "$orderby":
                     ThrowIfEmpty(kvp.Value, "$orderby");
                     RawValues.OrderBy = kvp.Value;
-                    OrderBy = new OrderByQueryOption(kvp.Value);
                     break;
                 case "$top":
                     ThrowIfEmpty(kvp.Value, "$top");
                     RawValues.Top = kvp.Value;
-                    Top = new TopQueryOption(kvp.Value);
                     break;
                 case "$skip":
                     ThrowIfEmpty(kvp.Value, "$skip");
                     RawValues.Skip = kvp.Value;
-                    Skip = new SkipQueryOption(kvp.Value);
                     break;
                 case "$select":
                     RawValues.Select = kvp.Value;
@@ -1239,7 +1237,6 @@ public class ODataQueryOptions
                 case "$count":
                     ThrowIfEmpty(kvp.Value, "$count");
                     RawValues.Count = kvp.Value;
-                    Count = new CountQueryOption(kvp.Value);
                     break;
                 case "$expand":
                     RawValues.Expand = kvp.Value;
@@ -1249,7 +1246,6 @@ public class ODataQueryOptions
                     break;
                 case "$skiptoken":
                     RawValues.SkipToken = kvp.Value;
-                    SkipToken = new SkipTokenQueryOption(kvp.Value);
                     break;
                 case "$deltatoken":
                     RawValues.DeltaToken = kvp.Value;
@@ -1257,27 +1253,19 @@ public class ODataQueryOptions
                 case "$apply":
                     ThrowIfEmpty(kvp.Value, "$apply");
                     RawValues.Apply = kvp.Value;
-                    Apply = new ApplyQueryOption(kvp.Value);
                     break;
                 case "$compute":
                     ThrowIfEmpty(kvp.Value, "$compute");
                     RawValues.Compute = kvp.Value;
-                    Compute = new ComputeQueryOption(kvp.Value);
                     break;
                 case "$search":
                     ThrowIfEmpty(kvp.Value, "$search");
                     RawValues.Search = kvp.Value;
-                    Search = new SearchQueryOption(kvp.Value);
                     break;
                 default:
                     // we don't throw if we can't recognize the query
                     break;
             }
-        }
-
-        if (!string.IsNullOrWhiteSpace(RawValues.Select) || !string.IsNullOrWhiteSpace(RawValues.Expand))
-        {
-            SelectExpand = new SelectExpandQueryOption(RawValues.Select, RawValues.Expand);
         }
     }
 

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -55,6 +55,14 @@ public class ODataQueryOptions
 
     private OrderByQueryOption _stableOrderBy;
 
+    // Holds the computed query state (select/expand clause, total count, page size, etc.) when this
+    // instance is not associated with an HttpRequest (stand-alone/detached scenarios).
+    private ODataFeature _detachedODataFeature;
+
+    // Holds the query parameters this instance was constructed from when there is no HttpRequest,
+    // so query re-parsing (e.g. for auto $select/$expand) works in stand-alone/detached scenarios.
+    private IDictionary<string, string> _queryParameters;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ODataQueryOptions"/> class based on the incoming request and some metadata information from
     /// the <see cref="ODataQueryContext"/>.
@@ -84,14 +92,19 @@ public class ODataQueryOptions
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ODataQueryOptions"/> class based on the given query parameters and context.
+    /// Initializes a new instance of the <see cref="ODataQueryOptions"/> class based on the given query parameters,
+    /// without requiring an <see cref="HttpRequest"/>. This is useful for stand-alone scenarios such as deserializing
+    /// query options from JSON, testing, or tooling.
     /// </summary>
     /// <param name="queryParameters">The OData query parameters as a dictionary.</param>
-    /// <param name="model">The EdmModel that includes the <see cref="IEdmType"/> corresponding to
-    /// the given <paramref name="elementClrType"/>.</param>
     /// <param name="elementClrType">The CLR type of the element of the collection being queried.</param>
-    /// <param name="path">The parsed <see cref="ODataPath"/>.</param>
-    public ODataQueryOptions(IDictionary<string, string> queryParameters, Type elementClrType, IEdmModel model = null, ODataPath path = null)
+    /// <param name="model">The <see cref="IEdmModel"/> that includes the <see cref="IEdmType"/> corresponding to
+    /// the given <paramref name="elementClrType"/>. When <c>null</c>, only the raw query values are captured and the
+    /// options cannot be applied to an <see cref="IQueryable"/>.</param>
+    /// <param name="path">The parsed <see cref="ODataPath"/>. Optional.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve OData services such as custom
+    /// binders, validators, or an <see cref="ODataUriResolver"/>. Optional; sensible defaults are used when it is <c>null</c>.</param>
+    public ODataQueryOptions(IDictionary<string, string> queryParameters, Type elementClrType, IEdmModel model = null, ODataPath path = null, IServiceProvider serviceProvider = null)
     {
         if (queryParameters == null)
         {
@@ -103,30 +116,32 @@ public class ODataQueryOptions
             throw Error.ArgumentNull(nameof(elementClrType));
         }
 
+        RawValues = new ODataRawQueryOptions();
+
         if (model == null)
         {
-            RawValues = new ODataRawQueryOptions();
-
+            // Non-model scenario: only capture the raw query values. Without a model the query
+            // options cannot be parsed or applied to an IQueryable.
             BuildQueryOptionsOnly(queryParameters);
             return;
         }
 
-        ODataQueryContext context = new ODataQueryContext(model ?? EdmCoreModel.Instance, elementClrType, path);
+        ODataQueryContext context = new ODataQueryContext(model, elementClrType, path)
+        {
+            RequestContainer = serviceProvider
+        };
 
         Context = context;
-        Request = context.Request;
+        _queryParameters = queryParameters;
 
-        RawValues = new ODataRawQueryOptions();
-
-        // Use the provided dictionary directly
         _queryOptionParser = new ODataQueryOptionParser(
             context.Model,
             context.ElementType,
             context.NavigationSource,
             queryParameters,
-            context.RequestContainer);
+            serviceProvider);
 
-        var uriResolver = context.RequestContainer?.GetService<ODataUriResolver>();
+        ODataUriResolver uriResolver = serviceProvider?.GetService<ODataUriResolver>();
         if (uriResolver != null)
         {
             _queryOptionParser.Resolver = uriResolver;
@@ -264,7 +279,7 @@ public class ODataQueryOptions
     {
         get
         {
-            if (!_etagIfMatchChecked && _etagIfMatch == null)
+            if (!_etagIfMatchChecked && _etagIfMatch == null && Request != null)
             {
                 StringValues ifMatchValues;
                 if (Request.Headers.TryGetValue("If-Match", out ifMatchValues))
@@ -286,7 +301,7 @@ public class ODataQueryOptions
     {
         get
         {
-            if (!_etagIfNoneMatchChecked && _etagIfNoneMatch == null)
+            if (!_etagIfNoneMatchChecked && _etagIfNoneMatch == null && Request != null)
             {
                 StringValues ifNoneMatchValues;
                 if (Request.Headers.TryGetValue("If-None-Match", out ifNoneMatchValues))
@@ -426,8 +441,15 @@ public class ODataQueryOptions
             throw Error.ArgumentNull(nameof(querySettings));
         }
 
+        if (Context == null)
+        {
+            // The instance was created from query parameters without an IEdmModel (raw-values-only).
+            // A model is required to parse and apply the query options to an IQueryable.
+            throw Error.InvalidOperation(SRResources.ApplyToRequiresModel);
+        }
+
         IQueryable result = query;
-        IODataFeature odataFeature = Request.ODataFeature();
+        IODataFeature odataFeature = GetOrCreateODataFeature();
 
         // Update the query setting
         querySettings = Context.UpdateQuerySettings(querySettings, query);
@@ -482,7 +504,7 @@ public class ODataQueryOptions
                 }
             }
 
-            if (Request.IsCountRequest())
+            if (Request != null && Request.IsCountRequest())
             {
                 return result;
             }
@@ -551,6 +573,23 @@ public class ODataQueryOptions
         return result;
     }
 
+    /// <summary>
+    /// Gets the <see cref="IODataFeature"/> used to carry the computed query state (select/expand clause,
+    /// total count, page size, next link, etc.). Uses the request's feature when an <see cref="HttpRequest"/>
+    /// is associated with this instance; otherwise a detached feature is used so the query options can be
+    /// applied without an <see cref="HttpRequest"/> (stand-alone scenarios).
+    /// </summary>
+    /// <returns>The <see cref="IODataFeature"/> to use.</returns>
+    private IODataFeature GetOrCreateODataFeature()
+    {
+        if (Request != null)
+        {
+            return Request.ODataFeature();
+        }
+
+        return _detachedODataFeature ??= new ODataFeature();
+    }
+
     internal IQueryable ApplyPaging(IQueryable result, ODataQuerySettings querySettings)
     {
         int pageSize = -1;
@@ -564,17 +603,17 @@ public class ODataQueryOptions
         }
 
         int preferredPageSize = -1;
-        if (RequestPreferenceHelpers.RequestPrefersMaxPageSize(Request.Headers, out preferredPageSize))
+        if (Request != null && RequestPreferenceHelpers.RequestPrefersMaxPageSize(Request.Headers, out preferredPageSize))
         {
             pageSize = Math.Min(pageSize, preferredPageSize);
         }
 
-        ODataFeature odataFeature = Request.ODataFeature() as ODataFeature;
+        ODataFeature odataFeature = GetOrCreateODataFeature() as ODataFeature;
         if (pageSize > 0)
         {
             bool resultsLimited;
             result = LimitResults(result, pageSize, querySettings.EnableConstantParameterization, out resultsLimited);
-            if (resultsLimited && Request.GetEncodedUrl() != null &&
+            if (resultsLimited && Request != null && Request.GetEncodedUrl() != null &&
                 odataFeature.NextLink == null)
             {
                 odataFeature.PageSize = pageSize;
@@ -948,10 +987,16 @@ public class ODataQueryOptions
     {
         Dictionary<string, string> result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var query in Request.Query)
+        // When there is no HttpRequest (stand-alone/detached scenarios), fall back to the query
+        // parameters this instance was constructed from.
+        IEnumerable<KeyValuePair<string, string>> queryParameters = Request != null
+            ? Request.Query.Select(q => new KeyValuePair<string, string>(q.Key, q.Value.ToString()))
+            : (_queryParameters ?? Enumerable.Empty<KeyValuePair<string, string>>());
+
+        foreach (KeyValuePair<string, string> query in queryParameters)
         {
             string key = query.Key.Trim();
-            string value = query.Value.ToString();
+            string value = query.Value;
             // Check supported system query options per $-sign-prefix option.
             if (!_enableNoDollarSignQueryOptions)
             {
@@ -1248,8 +1293,9 @@ public class ODataQueryOptions
                 SelectExpand.Context,
                 processedClause);
 
-            Request.ODataFeature().SelectExpandClause = processedClause;
-            (Request.ODataFeature() as ODataFeature).QueryOptions = this;
+            IODataFeature odataFeature = GetOrCreateODataFeature();
+            odataFeature.SelectExpandClause = processedClause;
+            (odataFeature as ODataFeature).QueryOptions = this;
 
             if (computeAvailable)
             {

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -1129,7 +1129,8 @@ public class ODataQueryOptions
                 Context, _queryOptionParser);
         }
 
-        if (Request.IsCountRequest())
+        // Ensure Request is not null before checking for CountRequest
+        if (Request != null && Request.IsCountRequest())
         {
             Count = new CountQueryOption(
                 "true",

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -372,6 +372,8 @@ public class ODataQueryOptions
     /// <returns>The new <see cref="IQueryable"/> after the query has been applied to.</returns>
     public virtual IQueryable ApplyTo(IQueryable query)
     {
+        EnsureContextForQueryComposition();
+
         ODataQuerySettings querySettings = Context.GetODataQuerySettings();
 
         // Only do the following in ApplyTo() without providing 'ODataQuerySettings'.
@@ -393,6 +395,8 @@ public class ODataQueryOptions
     /// <returns>The new <see cref="IQueryable"/> after the query has been applied to.</returns>
     public virtual IQueryable ApplyTo(IQueryable query, AllowedQueryOptions ignoreQueryOptions)
     {
+        EnsureContextForQueryComposition();
+
         ODataQuerySettings querySettings = Context.GetODataQuerySettings();
         querySettings.IgnoredQueryOptions = ignoreQueryOptions;
 
@@ -441,12 +445,7 @@ public class ODataQueryOptions
             throw Error.ArgumentNull(nameof(querySettings));
         }
 
-        if (Context == null)
-        {
-            // The instance was created from query parameters without an IEdmModel (raw-values-only).
-            // A model is required to parse and apply the query options to an IQueryable.
-            throw Error.InvalidOperation(SRResources.ApplyToRequiresModel);
-        }
+        EnsureContextForQueryComposition();
 
         IQueryable result = query;
         IODataFeature odataFeature = GetOrCreateODataFeature();
@@ -590,6 +589,21 @@ public class ODataQueryOptions
         return _detachedODataFeature ??= new ODataFeature();
     }
 
+    /// <summary>
+    /// Ensures that this instance has an <see cref="ODataQueryContext"/> (i.e. it was created with an
+    /// <see cref="IEdmModel"/>). Instances created from query parameters without a model only capture the raw
+    /// query values and cannot parse, validate, or apply the query options to an <see cref="IQueryable"/> or entity.
+    /// </summary>
+    private void EnsureContextForQueryComposition()
+    {
+        if (Context == null)
+        {
+            // The instance was created from query parameters without an IEdmModel (raw-values-only).
+            // A model is required to parse and apply the query options to an IQueryable.
+            throw Error.InvalidOperation(SRResources.ApplyToRequiresModel);
+        }
+    }
+
     internal IQueryable ApplyPaging(IQueryable result, ODataQuerySettings querySettings)
     {
         int pageSize = -1;
@@ -728,6 +742,8 @@ public class ODataQueryOptions
             throw Error.ArgumentNull("querySettings");
         }
 
+        EnsureContextForQueryComposition();
+
         if (Filter != null || OrderBy != null || Top != null || Skip != null || Count != null)
         {
             throw Error.InvalidOperation(SRResources.NonSelectExpandOnSingleEntity);
@@ -761,6 +777,8 @@ public class ODataQueryOptions
         {
             throw Error.ArgumentNull(nameof(validationSettings));
         }
+
+        EnsureContextForQueryComposition();
 
         this.Context.ValidationSettings = validationSettings;
 

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -45,6 +46,26 @@ public class ODataQueryOptions<TEntity> : ODataQueryOptions, IEndpointParameterM
         if (context.ElementClrType != typeof(TEntity))
         {
             throw Error.Argument("context", SRResources.EntityTypeMismatch, context.ElementClrType.FullName, typeof(TEntity).FullName);
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ODataQueryOptions{TEntity}"/> class based on the given query parameters and context.
+    /// </summary>
+    /// <param name="model">The EDM model (can be null for non-model scenarios).</param>
+    /// <param name="queryParameters">The OData query parameters as a dictionary.</param>
+    /// <param name="path">The ODataPath (optional, can be null).</param>
+    public ODataQueryOptions(IEdmModel model, IDictionary<string, string> queryParameters, ODataPath path = null)
+        : base(queryParameters, new ODataQueryContext(model, typeof(TEntity), path))
+    {
+        if (Context.ElementClrType == null)
+        {
+            throw Error.Argument("context", SRResources.ElementClrTypeNull, typeof(ODataQueryContext).Name);
+        }
+
+        if (Context.ElementClrType != typeof(TEntity))
+        {
+            throw Error.Argument("context", SRResources.EntityTypeMismatch, Context.ElementClrType.FullName, typeof(TEntity).FullName);
         }
     }
 

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
@@ -55,18 +55,18 @@ public class ODataQueryOptions<TEntity> : ODataQueryOptions, IEndpointParameterM
     /// <param name="model">The EDM model (can be null for non-model scenarios).</param>
     /// <param name="queryParameters">The OData query parameters as a dictionary.</param>
     /// <param name="path">The ODataPath (optional, can be null).</param>
-    public ODataQueryOptions(IEdmModel model, IDictionary<string, string> queryParameters, ODataPath path = null)
-        : base(queryParameters, new ODataQueryContext(model, typeof(TEntity), path))
+    public ODataQueryOptions(IDictionary<string, string> queryParameters, IEdmModel model = null, ODataPath path = null)
+        : base(queryParameters, typeof(TEntity), model, path)
     {
-        if (Context.ElementClrType == null)
-        {
-            throw Error.Argument("context", SRResources.ElementClrTypeNull, typeof(ODataQueryContext).Name);
-        }
+        //if (Context.ElementClrType == null)
+        //{
+        //    throw Error.Argument("context", SRResources.ElementClrTypeNull, typeof(ODataQueryContext).Name);
+        //}
 
-        if (Context.ElementClrType != typeof(TEntity))
-        {
-            throw Error.Argument("context", SRResources.EntityTypeMismatch, Context.ElementClrType.FullName, typeof(TEntity).FullName);
-        }
+        //if (Context.ElementClrType != typeof(TEntity))
+        //{
+        //    throw Error.Argument("context", SRResources.EntityTypeMismatch, Context.ElementClrType.FullName, typeof(TEntity).FullName);
+        //}
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
@@ -58,15 +58,6 @@ public class ODataQueryOptions<TEntity> : ODataQueryOptions, IEndpointParameterM
     public ODataQueryOptions(IDictionary<string, string> queryParameters, IEdmModel model = null, ODataPath path = null)
         : base(queryParameters, typeof(TEntity), model, path)
     {
-        //if (Context.ElementClrType == null)
-        //{
-        //    throw Error.Argument("context", SRResources.ElementClrTypeNull, typeof(ODataQueryContext).Name);
-        //}
-
-        //if (Context.ElementClrType != typeof(TEntity))
-        //{
-        //    throw Error.Argument("context", SRResources.EntityTypeMismatch, Context.ElementClrType.FullName, typeof(TEntity).FullName);
-        //}
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs
@@ -50,13 +50,17 @@ public class ODataQueryOptions<TEntity> : ODataQueryOptions, IEndpointParameterM
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ODataQueryOptions{TEntity}"/> class based on the given query parameters and context.
+    /// Initializes a new instance of the <see cref="ODataQueryOptions{TEntity}"/> class based on the given query
+    /// parameters, without requiring an <see cref="HttpRequest"/>.
     /// </summary>
-    /// <param name="model">The EDM model (can be null for non-model scenarios).</param>
     /// <param name="queryParameters">The OData query parameters as a dictionary.</param>
-    /// <param name="path">The ODataPath (optional, can be null).</param>
-    public ODataQueryOptions(IDictionary<string, string> queryParameters, IEdmModel model = null, ODataPath path = null)
-        : base(queryParameters, typeof(TEntity), model, path)
+    /// <param name="model">The EDM model. When <c>null</c> only the raw query values are captured and the options
+    /// cannot be applied to an <see cref="IQueryable"/>.</param>
+    /// <param name="path">The <see cref="ODataPath"/>. Optional.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve OData services such as custom
+    /// binders, validators, or an <see cref="ODataUriResolver"/>. Optional; sensible defaults are used when it is <c>null</c>.</param>
+    public ODataQueryOptions(IDictionary<string, string> queryParameters, IEdmModel model = null, ODataPath path = null, IServiceProvider serviceProvider = null)
+        : base(queryParameters, typeof(TEntity), model, path, serviceProvider)
     {
     }
 
@@ -88,7 +92,7 @@ public class ODataQueryOptions<TEntity> : ODataQueryOptions, IEndpointParameterM
     /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
     internal override ETag GetETag(EntityTagHeaderValue etagHeaderValue)
     {
-        return Request.GetETag<TEntity>(etagHeaderValue);
+        return Request == null ? null : Request.GetETag<TEntity>(etagHeaderValue);
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Query/ApplyQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/ApplyQueryOptions.cs
@@ -59,6 +59,17 @@ public class ApplyQueryOption
         ResultClrType = Context.ElementClrType;
     }
 
+    // Used when only the raw value is known.
+    internal ApplyQueryOption(string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal ApplyQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/ComputeQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/ComputeQueryOption.cs
@@ -54,6 +54,16 @@ public class ComputeQueryOption
         ResultClrType = Context.ElementClrType;
     }
 
+    internal ComputeQueryOption(string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal ComputeQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/ComputeQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/ComputeQueryOption.cs
@@ -54,6 +54,7 @@ public class ComputeQueryOption
         ResultClrType = Context.ElementClrType;
     }
 
+    // Used when only the raw value is known.
     internal ComputeQueryOption(string rawValue)
     {
         if (string.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/CountQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/CountQueryOption.cs
@@ -51,6 +51,7 @@ public class CountQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    // Used when only the raw value is known.
     internal CountQueryOption(string rawValue)
     {
         if (String.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/CountQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/CountQueryOption.cs
@@ -51,6 +51,16 @@ public class CountQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    internal CountQueryOption(string rawValue)
+    {
+        if (String.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty("rawValue");
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal CountQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
@@ -54,6 +54,7 @@ public class FilterQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    // Used when only the raw value is known.
     internal FilterQueryOption(string rawValue)
     {
         if (String.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
@@ -33,25 +33,25 @@ public class FilterQueryOption
     /// <param name="queryOptionParser">The <see cref="ODataQueryOptionParser"/> which is used to parse the query option.</param>
     public FilterQueryOption(string rawValue, ODataQueryContext context, ODataQueryOptionParser queryOptionParser)
     {
-        if (context == null)
-        {
-            throw Error.ArgumentNull("context");
-        }
-
         if (String.IsNullOrEmpty(rawValue))
         {
             throw Error.ArgumentNullOrEmpty("rawValue");
-        }
-
-        if (queryOptionParser == null)
-        {
-            throw Error.ArgumentNull("queryOptionParser");
         }
 
         Context = context;
         RawValue = rawValue;
         Validator = context.GetFilterQueryValidator();
         _queryOptionParser = queryOptionParser;
+    }
+
+    internal FilterQueryOption(string rawValue)
+    {
+        if (String.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty("rawValue");
+        }
+
+        RawValue = rawValue;
     }
 
     internal FilterQueryOption(ODataQueryContext context, FilterClause filterClause)

--- a/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/FilterQueryOption.cs
@@ -33,9 +33,19 @@ public class FilterQueryOption
     /// <param name="queryOptionParser">The <see cref="ODataQueryOptionParser"/> which is used to parse the query option.</param>
     public FilterQueryOption(string rawValue, ODataQueryContext context, ODataQueryOptionParser queryOptionParser)
     {
+        if (context == null)
+        {
+            throw Error.ArgumentNull("context");
+        }
+
         if (String.IsNullOrEmpty(rawValue))
         {
             throw Error.ArgumentNullOrEmpty("rawValue");
+        }
+
+        if (queryOptionParser == null)
+        {
+            throw Error.ArgumentNull("queryOptionParser");
         }
 
         Context = context;

--- a/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
@@ -56,6 +56,7 @@ public class OrderByQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    // Used when only the raw value is known.
     internal OrderByQueryOption(string rawValue)
     {
         if (String.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/OrderByQueryOption.cs
@@ -56,6 +56,16 @@ public class OrderByQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    internal OrderByQueryOption(string rawValue)
+    {
+        if (String.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty("rawValue");
+        }
+
+        RawValue = rawValue;
+    }
+
     internal OrderByQueryOption(string rawValue, ODataQueryContext context, string applyRaw, string computeRaw)
     {
         if (context == null)

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SearchQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SearchQueryOption.cs
@@ -55,6 +55,7 @@ public class SearchQueryOption
         ResultClrType = Context.ElementClrType;
     }
 
+    // Used when only the raw value is known.
     internal SearchQueryOption(string rawValue)
     {
         if (string.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SearchQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SearchQueryOption.cs
@@ -55,6 +55,16 @@ public class SearchQueryOption
         ResultClrType = Context.ElementClrType;
     }
 
+    internal SearchQueryOption(string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal SearchQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SelectExpandQueryOption.cs
@@ -69,6 +69,17 @@ public class SelectExpandQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    internal SelectExpandQueryOption(string select, string expand)
+    {
+        if (string.IsNullOrWhiteSpace(select) && string.IsNullOrWhiteSpace(expand))
+        {
+            throw Error.Argument(SRResources.SelectExpandEmptyOrNull);
+        }
+
+        RawSelect = select;
+        RawExpand = expand;
+    }
+
     internal SelectExpandQueryOption(
         string select,
         string expand,

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SkipQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SkipQueryOption.cs
@@ -54,6 +54,7 @@ public class SkipQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    // Used when only the raw value is known.
     internal SkipQueryOption(string rawValue)
     {
         if (String.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SkipQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SkipQueryOption.cs
@@ -54,6 +54,16 @@ public class SkipQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    internal SkipQueryOption(string rawValue)
+    {
+        if (String.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal SkipQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SkipTokenQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SkipTokenQueryOption.cs
@@ -40,6 +40,16 @@ public class SkipTokenQueryOption
         Context = context;
     }
 
+    internal SkipTokenQueryOption(string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     /// <summary>
     /// Gets the raw $skiptoken value.
     /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Query/Query/SkipTokenQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/SkipTokenQueryOption.cs
@@ -40,6 +40,7 @@ public class SkipTokenQueryOption
         Context = context;
     }
 
+    // Used when only the raw value is known.
     internal SkipTokenQueryOption(string rawValue)
     {
         if (string.IsNullOrEmpty(rawValue))

--- a/src/Microsoft.AspNetCore.OData/Query/Query/TopQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/TopQueryOption.cs
@@ -54,6 +54,16 @@ public class TopQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    internal TopQueryOption(string rawValue)
+    {
+        if (String.IsNullOrEmpty(rawValue))
+        {
+            throw Error.ArgumentNullOrEmpty(nameof(rawValue));
+        }
+
+        RawValue = rawValue;
+    }
+
     // This constructor is intended for unit testing only.
     internal TopQueryOption(string rawValue, ODataQueryContext context)
     {

--- a/src/Microsoft.AspNetCore.OData/Query/Query/TopQueryOption.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Query/TopQueryOption.cs
@@ -54,6 +54,7 @@ public class TopQueryOption
         _queryOptionParser = queryOptionParser;
     }
 
+    // Used when only the raw value is known.
     internal TopQueryOption(string rawValue)
     {
         if (String.IsNullOrEmpty(rawValue))

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsController.cs
@@ -1,0 +1,38 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DetachedQueryOptionsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.QueryOptionsFromDictionary;
+
+[ApiController]
+[Route("api/detachedcustomers")]
+public class DetachedQueryOptionsController : ControllerBase
+{
+    private static readonly IEdmModel Model = DetachedQueryOptionsEdmModel.GetEdmModel();
+
+    // Applies query options supplied as a JSON dictionary body, constructing the
+    // ODataQueryOptions<T> WITHOUT any HttpRequest (the stand-alone/detached scenario
+    // enabled by the new dictionary constructor).
+    [HttpPost("apply")]
+    public IActionResult Apply([FromBody] Dictionary<string, string> queryOptions)
+    {
+        var options = new ODataQueryOptions<DetachedCustomer>(
+            queryOptions ?? new Dictionary<string, string>(),
+            Model);
+
+        IQueryable<DetachedCustomer> data = DetachedQueryOptionsDataSource.Customers.AsQueryable();
+
+        var result = options.ApplyTo(data).Cast<DetachedCustomer>().ToList();
+
+        return Ok(result);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsDataModel.cs
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DetachedQueryOptionsDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.QueryOptionsFromDictionary;
+
+public class DetachedCustomer
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public int Age { get; set; }
+}
+
+public static class DetachedQueryOptionsDataSource
+{
+    public static IList<DetachedCustomer> Customers { get; } = new List<DetachedCustomer>
+    {
+        new DetachedCustomer { Id = 1, Name = "Alice", Age = 30 },
+        new DetachedCustomer { Id = 2, Name = "Bob", Age = 25 },
+        new DetachedCustomer { Id = 3, Name = "Charlie", Age = 40 },
+        new DetachedCustomer { Id = 4, Name = "Dave", Age = 35 },
+        new DetachedCustomer { Id = 5, Name = "Eve", Age = 28 }
+    };
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsEdmModel.cs
@@ -1,0 +1,21 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DetachedQueryOptionsEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.QueryOptionsFromDictionary;
+
+public class DetachedQueryOptionsEdmModel
+{
+    public static IEdmModel GetEdmModel()
+    {
+        var builder = new ODataConventionModelBuilder();
+        builder.EntitySet<DetachedCustomer>("DetachedCustomers");
+        return builder.GetEdmModel();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/QueryOptionsFromDictionary/DetachedQueryOptionsTests.cs
@@ -1,0 +1,124 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DetachedQueryOptionsTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.QueryOptionsFromDictionary;
+
+public class DetachedQueryOptionsTests : WebApiTestBase<DetachedQueryOptionsTests>
+{
+    public DetachedQueryOptionsTests(WebApiTestFixture<DetachedQueryOptionsTests> fixture)
+        : base(fixture)
+    {
+    }
+
+    protected static void UpdateConfigureServices(IServiceCollection services)
+    {
+        services.ConfigureControllers(typeof(DetachedQueryOptionsController));
+    }
+
+    private async Task<List<DetachedCustomer>> PostQueryAsync(Dictionary<string, string> queryOptions)
+    {
+        var client = CreateClient();
+        var body = JsonConvert.SerializeObject(queryOptions);
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync("api/detachedcustomers/apply", content);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        return await response.Content.ReadAsObject<List<DetachedCustomer>>();
+    }
+
+    [Fact]
+    public async Task Apply_Filter_FromDictionary_ReturnsFilteredCustomers()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string> { { "$filter", "Age gt 30" } });
+
+        // Assert
+        Assert.Equal(new[] { 3, 4 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Apply_OrderByTop_FromDictionary_ReturnsOrderedTop()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string>
+        {
+            { "$orderby", "Age desc" },
+            { "$top", "2" }
+        });
+
+        // Assert
+        // Ages: Charlie(40), Dave(35), Alice(30), Eve(28), Bob(25) -> top 2 => 3, 4.
+        Assert.Equal(new[] { 3, 4 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Apply_Skip_FromDictionary_ReturnsSkippedCustomers()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string>
+        {
+            { "$orderby", "Id asc" },
+            { "$skip", "2" }
+        });
+
+        // Assert
+        Assert.Equal(new[] { 3, 4, 5 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Apply_Count_FromDictionary_AppliesWithoutError()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string>
+        {
+            { "$filter", "Age gt 30" },
+            { "$count", "true" }
+        });
+
+        // Assert
+        Assert.Equal(new[] { 3, 4 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Apply_CombinedOptions_FromDictionary_ReturnsExpected()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string>
+        {
+            { "$filter", "Age gt 25" },
+            { "$orderby", "Name asc" },
+            { "$top", "2" }
+        });
+
+        // Assert
+        // Age gt 25 -> Alice(1), Charlie(3), Dave(4), Eve(5); order by Name asc -> Alice, Charlie, Dave, Eve; top 2 => 1, 3.
+        Assert.Equal(new[] { 1, 3 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Apply_EmptyDictionary_FromDictionary_ReturnsAllCustomers()
+    {
+        // Act
+        var result = await PostQueryAsync(new Dictionary<string, string>());
+
+        // Assert
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result.Select(c => c.Id));
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1615,6 +1615,7 @@ ODataQueryParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions {
 	public ODataQueryOptions (Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.AspNetCore.Http.HttpRequest request)
+	public ODataQueryOptions (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, System.Type elementClrType, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path)
 
 	Microsoft.AspNetCore.OData.Query.ApplyQueryOption Apply  { public get; }
 	Microsoft.AspNetCore.OData.Query.ComputeQueryOption Compute  { public get; }
@@ -1654,6 +1655,7 @@ ODataQueryParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.AspNetCore.OData.Query.ODataQueryOptions, IEndpointParameterMetadataProvider {
 	public ODataQueryOptions`1 (Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.AspNetCore.Http.HttpRequest request)
+	public ODataQueryOptions`1 (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path)
 
 	ETag`1 IfMatch  { public get; }
 	ETag`1 IfNoneMatch  { public get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1615,7 +1615,7 @@ ODataQueryParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions {
 	public ODataQueryOptions (Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.AspNetCore.Http.HttpRequest request)
-	public ODataQueryOptions (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, System.Type elementClrType, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path)
+	public ODataQueryOptions (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, System.Type elementClrType, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path, params System.IServiceProvider serviceProvider)
 
 	Microsoft.AspNetCore.OData.Query.ApplyQueryOption Apply  { public get; }
 	Microsoft.AspNetCore.OData.Query.ComputeQueryOption Compute  { public get; }
@@ -1655,7 +1655,7 @@ ODataQueryParameterBindingAttribute(),
 ]
 public class Microsoft.AspNetCore.OData.Query.ODataQueryOptions`1 : Microsoft.AspNetCore.OData.Query.ODataQueryOptions, IEndpointParameterMetadataProvider {
 	public ODataQueryOptions`1 (Microsoft.AspNetCore.OData.Query.ODataQueryContext context, Microsoft.AspNetCore.Http.HttpRequest request)
-	public ODataQueryOptions`1 (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path)
+	public ODataQueryOptions`1 (System.Collections.Generic.IDictionary`2[[System.String],[System.String]] queryParameters, params Microsoft.OData.Edm.IEdmModel model, params Microsoft.OData.UriParser.ODataPath path, params System.IServiceProvider serviceProvider)
 
 	ETag`1 IfMatch  { public get; }
 	ETag`1 IfNoneMatch  { public get; }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
@@ -5,8 +5,11 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Formatter;
@@ -68,6 +71,182 @@ public class ODataQueryOptionsOfTEntityTests
 
         // Assert
         Assert.Equal("10", query.Top.RawValue);
+    }
+
+    [Fact]
+    public void Constructor_SetsProperties_FromDictionary()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 1" },
+            { "$top", "5" }
+        };
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.Equal("Id eq 1", options.RawValues.Filter);
+        Assert.Equal("5", options.RawValues.Top);
+        Assert.IsType<ODataQueryOptions<QCustomer>>(options);
+    }
+
+    [Fact]
+    public void Constructor_SetsAllSupportedODataOptions()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Name eq 'Test'" },
+            { "$orderby", "Id desc" },
+            { "$top", "10" },
+            { "$skip", "2" },
+            { "$select", "Id,Name" },
+            { "$expand", "Orders" },
+            { "$count", "true" },
+            { "$format", "json" },
+            { "$skiptoken", "abc" },
+            { "$deltatoken", "def" },
+            { "$apply", "aggregate(Id with sum as TotalId)" },
+            { "$compute", "Amount mul 2 as DoubleAmount" },
+            { "$search", "Test" }
+        };
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        // Assert
+        Assert.Equal("Name eq 'Test'", options.RawValues.Filter);
+        Assert.Equal("Id desc", options.RawValues.OrderBy);
+        Assert.Equal("10", options.RawValues.Top);
+        Assert.Equal("2", options.RawValues.Skip);
+        Assert.Equal("Id,Name", options.RawValues.Select);
+        Assert.Equal("Orders", options.RawValues.Expand);
+        Assert.Equal("true", options.RawValues.Count);
+        Assert.Equal("json", options.RawValues.Format);
+        Assert.Equal("abc", options.RawValues.SkipToken);
+        Assert.Equal("def", options.RawValues.DeltaToken);
+        Assert.Equal("aggregate(Id with sum as TotalId)", options.RawValues.Apply);
+        Assert.Equal("Amount mul 2 as DoubleAmount", options.RawValues.Compute);
+        Assert.Equal("Test", options.RawValues.Search);
+    }
+
+    [Fact]
+    public void Constructor_Handles_EmptyDictionary()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>();
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.Null(options.RawValues.Filter);
+        Assert.Null(options.RawValues.Top);
+        Assert.Null(options.RawValues.OrderBy);
+        Assert.Null(options.RawValues.Select);
+        Assert.Null(options.RawValues.Expand);
+    }
+
+    [Fact]
+    public void Constructor_Handles_UnknownKeys()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "unknown", "value" },
+            { "$filter", "Id eq 1" }
+        };
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        // Assert
+        Assert.Equal("Id eq 1", options.RawValues.Filter);
+        // Unknown keys should not throw or affect known options
+    }
+
+    [Fact]
+    public void Constructor_Supports_ODataPath()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 1" }
+        };
+        var entitySet = _model.FindDeclaredEntitySet("Customers");
+        var path = new ODataPath(new EntitySetSegment(entitySet));
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(_model, queryParams, path);
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.Equal("Id eq 1", options.RawValues.Filter);
+        Assert.Equal(typeof(QCustomer), options.Context.ElementClrType);
+        Assert.Equal(path, options.Context.Path);
+    }
+
+    [Fact]
+    public void JsonConverter_Deserializes_ODataQueryOptions_FromJson()
+    {
+        // Arrange
+        var json = "{\"$filter\":\"Id eq 1\",\"$top\":\"5\"}";
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ODataQueryOptionsJsonConverter<QCustomer>(_model));
+
+        // Act
+        var odataOptions = JsonSerializer.Deserialize<ODataQueryOptions<QCustomer>>(json, options);
+
+        // Assert
+        Assert.NotNull(odataOptions);
+        Assert.Equal("Id eq 1", odataOptions.RawValues.Filter);
+        Assert.Equal("5", odataOptions.RawValues.Top);
+    }
+
+    [Fact]
+    public void JsonConverter_Serializes_ODataQueryOptions_ToJson()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 1" },
+            { "$top", "5" },
+            { "$orderby", "Name ASC" },
+            { "$expand", "Orders" },
+            { "$select", "Id,Name" }
+        };
+        var odataOptions = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull 
+        };
+        options.Converters.Add(new ODataQueryOptionsJsonConverter<QCustomer>(_model));
+
+        // Act
+        var json = JsonSerializer.Serialize(odataOptions, options);
+
+        // Assert
+        Assert.Contains("\"$filter\":\"Id eq 1\",\"$top\":\"5\",\"$orderby\":\"Name ASC\",\"$select\":\"Id,Name\",\"$expand\":\"Orders\"", json);
+    }
+
+    [Fact]
+    public void Constructor_Throws_OnNullModel()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new ODataQueryOptions<QCustomer>(null, new Dictionary<string, string>()));
+    }
+
+    [Fact]
+    public void Constructor_Throws_OnNullDictionary()
+    {
+        var model = GetEdmModel();
+        Assert.Throws<ArgumentNullException>(() =>
+            new ODataQueryOptions<QCustomer>(model, null));
     }
 
     [Theory]
@@ -246,5 +425,43 @@ public class ODataQueryOptionsOfTEntityTests
 
     public class SubQCustomer : QCustomer
     {
+    }
+
+    public class ODataQueryOptionsJsonConverter<TEntity> : JsonConverter<ODataQueryOptions<TEntity>>
+    {
+        private readonly IEdmModel _edmModel;
+
+        public ODataQueryOptionsJsonConverter(IEdmModel edmModel)
+        {
+            _edmModel = edmModel;
+        }
+
+        public override ODataQueryOptions<TEntity> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+            return new ODataQueryOptions<TEntity>(_edmModel, dict);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ODataQueryOptions<TEntity> value, JsonSerializerOptions options)
+        {
+            var dict = new Dictionary<string, string>
+            {
+                ["$filter"] = value.RawValues.Filter,
+                ["$top"] = value.RawValues.Top,
+                ["$orderby"] = value.RawValues.OrderBy,
+                ["$select"] = value.RawValues.Select,
+                ["$expand"] = value.RawValues.Expand,
+                ["$skip"] = value.RawValues.Skip,
+                ["$count"] = value.RawValues.Count,
+                ["$format"] = value.RawValues.Format,
+                ["$skiptoken"] = value.RawValues.SkipToken,
+                ["$deltatoken"] = value.RawValues.DeltaToken,
+                ["$apply"] = value.RawValues.Apply,
+                ["$compute"] = value.RawValues.Compute,
+                ["$search"] = value.RawValues.Search
+            };
+
+            JsonSerializer.Serialize(writer, dict, options);
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
@@ -84,7 +84,7 @@ public class ODataQueryOptionsOfTEntityTests
         };
 
         // Act
-        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
 
         // Assert
         Assert.NotNull(options);
@@ -115,7 +115,47 @@ public class ODataQueryOptionsOfTEntityTests
         };
 
         // Act
-        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+
+        // Assert
+        Assert.Equal("Name eq 'Test'", options.RawValues.Filter);
+        Assert.Equal("Id desc", options.RawValues.OrderBy);
+        Assert.Equal("10", options.RawValues.Top);
+        Assert.Equal("2", options.RawValues.Skip);
+        Assert.Equal("Id,Name", options.RawValues.Select);
+        Assert.Equal("Orders", options.RawValues.Expand);
+        Assert.Equal("true", options.RawValues.Count);
+        Assert.Equal("json", options.RawValues.Format);
+        Assert.Equal("abc", options.RawValues.SkipToken);
+        Assert.Equal("def", options.RawValues.DeltaToken);
+        Assert.Equal("aggregate(Id with sum as TotalId)", options.RawValues.Apply);
+        Assert.Equal("Amount mul 2 as DoubleAmount", options.RawValues.Compute);
+        Assert.Equal("Test", options.RawValues.Search);
+    }
+
+    [Fact]
+    public void Constructor_SetsAllSupportedODataOptions_Where_EdmModel_IsNull()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Name eq 'Test'" },
+            { "$orderby", "Id desc" },
+            { "$top", "10" },
+            { "$skip", "2" },
+            { "$select", "Id,Name" },
+            { "$expand", "Orders" },
+            { "$count", "true" },
+            { "$format", "json" },
+            { "$skiptoken", "abc" },
+            { "$deltatoken", "def" },
+            { "$apply", "aggregate(Id with sum as TotalId)" },
+            { "$compute", "Amount mul 2 as DoubleAmount" },
+            { "$search", "Test" }
+        };
+
+        // Act
+        var options = new ODataQueryOptions<QCustomer>(queryParams);
 
         // Assert
         Assert.Equal("Name eq 'Test'", options.RawValues.Filter);
@@ -140,7 +180,7 @@ public class ODataQueryOptionsOfTEntityTests
         var queryParams = new Dictionary<string, string>();
 
         // Act
-        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
 
         // Assert
         Assert.NotNull(options);
@@ -162,7 +202,7 @@ public class ODataQueryOptionsOfTEntityTests
         };
 
         // Act
-        var options = new ODataQueryOptions<QCustomer>(_model, queryParams);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
 
         // Assert
         Assert.Equal("Id eq 1", options.RawValues.Filter);
@@ -181,7 +221,7 @@ public class ODataQueryOptionsOfTEntityTests
         var path = new ODataPath(new EntitySetSegment(entitySet));
 
         // Act
-        var options = new ODataQueryOptions<QCustomer>(_model, queryParams, path);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model, path);
 
         // Assert
         Assert.NotNull(options);
@@ -219,7 +259,8 @@ public class ODataQueryOptionsOfTEntityTests
             { "$expand", "Orders" },
             { "$select", "Id,Name" }
         };
-        var odataOptions = new ODataQueryOptions<QCustomer>(_model, queryParams);
+
+        var odataOptions = new ODataQueryOptions<QCustomer>(queryParams, _model);
 
         var options = new JsonSerializerOptions
         {
@@ -235,18 +276,11 @@ public class ODataQueryOptionsOfTEntityTests
     }
 
     [Fact]
-    public void Constructor_Throws_OnNullModel()
-    {
-        Assert.Throws<ArgumentNullException>(() =>
-            new ODataQueryOptions<QCustomer>(null, new Dictionary<string, string>()));
-    }
-
-    [Fact]
     public void Constructor_Throws_OnNullDictionary()
     {
         var model = GetEdmModel();
         Assert.Throws<ArgumentNullException>(() =>
-            new ODataQueryOptions<QCustomer>(model, null));
+            new ODataQueryOptions<QCustomer>(null, model));
     }
 
     [Theory]
@@ -439,7 +473,7 @@ public class ODataQueryOptionsOfTEntityTests
         public override ODataQueryOptions<TEntity> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
-            return new ODataQueryOptions<TEntity>(_edmModel, dict);
+            return new ODataQueryOptions<TEntity>(dict, _edmModel);
         }
 
         public override void Write(Utf8JsonWriter writer, ODataQueryOptions<TEntity> value, JsonSerializerOptions options)

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
@@ -28,6 +28,8 @@ public class ODataQueryOptionsOfTEntityTests
 {
     private static IEdmModel _model = GetEdmModel();
 
+    private static IEdmModel _navModel = GetNavEdmModel();
+
     [Fact]
     public void Ctor_Throws_Argument_IfContextIsofDifferentEntityType()
     {
@@ -443,10 +445,324 @@ public class ODataQueryOptionsOfTEntityTests
             () => query.ApplyTo(Enumerable.Empty<QCustomer>().AsQueryable(), new ODataQuerySettings()));
     }
 
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesFilter()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 2" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Bob" },
+            new QCustomer { Id = 3, Name = "Charlie" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<QCustomer>().ToList();
+
+        // Assert
+        var single = Assert.Single(result);
+        Assert.Equal(2, single.Id);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesOrderByTopAndSkip()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$orderby", "Id desc" },
+            { "$skip", "1" },
+            { "$top", "2" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Bob" },
+            new QCustomer { Id = 3, Name = "Charlie" },
+            new QCustomer { Id = 4, Name = "Dave" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<QCustomer>().ToList();
+
+        // Assert
+        Assert.Equal(new[] { 3, 2 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesSelect()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$select", "Name" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithServiceProvider_AppliesFilterAndWiresRequestContainer()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 3" }
+        };
+        var serviceProvider = BuildODataServiceProvider(_model);
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model, path: null, serviceProvider: serviceProvider);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 3, Name = "Charlie" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<QCustomer>().ToList();
+
+        // Assert
+        Assert.Same(serviceProvider, options.Context.RequestContainer);
+        var single = Assert.Single(result);
+        Assert.Equal(3, single.Id);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithNullModel_ThrowsInvalidOperation()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id eq 1" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" }
+        }.AsQueryable();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => options.ApplyTo(customers));
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesCount()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id gt 1" },
+            { "$count", "true" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Bob" },
+            new QCustomer { Id = 3, Name = "Charlie" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<QCustomer>().ToList();
+
+        // Assert
+        Assert.Equal(new[] { 2, 3 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesCompute()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$compute", "Id mul 2 as DoubleId" },
+            { "$select", "Name,DoubleId" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 5, Name = "Eve" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesApply()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$apply", "aggregate(Id with sum as TotalId)" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Bob" },
+            new QCustomer { Id = 3, Name = "Charlie" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        // aggregate with no groupby produces a single aggregated row.
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesCombinedOptions()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$filter", "Id gt 1" },
+            { "$orderby", "Name asc" },
+            { "$top", "2" },
+            { "$select", "Name" }
+        };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Charlie" },
+            new QCustomer { Id = 3, Name = "Bob" },
+            new QCustomer { Id = 4, Name = "Dave" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        // Id gt 1 -> {Charlie, Bob, Dave}; order by Name asc -> {Bob, Charlie, Dave}; top 2 -> 2 rows.
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AppliesExpand()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            { "$expand", "Order" }
+        };
+        var options = new ODataQueryOptions<NavCustomer>(queryParams, _navModel);
+        var customers = new List<NavCustomer>
+        {
+            new NavCustomer { Id = 1, Name = "Alice", Order = new NavOrder { Id = 10, Amount = 100m } },
+            new NavCustomer { Id = 2, Name = "Bob", Order = new NavOrder { Id = 20, Amount = 200m } }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithoutHttpRequest_AutoExpandsNavigation()
+    {
+        // Arrange
+        // AutoNavCustomer is annotated with [AutoExpand], so ApplyTo must invoke the
+        // auto-select/expand path (AddAutoSelectExpandProperties -> GetODataQueryParameters)
+        // even though no $expand was supplied. This directly regresses the null-Request
+        // NullReferenceException reported for the stand-alone constructor.
+        var queryParams = new Dictionary<string, string>();
+        var options = new ODataQueryOptions<AutoNavCustomer>(queryParams, _navModel);
+        var customers = new List<AutoNavCustomer>
+        {
+            new AutoNavCustomer { Id = 1, Name = "Alice", Order = new NavOrder { Id = 10, Amount = 100m } }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<object>().ToList();
+
+        // Assert
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ApplyTo_FromDictionaryConstructor_WithEmptyDictionary_ReturnsAllItems()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>();
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+        var customers = new List<QCustomer>
+        {
+            new QCustomer { Id = 1, Name = "Alice" },
+            new QCustomer { Id = 2, Name = "Bob" }
+        }.AsQueryable();
+
+        // Act
+        var result = options.ApplyTo(customers).Cast<QCustomer>().ToList();
+
+        // Assert
+        Assert.Equal(new[] { 1, 2 }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public void IfMatch_FromDictionaryConstructor_WithoutHttpRequest_ReturnsNull()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string> { { "$filter", "Id eq 1" } };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+
+        // Act & Assert
+        Assert.Null(options.IfMatch);
+    }
+
+    [Fact]
+    public void IfNoneMatch_FromDictionaryConstructor_WithoutHttpRequest_ReturnsNull()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string> { { "$filter", "Id eq 1" } };
+        var options = new ODataQueryOptions<QCustomer>(queryParams, _model);
+
+        // Act & Assert
+        Assert.Null(options.IfNoneMatch);
+    }
+
+    private static IServiceProvider BuildODataServiceProvider(IEdmModel model)
+    {
+        // Build a genuine OData per-route service container (the same kind normally
+        // obtained from HttpRequest.GetRouteServices()).
+        HttpRequest request = RequestFactory.Create(model, opt => opt.AddRouteComponents(model));
+        return request.GetRouteServices();
+    }
+
     private static IEdmModel GetEdmModel()
     {
         ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
         builder.EntitySet<QCustomer>("Customers");
+        return builder.GetEdmModel();
+    }
+
+    private static IEdmModel GetNavEdmModel()
+    {
+        ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+        builder.EntitySet<NavCustomer>("NavCustomers");
+        builder.EntitySet<AutoNavCustomer>("AutoNavCustomers");
+        builder.EntitySet<NavOrder>("NavOrders");
         return builder.GetEdmModel();
     }
 
@@ -459,6 +775,32 @@ public class ODataQueryOptionsOfTEntityTests
 
     public class SubQCustomer : QCustomer
     {
+    }
+
+    public class NavCustomer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public NavOrder Order { get; set; }
+    }
+
+    [AutoExpand]
+    public class AutoNavCustomer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public NavOrder Order { get; set; }
+    }
+
+    public class NavOrder
+    {
+        public int Id { get; set; }
+
+        public decimal Amount { get; set; }
     }
 
     public class ODataQueryOptionsJsonConverter<TEntity> : JsonConverter<ODataQueryOptions<TEntity>>

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Query/ODataQueryOptionsOfTEntityTests.cs
@@ -274,7 +274,13 @@ public class ODataQueryOptionsOfTEntityTests
         var json = JsonSerializer.Serialize(odataOptions, options);
 
         // Assert
-        Assert.Contains("\"$filter\":\"Id eq 1\",\"$top\":\"5\",\"$orderby\":\"Name ASC\",\"$select\":\"Id,Name\",\"$expand\":\"Orders\"", json);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal("Id eq 1", root.GetProperty("$filter").GetString());
+        Assert.Equal("5", root.GetProperty("$top").GetString());
+        Assert.Equal("Name ASC", root.GetProperty("$orderby").GetString());
+        Assert.Equal("Id,Name", root.GetProperty("$select").GetString());
+        Assert.Equal("Orders", root.GetProperty("$expand").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Description

fixes #1531 

This PR introduces a new constructor to both `ODataQueryOptions` and `ODataQueryOptions<TEntity>` that allows initialization directly from an `IDictionary<string, string>` and an optional `IEdmModel/ODataPath`, removing the requirement for an HttpRequest or ASP.NET Core infrastructure. This enables easier instantiation of OData query options in scenarios such as deserialization from JSON, tool integration, and testing.

## Key changes:

- Added ODataQueryOptions(IDictionary<string, string> queryParameters, ODataQueryContext context) constructor to support dictionary-based initialization.
- Added ODataQueryOptions<TEntity>(IEdmModel model, IDictionary<string, string> queryParameters, ODataPath path = null) constructor for generic scenarios.