### PR TITLE
Support type coercion in Delta<T>.TrySetPropertyValue

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
+++ b/src/Microsoft.AspNetCore.OData/Deltas/DeltaOfT.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
@@ -19,6 +20,7 @@ using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.OData.Abstracts;
 using Microsoft.AspNetCore.OData.Common;
+using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Extensions;
 
 namespace Microsoft.AspNetCore.OData.Deltas;
@@ -817,12 +819,47 @@ public class Delta<T> : Delta, IDelta, ITypedDelta where T : class
         Type propertyType = cacheHit.Property.PropertyType;
         if (value != null && !TypeHelper.IsCollection(propertyType) && !propertyType.IsAssignableFrom(value.GetType()))
         {
-            return false;
+            if (!TryConvertPropertyValue(propertyType, value, out object convertedValue))
+            {
+                return false;
+            }
+
+            value = convertedValue;
         }
 
         cacheHit.SetValue(_instance, value);
         _changedProperties.Add(name);
         return true;
+    }
+
+    private static bool TryConvertPropertyValue(Type propertyType, object value, out object convertedValue)
+    {
+        Debug.Assert(propertyType != null, "Argument propertyType is null");
+        Debug.Assert(value != null, "Argument value is null");
+
+        convertedValue = value;
+
+        Type targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        if (!targetType.IsValueType)
+        {
+            return false;
+        }
+
+        try
+        {
+            convertedValue = EdmPrimitiveHelper.ConvertPrimitiveValue(value, propertyType);
+        }
+        catch (ValidationException)
+        {
+            return false;
+        }
+
+        if (convertedValue == null)
+        {
+            return propertyType.IsNullable();
+        }
+
+        return propertyType.IsAssignableFrom(convertedValue.GetType());
     }
 
     private bool TrySetNestedResourceInternal(string name, object deltaNestedResource)

--- a/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Deltas/DeltaTests.cs
@@ -147,6 +147,40 @@ public class DeltaTest
     }
 
     [Fact]
+    public void TrySetPropertyValue_ReturnsTrue_AndTracksChange_WhenInt64ValueSetOnInt32Property()
+    {
+        // Arrange - simulates a boxed Int64 value arriving for an Int32 property (e.g. from JSON deserialization)
+        Delta<DeltaModel> delta = new Delta<DeltaModel>();
+        long int64Value = 42L;
+
+        // Act
+        bool result = delta.TrySetPropertyValue("IntProperty", int64Value);
+
+        // Assert
+        Assert.True(result, "TrySetPropertyValue should return true when an Int64 value can be coerced to the Int32 property type.");
+        Assert.Contains("IntProperty", delta.GetChangedPropertyNames());
+        delta.TryGetPropertyValue("IntProperty", out object retrievedValue);
+        Assert.Equal(42, retrievedValue);
+    }
+
+    [Fact]
+    public void TrySetPropertyValue_ReturnsTrue_AndTracksChange_WhenInt64ValueSetOnNullableInt32Property()
+    {
+        // Arrange - simulates a boxed Int64 value arriving for a nullable Int32 property
+        Delta<DeltaModel> delta = new Delta<DeltaModel>();
+        long int64Value = 42L;
+
+        // Act
+        bool result = delta.TrySetPropertyValue("NullableIntProperty", int64Value);
+
+        // Assert
+        Assert.True(result, "TrySetPropertyValue should return true when an Int64 value can be coerced to the nullable Int32 property type.");
+        Assert.Contains("NullableIntProperty", delta.GetChangedPropertyNames());
+        delta.TryGetPropertyValue("NullableIntProperty", out object retrievedValue);
+        Assert.Equal((int?)42, retrievedValue);
+    }
+
+    [Fact]
     public void TrySetPropertyValue_ThrowsInvalidOperation_IfDynamicContainerWithoutSetter()
     {
         // Arrange


### PR DESCRIPTION
Add TryConvertPropertyValue to enable value type coercion (e.g., Int64 to Int32) when setting properties in Delta<T>. Update TrySetPropertyValueInternal to use this logic. Add tests to verify correct handling and change tracking for coerced values.

Fixes #1572