### PR TITLE
Use the configured HandleNullPropagationOption

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -1227,12 +1227,10 @@ public class SelectExpandBinder : QueryBinder, ISelectExpandBinder
         return source;
     }
 
-    private QueryBinderContext CreateSubContext(QueryBinderContext context, ComputeClause computeClause, Type clrElementType,
-        HandleNullPropagationOption option = HandleNullPropagationOption.True)
+    private QueryBinderContext CreateSubContext(QueryBinderContext context, ComputeClause computeClause, Type clrElementType)
     {
         ODataQuerySettings newSettings = new ODataQuerySettings();
         newSettings.CopyFrom(context.QuerySettings);
-        newSettings.HandleNullPropagation = option;
         QueryBinderContext binderContext = new QueryBinderContext(context, newSettings, clrElementType);
         if (computeClause != null)
         {

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/SelectExpandBinderTest.cs
@@ -1948,6 +1948,59 @@ public class SelectExpandBinderTest
         var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as QueryCustomer;
         Assert.Null(customer);
     }
+
+    [Theory]
+    [InlineData(HandleNullPropagationOption.True)]
+    [InlineData(HandleNullPropagationOption.False)]
+    public void CreatePropertyValueExpression_Collection_WorksWithNavigationPropertyFilter_HandleNullPropagationOption(HandleNullPropagationOption nullOption)
+    {
+        // Arrange
+        _settings.HandleNullPropagation = nullOption;
+        var source = Expression.Constant(new QueryCustomer
+        {
+            Orders = new[]
+            {
+                new QueryOrder { Id = 1, Customer = new QueryCustomer { Name = "TestCustomer" } },
+                new QueryOrder { Id = 2, Customer = new QueryCustomer { Name = "OtherCustomer" } }
+            }
+        });
+
+        SelectExpandBinder binder = GetBinder<QueryCustomer>(_model);
+        var ordersProperty = _customer.NavigationProperties().Single(p => p.Name == "Orders");
+
+        SelectExpandClause selectExpand = ParseSelectExpand(null, "Orders($filter=Customer/Name eq 'TestCustomer')", _model, _customer, _customers);
+        ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+        Assert.NotNull(expandItem);
+        Assert.NotNull(expandItem.FilterOption);
+
+        // Act
+        var filterInExpand = binder.CreatePropertyValueExpression(_queryBinderContext, _customer, ordersProperty, source, expandItem.FilterOption);
+
+        // Assert
+        if (nullOption == HandleNullPropagationOption.True)
+        {
+            Assert.Equal(
+                string.Format(
+                    "IIF((value({0}) == null), null, IIF((value({0}).Orders == null), null, " +
+                    "value({0}).Orders.Where($it => (IIF(($it.Customer == null), null, $it.Customer.Name) == value({1}).TypedProperty))))",
+                    source.Type,
+                    "Microsoft.AspNetCore.OData.Query.Container.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]"),
+                filterInExpand.ToString());
+        }
+        else
+        {
+            Assert.Equal(
+                string.Format(
+                    "value({0}).Orders.Where($it => ($it.Customer.Name == value({1}).TypedProperty))",
+                    source.Type,
+                    "Microsoft.AspNetCore.OData.Query.Container.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]"),
+                filterInExpand.ToString());
+        }
+
+        var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<QueryOrder>;
+        QueryOrder order = Assert.Single(orders);
+        Assert.Equal(1, order.Id);
+    }
     #endregion
 
     [Fact]


### PR DESCRIPTION
# Fix unexpected behavior when HandleNullPropagationOption is configured in ODataQuerySettings

## Context
Although a developer can set the value of `context.QuerySettings.HandleNullPropagationOption` using
```csharp
[EnableQuery(HandleNullPropagation = HandleNullPropagationOption.False)]
```
or using DI with `ODataQuerySettings`
```csharp
services.AddSingleton(new ODataQuerySettings {
    HandleNullPropagation = HandleNullPropagationOption.False
});
```
In the current implementation, when execution enters `SelectExpandBinder` the setting is sometimes forced to `true`, regardless of the developer's configuration.

This is my first time contributing to this library, although I have used it extensively. I tried to trace the history of this behavior but couldn't find a clear reason for forcing the option. The oldest commit I found that introduced this change is [Commit: Merge routing, formatter, query into one](https://github.com/DanielBertocci/AspNetCoreOData/commit/de936ef813d6bf8d2bb12b85ad160a8c32a92dbd) from five years ago, and the behavior appears to have been retained through subsequent refactorings.

@xuzhg — you authored that commit and have recently worked on this file, so perhaps you can help if I've missed something.

All the tests are green, and I don't think if it is valuable to introduce a new one to validate this behavior.

## Current workaround (project side)
I register a custom `FilterBinder` that forces the `HandleNullPropagation` setting:
```csharp
class CustomODataFilterBinder : FilterBinder
{
    public override Expression Bind(QueryNode node, QueryBinderContext context)
    {
        context.QuerySettings.HandleNullPropagation = HandleNullPropagationOption.False;
        return base.Bind(node, context);
    }
}
```

## How I encountered this issue
I have a project that uses Entity Framework with PostgreSQL. I needed to build OData queries involving many-to-many relationships, for example:
1. `nodes?$expand=children($filter=children/$count gt 0)`
2. `customers?$expand=orders($filter=products/$count eq 0)`
3. `customers?$expand=orders($filter=products/any(c: c/name eq 'Sample'))`

In case 1, even though `HandleNullPropagationOption` was forced to `true`, the expression that joined the same table did not cause issues. However, when joining different tables (cases 2 and 3), the generated expression included null checks that Entity Framework could not translate.