### PR TITLE
Fix: Support for case sensitive properties

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -281,7 +281,7 @@ internal static class ExpressionHelpers
     public static LambdaExpression GetPropertyAccessLambda(Type type, string propertyName)
     {
         ParameterExpression odataItParameter = Expression.Parameter(type, "$it");
-        MemberExpression propertyAccess = Expression.Property(odataItParameter, propertyName);
+        MemberExpression propertyAccess = Expression.Property(odataItParameter, type.GetProperty(propertyName));
         return Expression.Lambda(propertyAccess, odataItParameter);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -1303,7 +1303,7 @@ public abstract partial class QueryBinder
         Expression propertyValue = source;
         foreach (string propertyName in propertyNameParts)
         {
-            propertyValue = Expression.Property(propertyValue, propertyName);
+            propertyValue = Expression.Property(propertyValue, propertyValue.Type.GetProperty(propertyName));
 
             // Consider a scenario like:
             // Sales?$apply=compute(Amount mul Product/TaxRate as Tax)/compute(Amount add Tax as Total,Amount div 10 as Discount)/compute(Total sub Discount as SalePrice)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveControllers.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveControllers.cs
@@ -5,12 +5,13 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Deltas;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.OData.E2E.Tests.PropertyNameCaseSensitive;
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.OData.E2E.Tests.PropertyNameCaseSensitive;
 public class BillsController : ODataController
 {
     [EnableQuery]
-    public IActionResult Post([FromBody]Bill bill)
+    public IActionResult Post([FromBody] Bill bill)
     {
         Assert.NotNull(bill);
 
@@ -82,5 +83,33 @@ public class BillsController : ODataController
             });
 
         return Ok(false);
+    }
+}
+
+
+public class DifferentPropertyCasesController : ODataController
+{
+    [EnableQuery(PageSize = 1)]
+    public ActionResult<IQueryable<DifferentPropertyCase>> Get()
+    {
+        return Ok(new DifferentPropertyCase[]
+        {
+            new DifferentPropertyCase
+            {
+                Id = 1,
+                Field = "Pascal",
+                FIELD = "Upper",
+                Nested = [
+                    new NestedDifferentPropertyCase{
+                        Id = 1,
+                        ID = "some old id 2",
+                    },
+                    new NestedDifferentPropertyCase{
+                        Id = 2,
+                        ID = "some old id 1",
+                    }
+                ]
+            }
+        }.AsQueryable());
     }
 }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveDataModel.cs
@@ -57,3 +57,16 @@ public class BillDetail
 
     public IList<int> DimensionInCentimeter { get; set; }
 }
+
+public class DifferentPropertyCase
+{
+    public int Id { get; set; }
+    public string Field { get; set; }
+    public string FIELD { get; set; }
+    public ICollection<NestedDifferentPropertyCase> Nested { get; set; }
+}
+public class NestedDifferentPropertyCase
+{
+    public int Id { get; set; }
+    public string ID { get; set; }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/PropertyNameCaseSensitive/PropertyNameCaseSensitiveTest.cs
@@ -32,14 +32,16 @@ public class PropertyNameCaseSensitiveTest : WebApiTestBase<PropertyNameCaseSens
     protected static void UpdateConfigureServices(IServiceCollection services)
     {
         IEdmModel edmModel = GetEdmModel();
-        services.ConfigureControllers(typeof(MetadataController), typeof(BillsController));
-        services.AddControllers().AddOData(opt => opt.AddRouteComponents("odata", edmModel));
+        services.ConfigureControllers(typeof(MetadataController), typeof(BillsController), typeof(DifferentPropertyCasesController));
+        services.AddControllers().AddOData(opt => opt.Select().OrderBy().Expand().AddRouteComponents("odata", edmModel));
     }
 
     public static IEdmModel GetEdmModel()
     {
         ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
         builder.EntitySet<Bill>("Bills");
+        builder.EntitySet<DifferentPropertyCase>("DifferentPropertyCases");
+        builder.EntityType<NestedDifferentPropertyCase>().HasKey(e => e.Id);
         var edmModel = builder.GetEdmModel();
         return edmModel;
     }
@@ -160,5 +162,84 @@ public class PropertyNameCaseSensitiveTest : WebApiTestBase<PropertyNameCaseSens
         string responseString = await response.Content.ReadAsStringAsync();
 
         Assert.Equal("{\"@odata.context\":\"http://localhost/odata/$metadata#Edm.Boolean\",\"value\":false}", responseString);
+    }
+
+
+    [Fact]
+    public async Task PropertyNameCaseSensitive_QueryCollection_WorksAsExpected()
+    {
+        // Arrange
+        var requestUri = "odata/DifferentPropertyCases";
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+        string responseString = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.True(HttpStatusCode.OK == response.StatusCode,
+            string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+            HttpStatusCode.OK, response.StatusCode, requestUri));
+
+        Assert.Contains("\"Field\":\"Pascal\"", responseString);
+        Assert.Contains("\"FIELD\":\"Upper\"", responseString);
+    }
+
+    [Fact]
+    public async Task PropertyNameCaseSensitive_QueryCollectionWithSelect_WorksAsExpected()
+    {
+        // Arrange
+        var requestUri = "odata/DifferentPropertyCases?$select=Field,FIELD";
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+        string responseString = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.True(HttpStatusCode.OK == response.StatusCode,
+            string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+            HttpStatusCode.OK, response.StatusCode, requestUri));
+
+        Assert.Contains("{\"Field\":\"Pascal\",\"FIELD\":\"Upper\"}", responseString);
+    }
+
+    [Fact]
+    public async Task PropertyNameCaseSensitive_QueryCollectionWithOrderBy_WorksAsExpected()
+    {
+        // Arrange
+        var requestUri = "odata/DifferentPropertyCases?orderBy=Field";
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+        string responseString = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.True(HttpStatusCode.OK == response.StatusCode,
+            string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+            HttpStatusCode.OK, response.StatusCode, requestUri));
+
+        Assert.Contains("\"Field\":\"Pascal\"", responseString);
+        Assert.Contains("\"FIELD\":\"Upper\"", responseString);
+    }
+
+    [Fact]
+    public async Task PropertyNameCaseSensitive_QueryCollectionWithExpandAndOrderFromPaging_WorksAsExpected()
+    {
+        // Arrange
+        var requestUri = "odata/DifferentPropertyCases?expand=Nested";
+        HttpClient client = CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+        string responseString = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.True(HttpStatusCode.OK == response.StatusCode,
+            string.Format("Response status code, expected: {0}, actual: {1}, request url: {2}",
+            HttpStatusCode.OK, response.StatusCode, requestUri));
+
+        Assert.Contains("{\"Id\":1,\"ID\":\"some old id 2\"}", responseString);
     }
 }


### PR DESCRIPTION
Allows to use sensitive fields in CLR according to (Case Sensitivity of Property Names, EntitySets, Singletons and Operations)[https://issues.oasis-open.org/browse/ODATA-1150]

That work starts in !1482, but PR was closed due to my mistake with branches

`dev-10.x` branch selected for check changes with E2E tests

project has several other places with `Expression.Property(expression, property_name_as_string)`, I check and fix only two cases, which breaks my app

I can continue work on that and cover another `Expression.Property` usings

Tests `PropertyNameCaseSensitive_QueryCollection_WorksAsExpected` and `PropertyNameCaseSensitive_QueryCollectionWithSelect_WorksAsExpected` works correctly without changes to `Expression.Property` and have been added for covering basic cases