### PR TITLE
Update VersionStartYear to 2022 in settings

### DIFF
--- a/tool/builder.versions.settings.targets
+++ b/tool/builder.versions.settings.targets
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <!--
-    The revision number is a date code. Note that this only work for 6 years before the year part (year minus 2020)
+    The revision number is a date code. Note that this only work for 6 years before the year part (year minus 2022)
     overflows the UInt16. The system conversion below will throw errors when this happens.
   -->
   <PropertyGroup>
-    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2020</VersionStartYear>
+    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2022</VersionStartYear>
     <VersionDateCode>$([System.Convert]::ToUInt16('$([MSBuild]::Add(1, $([MSBuild]::Subtract($([System.DateTime]::Now.Year), $(VersionStartYear)))))$([System.DateTime]::Now.ToString("MMdd"))'))</VersionDateCode>
     <VersionRevision Condition="'$(VersionRevision)' == '' OR '$(VersionRevision)' == '0'">$([System.Convert]::ToString($(VersionDateCode)))</VersionRevision>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2020</VersionStartYear>
+    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2022</VersionStartYear>
     <VersionMajor Condition="'$(VersionMajor)' == '0'">INVALID_VersionMajor</VersionMajor>
     <VersionMajor Condition="'$(VersionMajor)' == ''">INVALID_VersionMajor</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">INVALID_VersionMinor</VersionMinor>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fixes the following error that is observed when trying to load the solution:

> The expression "[System.Convert]::ToUInt16(70106)" cannot be evaluated. Value was either too large or too small for a UInt16.  C:\AspNetCoreOData\tool\builder.versions.settings.targets

Issue responsible for the pipeline failure. When the `VersionStartYear` falls too far behind, the following calculation starts to fail:
 ```
<VersionDateCode>$([System.Convert]::ToUInt16('$([MSBuild]::Add(1, $([MSBuild]::Subtract($([System.DateTime]::Now.Year), $(VersionStartYear)))))$([System.DateTime]::Now.ToString("MMdd"))'))</VersionDateCode>
```

We usually resolve the issue by moving the date but we should investigate whether `VersionDateCode` is used anywhere