### PR TITLE
Fix: Allow to Prefer maxpagesize from client when no PageSize specified

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -332,6 +332,7 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         bool shouldApplyQuery = responseValue != null &&
            request.GetEncodedUrl() != null &&
            (!String.IsNullOrWhiteSpace(request.QueryString.Value) ||
+           request.Headers.ContainsKey("Prefer") ||
            _querySettings.PageSize.HasValue ||
            _querySettings.ModelBoundPageSize.HasValue ||
            singleResultCollection != null ||

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -489,7 +489,14 @@ public class ODataQueryOptions
         int preferredPageSize = -1;
         if (RequestPreferenceHelpers.RequestPrefersMaxPageSize(Request.Headers, out preferredPageSize))
         {
-            pageSize = Math.Min(pageSize, preferredPageSize);
+            if (pageSize == -1)
+            {
+                pageSize = preferredPageSize;
+            }
+            else
+            {
+                pageSize = Math.Min(pageSize, preferredPageSize);
+            }
         }
 
         ODataFeature odataFeature = Request.ODataFeature() as ODataFeature;

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingControllers.cs
@@ -52,6 +52,26 @@ public class ServerSidePagingCustomersController : ODataController
     }
 }
 
+public class ServerSidePagingCustomersWithoutPagesizeController : ODataController
+{
+    private readonly IList<ServerSidePagingCustomerWithoutPagesize> _serverSidePagingCustomersWithoutPageSize;
+
+    public ServerSidePagingCustomersWithoutPagesizeController()
+    {
+        _serverSidePagingCustomersWithoutPageSize = Enumerable.Range(1, 7)
+            .Select(i => new ServerSidePagingCustomerWithoutPagesize
+            {
+                Id = i,
+            }).ToList();
+    }
+
+    [EnableQuery]
+    public IActionResult Get()
+    {
+        return Ok(_serverSidePagingCustomersWithoutPageSize);
+    }
+}
+
 public class ServerSidePagingEmployeesController : ODataController
 {
     private static List<ServerSidePagingEmployee> employees = new List<ServerSidePagingEmployee>(

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -30,6 +30,12 @@ public class ServerSidePagingOrder
     public ServerSidePagingCustomer ServerSidePagingCustomer { get; set; }
 }
 
+public class ServerSidePagingCustomerWithoutPagesize
+{
+    [Key]
+    public int Id { get; set; }
+}
+
 public class ServerSidePagingEmployee
 {
     public int Id { get; set; }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ServerSidePaging/ServerSidePagingTests.cs
@@ -38,6 +38,7 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
         IEdmModel edmModel = GetEdmModel();
         services.ConfigureControllers(
             typeof(ServerSidePagingCustomersController),
+            typeof(ServerSidePagingCustomersWithoutPagesizeController),
             typeof(ServerSidePagingEmployeesController),
             typeof(ContainmentPagingCustomersController),
             typeof(ContainmentPagingCompanyController),
@@ -54,6 +55,7 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
         ODataModelBuilder builder = new ODataConventionModelBuilder();
         builder.EntitySet<ServerSidePagingOrder>("ServerSidePagingOrders").EntityType.HasRequired(d => d.ServerSidePagingCustomer);
         builder.EntitySet<ServerSidePagingCustomer>("ServerSidePagingCustomers").EntityType.HasMany(d => d.ServerSidePagingOrders);
+        builder.EntitySet<ServerSidePagingCustomerWithoutPagesize>("ServerSidePagingCustomersWithoutPagesize");
         builder.EntitySet<ContainmentPagingCustomer>("ContainmentPagingCustomers");
         builder.Singleton<ContainmentPagingCustomer>("ContainmentPagingCompany");
         builder.EntitySet<NoContainmentPagingCustomer>("NoContainmentPagingCustomers");
@@ -117,6 +119,78 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
             bool nextLinkFound = document.RootElement.TryGetProperty("@odata.nextLink", out JsonElement nextLink);
             Assert.True(nextLinkFound);
             Assert.Equal("http://localhost/prefix/ServerSidePagingCustomers?$expand=ServerSidePagingOrders&$skip=5", nextLink.GetString());
+        }
+    }
+
+    [Fact]
+    public async Task ClientCanOwerwritePageSizeLowerThanPageSize()
+    {
+        // Arrange
+        string requestUri = "/prefix/ServerSidePagingCustomers";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Add("Prefer", "maxpagesize=1");
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+        string content = await response.Content.ReadAsStringAsync();
+
+        using (JsonDocument document = JsonDocument.Parse(content))
+        {
+            bool found = document.RootElement.TryGetProperty("value", out JsonElement value);
+            Assert.True(found);
+
+            bool nextLinkFound = document.RootElement.TryGetProperty("@odata.nextLink", out JsonElement nextLink);
+            Assert.True(nextLinkFound);
+            Assert.Equal("http://localhost/prefix/ServerSidePagingCustomers?$skip=1", nextLink.GetString());
+        }
+    }
+
+    [Fact]
+    public async Task ClientCanNotOwerwritePageSizeGreaterThanPageSize()
+    {
+        // Arrange
+        string requestUri = "/prefix/ServerSidePagingCustomers";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Add("Prefer", "maxpagesize=8");
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+        string content = await response.Content.ReadAsStringAsync();
+
+        using (JsonDocument document = JsonDocument.Parse(content))
+        {
+            bool found = document.RootElement.TryGetProperty("value", out JsonElement value);
+            Assert.True(found);
+
+            bool nextLinkFound = document.RootElement.TryGetProperty("@odata.nextLink", out JsonElement nextLink);
+            Assert.True(nextLinkFound);
+            Assert.Equal("http://localhost/prefix/ServerSidePagingCustomers?$skip=5", nextLink.GetString());
+        }
+    }
+
+    [Fact]
+    public async Task ClientCanSetMaxPageSizeIfNoPageSize()
+    {
+        // Arrange
+        string requestUri = "/prefix/ServerSidePagingCustomersWithoutPagesize";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Add("Prefer", "maxpagesize=1");
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+        string content = await response.Content.ReadAsStringAsync();
+
+        using (JsonDocument document = JsonDocument.Parse(content))
+        {
+            bool found = document.RootElement.TryGetProperty("value", out JsonElement value);
+            Assert.True(found);
+
+            bool nextLinkFound = document.RootElement.TryGetProperty("@odata.nextLink", out JsonElement nextLink);
+            Assert.True(nextLinkFound);
+            Assert.Equal("http://localhost/prefix/ServerSidePagingCustomersWithoutPagesize?$skip=1", nextLink.GetString());
         }
     }
 
@@ -254,7 +328,7 @@ public class ServerSidePagingTests : WebApiTestBase<ServerSidePagingTests>
         // Act
         var response = await client.SendAsync(request);
         var content = await response.Content.ReadAsStringAsync();
-         
+
         // Assert
         Assert.Contains("/prefix/UntypedPagingCustomerOrders/1/Orders?$skip=2", content);
         Assert.Contains("/prefix/UntypedPagingCustomerOrders/2/Orders?$skip=2", content);


### PR DESCRIPTION
[Preference maxpagesize](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_Preferencemaxpagesizeodatamaxpagesiz) should be applied to resulting query without server side limiting

MR created to dev-10.x branch for correctly working with E2E tests

Tests `ClientCanOwerwritePageSizeLowerThanPageSize`, `ClientCanNotOwerwritePageSizeGreaterThanPageSize` have been added only for checking how `maxpagesize` works with `PageSize`