### PR TITLE
Fixes #1545: ODataOptions.TimeZone is ignored; dates are always serialized using TimeZoneInfo.Local

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Results;
+using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OData;
@@ -98,6 +99,11 @@ public static class HttpContextExtensions
 
         // Check if the endpoint is a minimal endpoint.
         var endpoint = httpContext.GetEndpoint();
+        if (endpoint?.Metadata.GetMetadata<IODataRoutingMetadata>() != null)
+        {
+            return false;
+        }
+
         return endpoint?.Metadata.GetMetadata<HttpMethodAttribute>() == null
                && endpoint?.Metadata.GetMetadata<ODataMiniMetadata>() != null;
     }


### PR DESCRIPTION
Fixes #1545: 

Root cause:

1) If `ODataQueryOptions<T>` is used as parameter in the controller action, for example:

```C#
  [HttpGet]
  public IActionResult Get(ODataQueryOptions<TestModel> options)
  {
      return Ok(_models.AsQueryable());
  }
```

or minimal API as:
```C#
app.MapGet("/v2/test", (ODataQueryOptions<TestModel> options) =>
{
    IList<TestModel> _model = new[]
        {
        new TestModel { Id = 1, Name = "Test111", Date = DateTime.UtcNow },
        new TestModel { Id = 2, Name = "Testaaa", Date = DateTime.UtcNow.AddDays(1) }
    };

    return options.ApplyTo(_model.AsQueryable());
})
    .WithODataResult();
```
Then, the following code is executed ahead:

https://github.com/OData/AspNetCoreOData/blob/main/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptionsOfT.cs#L132

```C#
    public static void PopulateMetadata(ParameterInfo parameter, EndpointBuilder builder)
    {
        // Make sure we have the metadata added into the endpoint.
        // Shall we build the 'EdmModel' here? ==> Emm...No, because the 'convention' runs after this population.
        // If developer calls 'WithODataModel()', then any model created here will be replaced. So, no need/required to create model here.
        ODataEndpointConventionBuilderExtensions.ConfigureODataMetadata(builder, null);
   }
```

The processing codes is to add 'ODataMiniMetadata' into the endpoint metadata container, even it's controller-based application and minimal api application. 

Then, a request coming as: `GET {{WebApplication2_HostAddress}}/v1/Test`

The library tries to retrieve the 'TimeZone' configuration from the options, here: https://github.com/OData/AspNetCoreOData/blob/main/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs#L102


but, https://github.com/OData/AspNetCoreOData/blob/main/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs#L92 only checks 'ODataMiniMetadata'. 

in this case, controller-based application is also treated as minimal api. That's wrong.

This PR is to fix that by checking 'ODataRoutingMetadata' first. In the controller-based, the endpoint contains 'ODataRoutingMetadata', meanwhile, it's not in the minimal api.

