### PR TITLE
Fixes #1332, #1268: $select on Primitive Collections and Array-based Concurrency tokens. 

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Common/TypeHelper.cs
@@ -386,6 +386,26 @@ internal static class TypeHelper
     }
 
     /// <summary>
+    /// Check whether the given type is a primitive type or known type.
+    /// </summary>
+    /// <param name="type">The type to validate.</param>
+    /// <returns>True if type is primitive or known type, otherwise False.</returns>
+    public static bool IsPrimitiveOrKnownType(Type type)
+    {
+        return type.IsPrimitive 
+               || type == typeof(string)
+               || type == typeof(Uri)
+               || type == typeof(DateTime)
+#if NET6_0_OR_GREATER
+    || type == typeof(DateOnly)
+    || type == typeof(TimeOnly)
+#endif
+               || type == typeof(DateTimeOffset)
+               || type == typeof(Guid)
+               || type == typeof(Decimal);
+    }
+
+    /// <summary>
     /// Determines whether the specified <see cref="Type"/> represents an <see cref="IAsyncEnumerable{T}"/> type.
     /// </summary>
     /// <param name="clrType">The <see cref="Type"/> to evaluate.</param>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -1224,6 +1224,13 @@
             <param name="clrType">The <see cref="T:System.Type"/> to evaluate.</param>
             <returns>True if the type is an enumeration; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.IsPrimitiveOrKnownType(System.Type)">
+            <summary>
+            Check whether the given type is a primitive type or known type.
+            </summary>
+            <param name="type">The type to validate.</param>
+            <returns>True if type is primitive or known type, otherwise False.</returns>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Common.TypeHelper.GetImplementedIEnumerableType(System.Type)">
             <summary>
             Returns type of T if the type implements IEnumerable of T, otherwise, return null.

--- a/src/Microsoft.AspNetCore.OData/Query/ETag.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ETag.cs
@@ -126,19 +126,36 @@ public class ETag : DynamicObject
             return query;
         }
 
-        Type type = EntityType;
-        ParameterExpression param = Expression.Parameter(type);
-        Expression where = null;
-        foreach (KeyValuePair<string, object> item in ConcurrencyProperties)
-        {
-            MemberExpression name = Expression.Property(param, item.Key);
-            object itemValue = item.Value;
-            Expression value = itemValue != null
-                ? LinqParameterContainer.Parameterize(itemValue.GetType(), itemValue)
-                : Expression.Constant(value: null);
-            BinaryExpression equal = Expression.Equal(name, value);
-            where = where == null ? equal : Expression.AndAlso(where, equal);
-        }
+            Type type = EntityType;
+            ParameterExpression param = Expression.Parameter(type);
+            Expression where = null;
+            foreach (KeyValuePair<string, object> item in ConcurrencyProperties)
+            {
+                MemberExpression name = Expression.Property(param, item.Key);
+                object itemValue = item.Value;
+                
+                Expression equal;
+                if (itemValue != null)
+                {
+                    Type itemType = itemValue.GetType();
+                    Expression value = LinqParameterContainer.Parameterize(itemType, itemValue);
+                    if (itemType.IsArray)
+                    {
+                        equal = ExpressionHelpers.SequenceEquals(name, value);
+                    }
+                    else
+                    {
+                        equal = Expression.Equal(name, value);
+                    }
+                }
+                else
+                {
+                    Expression value = Expression.Constant(value: null);
+                    equal = Expression.Equal(name, value);
+                }
+                
+                where = where == null ? equal : Expression.AndAlso(where, equal);
+            }
 
         if (where == null)
         {

--- a/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ExpressionHelpers.cs
@@ -29,7 +29,9 @@ internal static class ExpressionHelpers
     public static IQueryable Skip(IQueryable query, int count, Type type, bool parameterize)
     {
         MethodInfo skipMethod = ExpressionHelperMethods.QueryableSkipGeneric.MakeGenericMethod(type);
-        Expression skipValueExpression = parameterize ? LinqParameterContainer.Parameterize(typeof(int), count) : Expression.Constant(count);
+        Expression skipValueExpression = parameterize
+            ? LinqParameterContainer.Parameterize(typeof(int), count)
+            : Expression.Constant(count);
 
         Expression skipQuery = Expression.Call(null, skipMethod, new[] { query.Expression, skipValueExpression });
 
@@ -58,7 +60,9 @@ internal static class ExpressionHelpers
             skipMethod = ExpressionHelperMethods.EnumerableSkipGeneric.MakeGenericMethod(type);
         }
 
-        Expression skipValueExpression = parameterize ? LinqParameterContainer.Parameterize(typeof(int), count) : Expression.Constant(count);
+        Expression skipValueExpression = parameterize
+            ? LinqParameterContainer.Parameterize(typeof(int), count)
+            : Expression.Constant(count);
         Expression skipQuery = Expression.Call(null, skipMethod, new[] { source, skipValueExpression });
         return skipQuery;
     }
@@ -75,7 +79,9 @@ internal static class ExpressionHelpers
             takeMethod = ExpressionHelperMethods.EnumerableTakeGeneric.MakeGenericMethod(elementType);
         }
 
-        Expression takeValueExpression = parameterize ? LinqParameterContainer.Parameterize(typeof(int), count) : Expression.Constant(count);
+        Expression takeValueExpression = parameterize
+            ? LinqParameterContainer.Parameterize(typeof(int), count)
+            : Expression.Constant(count);
         Expression takeQuery = Expression.Call(null, takeMethod, new[] { source, takeValueExpression });
         return takeQuery;
     }
@@ -110,7 +116,8 @@ internal static class ExpressionHelpers
                 }
                 else
                 {
-                    orderByMethod = ExpressionHelperMethods.QueryableOrderByDescendingGeneric.MakeGenericMethod(elementType,
+                    orderByMethod = ExpressionHelperMethods.QueryableOrderByDescendingGeneric.MakeGenericMethod(
+                        elementType,
                         returnType);
                 }
             }
@@ -123,7 +130,8 @@ internal static class ExpressionHelpers
                 }
                 else
                 {
-                    orderByMethod = ExpressionHelperMethods.EnumerableOrderByDescendingGeneric.MakeGenericMethod(elementType,
+                    orderByMethod = ExpressionHelperMethods.EnumerableOrderByDescendingGeneric.MakeGenericMethod(
+                        elementType,
                         returnType);
                 }
             }
@@ -139,7 +147,8 @@ internal static class ExpressionHelpers
                 }
                 else
                 {
-                    orderByMethod = ExpressionHelperMethods.QueryableThenByDescendingGeneric.MakeGenericMethod(elementType,
+                    orderByMethod = ExpressionHelperMethods.QueryableThenByDescendingGeneric.MakeGenericMethod(
+                        elementType,
                         returnType);
                 }
             }
@@ -152,22 +161,26 @@ internal static class ExpressionHelpers
                 }
                 else
                 {
-                    orderByMethod = ExpressionHelperMethods.EnumerableThenByDescendingGeneric.MakeGenericMethod(elementType,
+                    orderByMethod = ExpressionHelperMethods.EnumerableThenByDescendingGeneric.MakeGenericMethod(
+                        elementType,
                         returnType);
                 }
             }
         }
+
         return Expression.Call(null, orderByMethod, new[] { source, orderByLambda });
     }
 
-    public static IQueryable OrderByIt(IQueryable query, OrderByDirection direction, Type type, bool alreadyOrdered = false)
+    public static IQueryable OrderByIt(IQueryable query, OrderByDirection direction, Type type,
+        bool alreadyOrdered = false)
     {
         ParameterExpression odataItParameter = Expression.Parameter(type, "$it");
         LambdaExpression orderByLambda = Expression.Lambda(odataItParameter, odataItParameter);
         return OrderBy(query, orderByLambda, direction, type, alreadyOrdered);
     }
 
-    public static IQueryable OrderByProperty(IQueryable query, IEdmModel model, IEdmProperty property, OrderByDirection direction, Type type, bool alreadyOrdered = false)
+    public static IQueryable OrderByProperty(IQueryable query, IEdmModel model, IEdmProperty property,
+        OrderByDirection direction, Type type, bool alreadyOrdered = false)
     {
         // property aliasing
         string propertyName = model.GetClrPropertyName(property);
@@ -175,7 +188,8 @@ internal static class ExpressionHelpers
         return OrderBy(query, orderByLambda, direction, type, alreadyOrdered);
     }
 
-    public static IQueryable OrderBy(IQueryable query, LambdaExpression orderByLambda, OrderByDirection direction, Type type, bool alreadyOrdered = false)
+    public static IQueryable OrderBy(IQueryable query, LambdaExpression orderByLambda, OrderByDirection direction,
+        Type type, bool alreadyOrdered = false)
     {
         Type returnType = orderByLambda.Body.Type;
 
@@ -193,11 +207,13 @@ internal static class ExpressionHelpers
             }
             else
             {
-                orderByMethod = ExpressionHelperMethods.QueryableThenByDescendingGeneric.MakeGenericMethod(type, returnType);
+                orderByMethod =
+                    ExpressionHelperMethods.QueryableThenByDescendingGeneric.MakeGenericMethod(type, returnType);
             }
 
             orderedQuery = query as IOrderedQueryable;
-            orderedQuery = orderByMethod.Invoke(null, new object[] { orderedQuery, orderByLambda }) as IOrderedQueryable;
+            orderedQuery =
+                orderByMethod.Invoke(null, new object[] { orderedQuery, orderByLambda }) as IOrderedQueryable;
         }
         else
         {
@@ -207,7 +223,8 @@ internal static class ExpressionHelpers
             }
             else
             {
-                orderByMethod = ExpressionHelperMethods.QueryableOrderByDescendingGeneric.MakeGenericMethod(type, returnType);
+                orderByMethod =
+                    ExpressionHelperMethods.QueryableOrderByDescendingGeneric.MakeGenericMethod(type, returnType);
             }
 
             orderedQuery = orderByMethod.Invoke(null, new object[] { query, orderByLambda }) as IOrderedQueryable;
@@ -224,7 +241,8 @@ internal static class ExpressionHelpers
 
     public static IQueryable Select(IQueryable query, LambdaExpression expression, Type type)
     {
-        MethodInfo selectMethod = ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(type, expression.Body.Type);
+        MethodInfo selectMethod =
+            ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(type, expression.Body.Type);
         return selectMethod.Invoke(null, new object[] { query, expression }) as IQueryable;
     }
 
@@ -232,7 +250,8 @@ internal static class ExpressionHelpers
     public static IQueryable SelectMany(IQueryable query, LambdaExpression expression, Type type)
     {
         Type elementType = TypeHelper.GetInnerElementType(expression.Body.Type);
-        MethodInfo selectManyMethod = ExpressionHelperMethods.QueryableSelectManyGeneric.MakeGenericMethod(type, elementType);
+        MethodInfo selectManyMethod =
+ ExpressionHelperMethods.QueryableSelectManyGeneric.MakeGenericMethod(type, elementType);
         return selectManyMethod.Invoke(null, new object[] { query, expression }) as IQueryable;
     }
 
@@ -276,6 +295,15 @@ internal static class ExpressionHelpers
         {
             return Expression.Constant(null, type);
         }
+    }
+
+    public static Expression SequenceEquals(Expression left, Expression right)
+    {
+        MethodInfo sequenceEqualMethod = typeof(Enumerable)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .First(m => m.Name == "SequenceEqual" && m.GetParameters().Length == 2)
+            .MakeGenericMethod(right.Type.GetElementType());
+        return Expression.Call(sequenceEqualMethod, left, right);
     }
 
     public static LambdaExpression GetPropertyAccessLambda(Type type, string propertyName)

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/SelectExpandBinder.cs
@@ -1397,7 +1397,9 @@ public class SelectExpandBinder : QueryBinder, ISelectExpandBinder
         // expression
         //      source.Select((ElementType element) => new Wrapper { })
         var selectMethod = GetSelectMethod(elementType, projection.Type);
-        Expression selectedExpresion = Expression.Call(selectMethod, source, selector);
+        bool isPrimitiveCollection = TypeHelper.IsPrimitiveOrKnownType(elementType);
+        Expression selectedExpresion =
+            isPrimitiveCollection ? source : Expression.Call(selectMethod, source, selector);
 
         // Append ToList() to collection as a hint to LINQ provider to buffer correlated sub-queries in memory and avoid executing N+1 queries
         if (settings.EnableCorrelatedSubqueryBuffering)

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/DerivedETagTests.cs
@@ -48,6 +48,7 @@ public class DerivedETagTests : WebApiTestBase<DerivedETagTests>
         SingletonConfiguration<ETagsCustomer> eTagsCustomerSingleton = builder.Singleton<ETagsCustomer>("ETagsDerivedCustomersSingleton");
         eTagsCustomerSingleton.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
         eTagsCustomerSingleton.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+        eTagsCustomersSet.EntityType.Ignore(d => d.RowVersion);
         return builder.GetEdmModel();
     }
 
@@ -60,6 +61,8 @@ public class DerivedETagTests : WebApiTestBase<DerivedETagTests>
         EntitySetConfiguration<ETagsDerivedCustomer> eTagsDerivedCustomersSet = builder.EntitySet<ETagsDerivedCustomer>("ETagsDerivedCustomers");
         eTagsDerivedCustomersSet.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
         eTagsDerivedCustomersSet.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+        eTagsDerivedCustomersSet.EntityType.Ignore(d => d.RowVersion);
+        eTagsCustomersSet.EntityType.Ignore(d => d.RowVersion);
         return builder.GetEdmModel();
     }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsController.cs
@@ -121,7 +121,7 @@ public class ETagsCustomersController : ODataController
         customer.UlongProperty = eTagsCustomer.UlongProperty;
         customer.GuidProperty = eTagsCustomer.GuidProperty;
         customer.DateTimeOffsetProperty = eTagsCustomer.DateTimeOffsetProperty;
-
+        customer.RowVersion[7]++;
         return Ok(customer);
     }
 
@@ -172,7 +172,7 @@ public class ETagsCustomersController : ODataController
            
         ETagsCustomer customer = appliedCustomers.Single();
         patch.Patch(customer);
-
+        customer.RowVersion[7]++;
         return Ok(customer);
     }
 }
@@ -216,6 +216,7 @@ internal class Helpers
             ShortProperty = (short)(Int16.MaxValue - i),
             DoubleProperty = 2.0 * (i + 1),
             Notes = Enumerable.Range(0, i + 1).Select(j => "This is note " + (i * 10 + j)).ToList(),
+            RowVersion = new byte[] { 0, 0, 0, 0, 0, 0, 16, 28 },
             RelatedCustomer = new ETagsCustomer
             {
                 Id = i + 1,

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsModel.cs
@@ -41,6 +41,8 @@ public class ETagsCustomer
     public ETagsCustomer RelatedCustomer { get; set; }
     [Contained]
     public ETagsCustomer ContainedCustomer { get; set; }
+    [Timestamp]
+    public byte[] RowVersion { get; set; }
 }
 
 public class ETagSimpleThing

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsOtherTypesTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/ETagsOtherTypesTest.cs
@@ -45,6 +45,7 @@ public class ETagsOtherTypesTest : WebApiTestBase<ETagsOtherTypesTest>
         var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
         customer.Property(c => c.DoubleProperty).IsConcurrencyToken();
         customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+        customer.Ignore(c => c.RowVersion);
         return builder.GetEdmModel();
     }
 
@@ -53,6 +54,7 @@ public class ETagsOtherTypesTest : WebApiTestBase<ETagsOtherTypesTest>
         var builder = new ODataConventionModelBuilder();
         var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
         customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+        customer.Ignore(c => c.RowVersion);
         customer.Property(c => c.ShortProperty).IsConcurrencyToken();
         return builder.GetEdmModel();
     }

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/ETags/JsonETagsTests.cs
@@ -62,6 +62,7 @@ public class JsonETagsTests : WebApiTestBase<JsonETagsTests>
         eTagsCustomers.Property(c => c.UlongProperty).IsConcurrencyToken();
         eTagsCustomers.Property(c => c.GuidProperty).IsConcurrencyToken();
         eTagsCustomers.Property(c => c.DateTimeOffsetProperty).IsConcurrencyToken();
+        eTagsCustomers.Ignore(d => d.RowVersion);
         return builder.GetEdmModel();
     }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsContext.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsContext.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ListsContext.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Lists
+{
+    public class ListsContext : DbContext
+    {
+        public ListsContext(DbContextOptions<ListsContext> options)
+            : base(options)
+        {
+       
+        }
+
+        public DbSet<Product> Products{ get; set; }
+        public DbSet<Order> Orders{ get; set; }
+    }
+}
+

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsController.cs
@@ -1,0 +1,186 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ListsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Attributes;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Lists
+{
+    [Route("convention")]
+    public class ProductsController : ODataController
+    {
+        private readonly ListsContext _dbContext;
+        public ProductsController(ListsContext context)
+        {
+            _dbContext = context;
+        }
+
+        [EnableQuery(PageSize = 10, MaxExpansionDepth = 5)]
+        public IActionResult Get()
+        {
+            return Ok(_dbContext.Products);
+        }
+
+        [EnableQuery]
+        public IActionResult Get(string key)
+        {
+            return Ok(_dbContext.Products.Find(key));
+        }
+
+        public IActionResult Post([FromBody] Product Product)
+        {
+            Product.ProductId = _dbContext.Products.Count() + 1+"";
+            _dbContext.Products.Add(Product);
+            _dbContext.SaveChanges();
+
+            return Created(Product);
+        }
+
+        public IActionResult Put(int key, [FromBody] Product Product)
+        {
+            Product.ProductId = key+"";
+            Product originalProduct = _dbContext.Products.Find(key);
+
+            if (originalProduct == null)
+            {
+                _dbContext.Products.Add(Product);
+
+                return Created(Product);
+            }
+
+            _dbContext.Products.Remove(originalProduct);
+            _dbContext.Products.Add(Product);
+            return Ok(Product);
+        }
+
+        public IActionResult Patch(int key, [FromBody] Delta<Product> delta)
+        {
+            Product originalProduct = _dbContext.Products.Find(key);
+
+            if (originalProduct == null)
+            {
+                Product temp = new Product();
+                delta.Patch(temp);
+                _dbContext.Products.Add(temp);
+                return Created(temp);
+            }
+
+            delta.Patch(originalProduct);
+            return Ok(delta);
+        }
+
+        public IActionResult Delete(int key)
+        {
+            Product Product = _dbContext.Products.Find(key);
+
+            _dbContext.Products.Remove(Product);
+            return this.StatusCode(StatusCodes.Status204NoContent);
+        }
+
+        [HttpPost("ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dbContext.Orders.RemoveRange(_dbContext.Orders);
+            _dbContext.Products.RemoveRange(_dbContext.Products);
+            _dbContext.SaveChanges();
+
+            // Add new seed data
+            _dbContext.Products.AddRange(
+               new Product
+               {
+                   ProductId = "1",
+                   Name = "Product1",
+                   Category = "Category1",
+                   ListTestString = new List<string> { "Test1", "Test2", "Test99" },
+                   ListTestBool = new List<bool> { true, false },
+                   ListTestInt = new List<int> { 1, 2, 3 },
+                   ListTestDouble = new List<double> { 1.1, 2.2 },
+                   ListTestFloat = new List<float> { 1.1f, 2.2f },
+                   ListTestDateTime = new List<DateTimeOffset> { DateTime.Now, DateTime.UtcNow },
+                   ListTestUri = new List<Uri> { new Uri("https://example.com") },
+                   ListTestUint = new uint[] { 1, 2, 3 },
+                   ListTestOrder = new List<Order>
+                    {
+                        new Order { OrderId = "Order1" },
+                        new Order { OrderId = "Order2" }
+                    }
+               },
+                new Product
+                {
+                    ProductId = "2",
+                    Name = "Product2",
+                    Category = "Category2",
+                    ListTestString = new List<string> { "Test3", "Test4", "Test99" },
+                    ListTestBool = new List<bool> { false, true },
+                    ListTestInt = new List<int> { 4, 5, 6 },
+                    ListTestDouble = new List<double> { 3.3, 4.4 },
+                    ListTestFloat = new List<float> { 3.3f, 4.4f },
+                    ListTestDateTime = new List<DateTimeOffset> { DateTime.Now.AddDays(1), DateTime.UtcNow.AddDays(1) },
+                    ListTestUri = new List<Uri> { new Uri("https://example.org") },
+                    ListTestUint = new uint[] { 4, 5, 6 }
+                },
+                new Product
+                {
+                    ProductId = "3",
+                    Name = "Product3",
+                    Category = "Category3",
+                    ListTestString = new List<string> { "Test5", "Test6" },
+                    ListTestBool = new List<bool> { true, true },
+                    ListTestInt = new List<int> { 7, 8, 9 },
+                    ListTestDouble = new List<double> { 5.5, 6.6 },
+                    ListTestFloat = new List<float> { 5.5f, 6.6f },
+                    ListTestDateTime = new List<DateTimeOffset> { DateTime.Now.AddDays(2), DateTime.UtcNow.AddDays(2) },
+                    ListTestUri = new List<Uri> { new Uri("https://example.net") },
+                    ListTestUint = new uint[] { 7, 8, 9 }
+                },
+                new Product
+                {
+                    ProductId = "4",
+                    Name = "Product4",
+                    Category = "Category4",
+                    ListTestString = new List<string> { "Test98", "Test98" },
+                    ListTestBool = new List<bool> { false, false },
+                    ListTestInt = new List<int> { 10, 11, 12 },
+                    ListTestDouble = new List<double> { 7.7, 8.8 },
+                    ListTestFloat = new List<float> { 7.7f, 8.8f },
+                    ListTestDateTime = new List<DateTimeOffset> { DateTime.Now.AddDays(3), DateTime.UtcNow.AddDays(3) },
+                    ListTestUri = new List<Uri> { new Uri("https://example.edu") },
+                    ListTestUint = new uint[] { 10, 11, 12 }
+                },
+                new Product
+                {
+                    ProductId = "5",
+                    Name = "Product5",
+                    Category = "Category5",
+                    ListTestString = new List<string> { "Test98", "Test98" },
+                    ListTestBool = new List<bool> { true, false },
+                    ListTestInt = new List<int> { 13, 14, 15 },
+                    ListTestDouble = new List<double> { 9.9, 10.10 },
+                    ListTestFloat = new List<float> { 9.9f, 10.10f },
+                    ListTestDateTime = new List<DateTimeOffset> { DateTime.Now.AddDays(4), DateTime.UtcNow.AddDays(4) },
+                    ListTestUri = new List<Uri> { new Uri("https://example.gov") },
+                    ListTestUint = new uint[] { 13, 14, 15 }
+                }
+            );
+            _dbContext.SaveChanges();
+            return this.StatusCode(StatusCodes.Status204NoContent);
+        }
+
+
+    }
+
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsDataModel.cs
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ListsDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Lists
+{
+    public class Product
+    {
+        [Key]
+        public string ProductId { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public IList<string> ListTestString { get; set; } = new List<string>();
+        public IList<bool> ListTestBool { get; set; }
+        public IList<int> ListTestInt { get; set; }
+        public IList<double> ListTestDouble { get; set; }
+        public IList<float> ListTestFloat { get; set; }
+        public IList<DateTimeOffset> ListTestDateTime { get; set; }
+        public IList<Uri> ListTestUri { get; set; }
+        public uint[] ListTestUint { get; set; }
+        public IList<Order>? ListTestOrder { get; set; }
+    }
+
+    public class Order
+    {
+        [Key] public string OrderId { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsEdmModel.cs
@@ -1,0 +1,28 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ListsEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Lists
+{
+    internal class ListsEdmModel
+    {
+        public static IEdmModel GetConventionModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            EntitySetConfiguration<Product> Products = builder.EntitySet<Product>("Products");
+            EntitySetConfiguration<Order> Orders = builder.EntitySet<Order>("Orders");
+
+            builder.Namespace = typeof(Product).Namespace;
+            builder.Namespace = typeof(Order).Namespace;
+
+            var edmModel = builder.GetEdmModel();
+            return edmModel;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Lists/ListsTest.cs
@@ -1,0 +1,302 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ListsTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+#if NET8_0_OR_GREATER
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.AspNetCore.OData.E2E.Tests.Extensions;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Lists
+{
+    public class ListsTest : WebApiTestBase<ListsTest>
+    {
+        private Dictionary<string, string> _map;
+
+        protected static void UpdateConfigureServices(IServiceCollection services)
+        {
+            string currentDirectory = Environment.CurrentDirectory;
+            services.ConfigureControllers(typeof(ProductsController), typeof(MetadataController));
+            var keepAliveConnection = new SqliteConnection("DataSource=:memory:");
+            keepAliveConnection.Open();
+
+            services.AddDbContext<ListsContext>(options =>
+                options.UseSqlite(keepAliveConnection));
+
+            IEdmModel model1 = ListsEdmModel.GetConventionModel();
+
+            services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(5)
+                .AddRouteComponents("convention", model1));
+
+            var serviceProvider = services.BuildServiceProvider();
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<ListsContext>();
+                context.Database.OpenConnection(); // Open connection to in-memory database
+                context.Database.EnsureCreated(); // Ensure the schema is created
+            }
+        }
+
+        public ListsTest(WebApiTestFixture<ListsTest> fixture)
+           : base(fixture)
+        {
+             _map = new Dictionary<string, string>
+                {
+                    {"ListTestString", "String"},
+                    {"ListTestBool", "Boolean"},
+                    {"ListTestInt", "Int32"},
+                    {"ListTestDouble", "Double"},
+                    {"ListTestFloat", "Single"},
+                    {"ListTestDateTime", "DateTimeOffset"},
+                    {"ListTestUri", "Microsoft.AspNetCore.OData.E2E.Tests.Lists.Uri"},
+                    {"ListTestOrder", "Microsoft.AspNetCore.OData.E2E.Tests.Lists.Order"},
+                    {"ListTestUint", "UInt32"},
+                };
+        }
+
+        [Theory]
+        [InlineData("application/json;odata.metadata=full")]
+        [InlineData("application/json;odata.metadata=minimal")]
+        [InlineData("application/json;odata.metadata=none")]
+        public async Task QueryEntitySet(string format)
+        {
+            // Arrange
+            await ResetDatasource();
+            string requestUri = "/convention/Products?$format=" + format;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var json = await response.Content.ReadAsObject<JObject>();
+            var results = json.GetValue("value") as JArray;
+            Assert.Equal<int>(5, results.Count);
+            if (format == "application/json;odata.metadata=full")
+            {
+                var typeOfListTestString = results[0]["ListTestString@odata.type"].ToString();
+                Assert.Equal("#Collection(String)", typeOfListTestString);
+
+                var typeOfListTestBool = results[0]["ListTestBool@odata.type"].ToString();
+                Assert.Equal("#Collection(Boolean)", typeOfListTestBool);
+
+                var typeOfListTestFloat = results[0]["ListTestFloat@odata.type"].ToString();
+                Assert.Equal("#Collection(Single)", typeOfListTestFloat);
+
+                var typeOfListTestDouble = results[0]["ListTestDouble@odata.type"].ToString();
+                Assert.Equal("#Collection(Double)", typeOfListTestDouble);
+
+                var typeOfListTestInt = results[0]["ListTestInt@odata.type"].ToString();
+                Assert.Equal("#Collection(Int32)", typeOfListTestInt);
+
+                var typeOfListTestDateTime = results[0]["ListTestDateTime@odata.type"].ToString();
+                Assert.Equal("#Collection(DateTimeOffset)", typeOfListTestDateTime);
+
+                var typeOfListTestUri = results[0]["ListTestUri@odata.type"].ToString();
+                Assert.Equal("#Collection(Microsoft.AspNetCore.OData.E2E.Tests.Lists.Uri)", typeOfListTestUri);
+            }
+        }
+
+        [Theory]
+        [InlineData("application/json;odata.metadata=full")]
+        [InlineData("application/json;odata.metadata=minimal")]
+        [InlineData("application/json;odata.metadata=none")]
+        public async Task QueryEntity(string format)
+        {
+            await ResetDatasource();
+            HttpClient client = CreateClient();
+            string requestUri = "/convention/Products('1')?$format=" + format;
+
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+            if (format == "application/json;odata.metadata=full")
+            {
+                var typeOfListTestString = result["ListTestString@odata.type"].ToString();
+                Assert.Equal("#Collection(String)", typeOfListTestString);
+
+                var typeOfListTestBool = result["ListTestBool@odata.type"].ToString();
+                Assert.Equal("#Collection(Boolean)", typeOfListTestBool);
+
+                var typeOfListTestFloat = result["ListTestFloat@odata.type"].ToString();
+                Assert.Equal("#Collection(Single)", typeOfListTestFloat);
+
+                var typeOfListTestDouble = result["ListTestDouble@odata.type"].ToString();
+                Assert.Equal("#Collection(Double)", typeOfListTestDouble);
+
+                var typeOfListTestInt = result["ListTestInt@odata.type"].ToString();
+                Assert.Equal("#Collection(Int32)", typeOfListTestInt);
+
+                var typeOfListTestDateTime = result["ListTestDateTime@odata.type"].ToString();
+                Assert.Equal("#Collection(DateTimeOffset)", typeOfListTestDateTime);
+
+                var typeOfListTestUri = result["ListTestUri@odata.type"].ToString();
+                Assert.Equal("#Collection(Microsoft.AspNetCore.OData.E2E.Tests.Lists.Uri)", typeOfListTestUri);
+            }
+        }
+
+        [Theory]
+        [InlineData("/convention/Products/$count", 5)]
+        [InlineData("/convention/Products/$count?$filter=Name eq 'Product1'", 1)]
+        public async Task QueryEntitySetCount(string requestUri, int expectedCount)
+        {
+            // Arrange
+            await ResetDatasource();
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            string count = await response.Content.ReadAsStringAsync();
+            Assert.Equal<int>(expectedCount, int.Parse(count));
+        }
+
+        [Theory]
+        [InlineData("/convention/Products/$count", true)]
+        [InlineData("/convention/Products/$count", false)]
+        public async Task QueryEntitySetCountEncoding(string requestUri, bool sendAcceptCharset)
+        {
+            // Arrange
+            await ResetDatasource();
+            HttpClient client = CreateClient();
+            client.DefaultRequestHeaders.AcceptCharset.Clear();
+            if (sendAcceptCharset)
+            {
+                client.DefaultRequestHeaders.AcceptCharset.ParseAdd("utf-8");
+            }
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            var blob = await response.Content.ReadAsByteArrayAsync();
+            Assert.Equal("utf-8", response.Content.Headers.ContentType.CharSet, StringComparer.OrdinalIgnoreCase);
+            var count = Encoding.UTF8.GetString(blob);
+            Assert.Equal(5, int.Parse(count));
+            Assert.False((blob[0] == 0xEF) && (blob[1] == 0xBB) && (blob[2] == 0xBF));
+        }
+
+        [Theory]
+        [InlineData("application/json;odata.metadata=full", "ListTestString")]
+        [InlineData("application/json;odata.metadata=full", "ListTestBool")]
+        [InlineData("application/json;odata.metadata=full", "ListTestFloat")]
+        [InlineData("application/json;odata.metadata=full", "ListTestDouble")]
+        [InlineData("application/json;odata.metadata=full", "ListTestInt")]
+        [InlineData("application/json;odata.metadata=full", "ListTestDateTime")]
+        //[InlineData("application/json;odata.metadata=full", "ListTestUri")]
+        [InlineData("application/json;odata.metadata=full", "ListTestOrder")]
+        public async Task QueryEntitySetSelect(string format, string select)
+        {
+            // Arrange
+            await ResetDatasource();
+            string requestUri = "/convention/Products?$expand=ListTestOrder&$format=" + format + "&$select=" + select;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var json = await response.Content.ReadAsObject<JObject>();
+            var results = json.GetValue("value") as JArray;
+            Assert.Equal<int>(5, results.Count);
+
+            var typeOfListTestString = results[0][$"{select}@odata.type"].ToString();
+            Assert.Equal($"#Collection({_map[select]})", typeOfListTestString);
+
+        }
+
+        [Theory]
+        [InlineData("application/json;odata.metadata=full", "ListTestString")]
+        [InlineData("application/json;odata.metadata=full", "ListTestBool")]
+        [InlineData("application/json;odata.metadata=full", "ListTestFloat")]
+        [InlineData("application/json;odata.metadata=full", "ListTestDouble")]
+        [InlineData("application/json;odata.metadata=full", "ListTestInt")]
+        [InlineData("application/json;odata.metadata=full", "ListTestDateTime")]
+        //[InlineData("application/json;odata.metadata=full", "ListTestUri")]
+        [InlineData("application/json;odata.metadata=full", "ListTestOrder")]
+        public async Task QueryEntitySelect(string format, string select)
+        {
+            // Arrange
+            await ResetDatasource();
+            string requestUri = "/convention/Products('1')?$expand=ListTestOrder&$format=" + format + "&$select=" + select;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+
+            var typeOfListTestString = result[$"{select}@odata.type"].ToString();
+            Assert.Equal($"#Collection({_map[select]})", typeOfListTestString);
+        }
+
+        [Theory]
+        [InlineData("application/json;odata.metadata=full", "ListTestString", "/any(t: t eq 'Test99')", 2)]
+        [InlineData("application/json;odata.metadata=full", "ListTestString", "/all(t: contains(t, 'Test98'))", 2)]
+        [InlineData("application/json;odata.metadata=full", "ListTestBool", "/any(b: b eq true)", 4)]
+        [InlineData("application/json;odata.metadata=full", "ListTestBool", "/all(b: b eq true)", 1)]
+        [InlineData("application/json;odata.metadata=full", "ListTestFloat", "/any(f: f lt 4.0)", 2)]
+        [InlineData("application/json;odata.metadata=full", "ListTestFloat", "/all(f: f lt 4.0)", 1)]
+        [InlineData("application/json;odata.metadata=full", "ListTestDouble", "/any(d: d ge 5.5)", 3)]
+        [InlineData("application/json;odata.metadata=full", "ListTestDouble", "/all(d: d gt 5.5)", 2)]
+        [InlineData("application/json;odata.metadata=full", "ListTestInt", "/any(i: i le 5)", 2)]
+        [InlineData("application/json;odata.metadata=full", "ListTestInt", "/all(i: i le 5)", 1)]
+        //[InlineData("application/json;odata.metadata=full", "ListTestDateTime", "/any(d: d gt 2024-07-26T00:00:00Z)", 4)]
+        //[InlineData("application/json;odata.metadata=full", "ListTestDateTime", "/all(d: d gt 2024-07-26T00:00:00Z)", 4)]
+        //[InlineData("application/json;odata.metadata=full", "ListTestUri")]
+        public async Task QueryEntitySetFilter(string format, string filter, string expr, int expected)
+        {
+            // Arrange
+            await ResetDatasource();
+            string requestUri = "/convention/Products?$format=" + format + "&$filter=" + filter+expr;
+            HttpClient client = CreateClient();
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var json = await response.Content.ReadAsObject<JObject>();
+            var results = json.GetValue("value") as JArray;
+            Assert.Equal<int>(expected, results.Count);
+
+            var typeOfListTestString = results[0][$"{filter}@odata.type"].ToString();
+            Assert.Equal($"#Collection({_map[filter]})", typeOfListTestString);
+        }
+
+        private async Task<HttpResponseMessage> ResetDatasource()
+        {
+            HttpClient client = CreateClient();
+            var response = await client.PostAsync("convention/ResetDataSource", null);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            return response;
+        }
+    }
+}
+#endif

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Microsoft.AspNetCore.OData.E2E.Tests.csproj
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Microsoft.AspNetCore.OData.E2E.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.AspNetCore.OData.E2E.Tests</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.OData.E2E.Tests</RootNamespace>
 
@@ -39,8 +40,30 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.7" />
   </ItemGroup>
-    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.8" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.OData.TestCommon\Microsoft.AspNetCore.OData.TestCommon.csproj" />


### PR DESCRIPTION
I opened the issues #1268, and #1332 in late 2024 and early 2025 respectively and submitted a PR each into the `release-8.x` branch. The PRs were #1282 and #1334 respectively.

I noticed for a long time that the bugs were never fixed in 9.x and 10.x. 

This PR knocks out both of them for 9.x.

**Please also let me know if I need to create a separate PR for 10.x because it appears to me that 10.x and 9.x have been very much in sync.**