### PR TITLE
Fix: Handle null propagation for nullable navigation properties when expanding and ordering

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Edm/EdmHelpers.cs
@@ -520,4 +520,18 @@ internal static class EdmHelpers
         Contract.Assert(model != null);
         return model.GetAnnotationValue<OperationTitleAnnotation>(operation);
     }
+
+    /// <summary>
+    /// Tests whether a <see cref="IEdmProperty"/> is a nullable navigation property.
+    /// </summary>
+    /// <param name="property">The property to test.</param>
+    /// <returns>True if the property is a nullable navigation property, false otherwise.</returns>
+    internal static bool IsNullableNavigationProperty(this IEdmProperty property)
+    {
+        if (property is IEdmNavigationProperty navigationProperty)
+        {
+            return navigationProperty.Type.IsNullable;
+        }
+        return false;
+    }
 }

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -2301,6 +2301,13 @@
             <param name="isNullable">Nullable value.</param>
             <returns>The Edm type reference.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Edm.EdmHelpers.IsNullableNavigationProperty(Microsoft.OData.Edm.IEdmProperty)">
+            <summary>
+            Tests whether a <see cref="T:Microsoft.OData.Edm.IEdmProperty"/> is a nullable navigation property.
+            </summary>
+            <param name="property">The property to test.</param>
+            <returns>True if the property is a nullable navigation property, false otherwise.</returns>
+        </member>
         <member name="T:Microsoft.AspNetCore.OData.Edm.EdmModelAnnotationExtensions">
             <summary>
             The extensions for the <see cref="T:Microsoft.OData.Edm.IEdmModel"/> for the annotations.

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -1261,9 +1261,11 @@ public abstract partial class QueryBinder
     {
         string propertyName = context.Model.GetClrPropertyName(property);
         propertyPath = propertyPath ?? propertyName;
-        if (context.QuerySettings.HandleNullPropagation == HandleNullPropagationOption.True && ExpressionBinderHelper.IsNullable(source.Type) &&
+        if (context.QuerySettings.HandleNullPropagation == HandleNullPropagationOption.True &&
             source != context.CurrentParameter &&
-            !IsFlatteningSource(source, context))
+            !IsFlatteningSource(source, context) &&
+            (ExpressionBinderHelper.IsNullable(source.Type) ||
+            property.IsNullableNavigationProperty()))
         {
             Expression cleanSource = ExpressionBinderHelper.RemoveInnerNullPropagation(source, context.QuerySettings);
             Expression propertyAccessExpression = null;


### PR DESCRIPTION
## Summary

Fixes null propagation handling when expanding nullable navigation properties and ordering by their nullable properties.

## Changes

- Added `IsNullableNavigationProperty()` extension method to `IEdmProperty` to properly identify nullable navigation properties
- Updated `QueryBinder.CreatePropertyAccessExpression()` to include nullable navigation properties in null propagation checks
- The fix ensures that when `HandleNullPropagation` is enabled, both nullable value types AND nullable navigation properties are properly handled during query binding

## Why this matters

Previously, when expanding a nullable navigation property and then ordering by an integer property of that same nullable navigation property, the null propagation logic would not correctly handle the nullable navigation property case, potentially causing runtime errors or incorrect query results.

The updated logic now checks for either:
1. Nullable value types (`ExpressionBinderHelper.IsNullable(source.Type)`)
2. Nullable navigation properties (`property.IsNullableNavigationProperty()`)

This ensures consistent null handling across both scenarios.