### PR TITLE
Tests on linux fail because of hardcoded line-endings

### DIFF
--- a/test/Microsoft.AspNetCore.OData.Tests/Commons/ExceptionAssert.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Commons/ExceptionAssert.cs
@@ -296,7 +296,7 @@ public class ExceptionAssert
             exceptionMessage = exceptionMessage + " (Parameter '" + paramName + "')";
             if (actualValue != null)
             {
-                exceptionMessage += string.Format(CultureInfo.CurrentCulture, "\r\nActual value was {0}.", actualValue);
+                exceptionMessage += string.Format(CultureInfo.CurrentCulture, Environment.NewLine + "Actual value was {0}.", actualValue);
             }
         }
 
@@ -545,11 +545,11 @@ public class ExceptionAssert
         {
             if (!partialMatch)
             {
-                Assert.Equal(expectedMessage, exception.Message);
+                Assert.Equal(expectedMessage.ReplaceLineEndings(), exception.Message.ReplaceLineEndings());
             }
             else
             {
-                Assert.Contains(expectedMessage, exception.Message);
+                Assert.Contains(expectedMessage.ReplaceLineEndings(), exception.Message.ReplaceLineEndings());
             }
         }
     }

--- a/test/Microsoft.AspNetCore.OData.Tests/Extensions/SerializableErrorExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Extensions/SerializableErrorExtensionsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.OData;
+using NuGet.Frameworks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Extensions;
@@ -39,7 +40,7 @@ public class SerializableErrorExtensionsTests
 
         // Assert
         Assert.NotNull(error);
-        Assert.Equal("key1:\r\nTest Error 1\r\nTest Error 2\r\n\r\nkey3:\r\nTest Error 3", error.Message);
+        Assert.Equal("key1:\r\nTest Error 1\r\nTest Error 2\r\n\r\nkey3:\r\nTest Error 3", error.Message, ignoreLineEndingDifferences: true);
         Assert.Null(error.Code);
         Assert.Null(error.InnerError);
         Assert.Equal(3, error.Details.Count);
@@ -63,11 +64,11 @@ public class SerializableErrorExtensionsTests
 
         // Assert
         Assert.NotNull(error);
-        Assert.Equal("key1:\r\nTest Error 1\r\n\r\nkey2:\r\nTest Error 2", error.Message);
+        Assert.Equal("key1:\r\nTest Error 1\r\n\r\nkey2:\r\nTest Error 2", error.Message, ignoreLineEndingDifferences: true);
         Assert.Null(error.Code);
         Assert.True(error.InnerError.Properties.TryGetValue(SerializableErrorKeys.MessageKey, out ODataValue odataValue));
         var exceptionMessage = Assert.IsType<ODataPrimitiveValue>(odataValue).Value as string;
-        Assert.Equal("key3:\r\nTest Error 3", exceptionMessage);
+        Assert.Equal("key3:\r\nTest Error 3", exceptionMessage, ignoreLineEndingDifferences: true);
         Assert.Equal(2, error.Details.Count);
     }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Extensions/SerializableErrorExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Extensions/SerializableErrorExtensionsTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.OData;
-using NuGet.Frameworks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.Tests.Extensions;

--- a/test/Microsoft.AspNetCore.OData.Tests/Results/PageResultOfTTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Results/PageResultOfTTests.cs
@@ -53,7 +53,7 @@ public class PageResultOfTTests
 
         // Assert
         ArgumentOutOfRangeException exception = ExceptionAssert.Throws<ArgumentOutOfRangeException>(test);
-        Assert.Contains("Value must be greater than or equal to 0. (Parameter 'value')\r\nActual value was -1.", exception.Message);
+        Assert.Contains("Value must be greater than or equal to 0. (Parameter 'value')\r\nActual value was -1.".ReplaceLineEndings(), exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
This fixes tests using hardcoded returnvalue comparisons using preset newlines in windows format (CRLF).
Handling here is mosly using ReplaceLineEndings and ignoreLineEndingDifferences parameter to use the environment newlines instead.