### PR TITLE
Add publishing modes to separate nightly validation packages from release package publication

### DIFF
--- a/pipelines/azure_pipelines_nightly.yml
+++ b/pipelines/azure_pipelines_nightly.yml
@@ -8,12 +8,12 @@ schedules:
 
 parameters:
   - name: PublishMode
-    displayName: Package publishing mode
+    displayName: Package publishing mode ('NightlyOnly' for nightly packages; 'ReleaseAndNightly' for both release and nightly packages)
     type: string
     default: NightlyOnly
     values:
     - NightlyOnly
-    - Release
+    - ReleaseAndNightly
 
 resources:
   repositories:
@@ -41,7 +41,7 @@ variables:
   - name: PackagesToPush
     value: $(Build.ArtifactStagingDirectory)\Nuget\*Nightly*nupkg
 
-- ${{ if eq(parameters.PublishMode, 'Release') }}: 
+- ${{ if eq(parameters.PublishMode, 'ReleaseAndNightly') }}: 
   - name: PackagesToPush
     value: '$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg'
 

--- a/pipelines/azure_pipelines_nightly.yml
+++ b/pipelines/azure_pipelines_nightly.yml
@@ -5,6 +5,16 @@ schedules:
     include:
     - main
     - dev-9.x
+
+parameters:
+  - name: PublishMode
+    displayName: Package publishing mode
+    type: string
+    default: NightlyOnly
+    values:
+    - NightlyOnly
+    - Release
+
 resources:
   repositories:
   - repository: self
@@ -27,6 +37,13 @@ variables:
 - group: OData-Shared
 - name: AZURE_ARTIFACTS_FEED 
   value: $(ODataFeed)
+- ${{ if eq(parameters.PublishMode, 'NightlyOnly') }}:
+  - name: PackagesToPush
+    value: $(Build.ArtifactStagingDirectory)\Nuget\*Nightly*nupkg
+
+- ${{ if eq(parameters.PublishMode, 'Release') }}: 
+  - name: PackagesToPush
+    value: '$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -66,7 +83,7 @@ extends:
           - output: nuget
             displayName: 'NuGet push - Packages to Internal Feed'
             packageParentPath: '$(Build.ArtifactStagingDirectory)\Nuget'
-            packagesToPush: '$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg'
+            packagesToPush: '$(PackagesToPush)'
             nuGetFeedType: internal
             publishVstsFeed: $(ODataPublishFeed)
             allowPackageConflicts: true


### PR DESCRIPTION
## Summary
Adds a publishing mode parameter to the OData nightly pipeline that controls which NuGet packages are published to Azure Artifacts.
The default behavior publishes only nightly packages, making scheduled validation runs safe and preventing accidental consumption of stable package versions. When a release is ready, the pipeline can be manually queued to publish both release and nightly packages.

## Motivation
Azure Artifacts package versions are immutable. Once a package version is published, that version cannot be republished, even if the package is later deleted. This makes it easy to accidentally consume a stable version during testing if release packages are published from routine nightly runs.

This change makes nightly validation the default experience while preserving the ability to publish release packages from the same pipeline.