### PR TITLE
Cherry-pick: Add opt-in diagnostic logging for OData query validation failures

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.xml
@@ -6877,6 +6877,19 @@
             Default is 100 MB (104,857,600 bytes). Please call 'SetMaxReceivedMessageSize()' to config.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableQueryValidationErrorLogging">
+            <summary>
+            Gets a value indicating whether diagnostic details are recorded when an incoming query fails validation.
+            Please call 'SetQueryValidationErrorLogging()' to config. The default value is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataMiniOptions.QueryValidationErrorLogLevel">
+            <summary>
+            Gets the <see cref="T:Microsoft.Extensions.Logging.LogLevel"/> at which query validation diagnostics are written when
+            <see cref="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableQueryValidationErrorLogging"/> is enabled. Please call 'SetQueryValidationErrorLogLevel()' to
+            config. The default value is <see cref="F:Microsoft.Extensions.Logging.LogLevel.Warning"/>.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetNoDollarQueryOptions(System.Boolean)">
             <summary>
             Config whether or not no '$' sign query option.
@@ -6889,6 +6902,22 @@
             Config the case insensitive.
             </summary>
             <param name="enableCaseInsensitive">Case insensitive or not.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetQueryValidationErrorLogging(System.Boolean)">
+            <summary>
+            Config whether or not diagnostic details are recorded when an incoming query fails validation. When
+            enabled, the endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the
+            failure reason are written.
+            </summary>
+            <param name="enableQueryValidationErrorLogging">Whether to record query validation diagnostics.</param>
+            <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetQueryValidationErrorLogLevel(Microsoft.Extensions.Logging.LogLevel)">
+            <summary>
+            Config the <see cref="T:Microsoft.Extensions.Logging.LogLevel"/> at which query validation diagnostics are written.
+            </summary>
+            <param name="logLevel">The level at which query validation diagnostics are written.</param>
             <returns>The current <see cref="T:Microsoft.AspNetCore.OData.ODataMiniOptions"/> instance to enable further configuration.</returns>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.ODataMiniOptions.SetContinueOnErrorHeader(System.Boolean)">
@@ -7211,6 +7240,25 @@
         <member name="P:Microsoft.AspNetCore.OData.ODataOptions.EnableNoDollarQueryOptions">
             <summary>
             Gets or sets whether or not the OData system query options should be prefixed with '$'.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging">
+            <summary>
+            Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+            fails validation for actions annotated with <see cref="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute"/>. When enabled, the
+            endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the failure
+            reason are written. This value provides
+            the default for every such action, allowing the behavior to be configured once instead of on each
+            attribute; an individual <see cref="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute"/> overrides it by setting
+            <see cref="P:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.EnableQueryValidationErrorLogging"/> explicitly. The default value is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.AspNetCore.OData.ODataOptions.QueryValidationErrorLogLevel">
+            <summary>
+            Gets or sets the <see cref="T:Microsoft.Extensions.Logging.LogLevel"/> at which query validation diagnostics are written for actions
+            annotated with <see cref="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute"/> when <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging"/> is enabled.
+            This value applies to every such action, so the level can be configured once. The default value is
+            <see cref="F:Microsoft.Extensions.Logging.LogLevel.Warning"/>.
             </summary>
         </member>
         <member name="P:Microsoft.AspNetCore.OData.ODataOptions.QuerySettings">
@@ -9301,6 +9349,20 @@
             Gets or sets the maximum number of expressions that can be present in the $orderby.
             </summary>
         </member>
+        <member name="P:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.EnableQueryValidationErrorLogging">
+            <summary>
+            Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+            fails validation. When enabled, the endpoint's route template, the queried type, the attempted
+            <c>$select</c> and <c>$expand</c> options, and the failure reason are written, together with the
+            validation exception, to an <see cref="T:Microsoft.Extensions.Logging.ILogger`1"/> resolved from the request services
+            and categorized for <see cref="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute"/>. This information is captured from the request
+            even when the query options cannot be fully parsed. When this property is not set on the attribute,
+            the value of <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging"/> is used, so the behavior can be
+            configured once for all actions; setting it here overrides that global value for this action. The
+            diagnostic is written at the level from <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.QueryValidationErrorLogLevel"/>
+            (default <see cref="F:Microsoft.Extensions.Logging.LogLevel.Warning"/>). The default value is <c>false</c>.
+            </summary>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.OnActionExecuting(Microsoft.AspNetCore.Mvc.Filters.ActionExecutingContext)">
             <summary>
             Performs the query composition before action is executing.
@@ -9347,13 +9409,27 @@
             <param name="actionDescriptor">The action context, i.e. action and controller name.</param>
             <param name="request">The request.</param>
         </member>
-        <member name="M:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.CreateBadRequestResult(System.String,System.Exception)">
+        <member name="M:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.CreateBadRequestResult(Microsoft.AspNetCore.Http.HttpContext,System.String,System.Exception)">
             <summary>
             Create a BadRequestObjectResult.
             </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
             <param name="message">The error message.</param>
             <param name="exception">The exception.</param>
             <returns>A BadRequestObjectResult.</returns>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.LogQueryValidationError(Microsoft.AspNetCore.Http.HttpContext,System.Exception)">
+            <summary>
+            Records diagnostic details about a query that failed validation, using the request state that is
+            available even when the query options could not be fully parsed. Does nothing unless logging is
+            enabled for the action — either on the attribute or through the global
+            <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging"/> value — and a logger is available. The diagnostic
+            is written at the level from the global <see cref="P:Microsoft.AspNetCore.OData.ODataOptions.QueryValidationErrorLogLevel"/>
+            (default <see cref="F:Microsoft.Extensions.Logging.LogLevel.Warning"/>). This never changes the response produced for
+            the failed query.
+            </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <param name="exception">The exception raised while validating the query.</param>
         </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.CreateErrorResponse(System.String,System.Exception)">
             <summary>
@@ -11778,6 +11854,17 @@
             The <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> instance constructed based on the incoming request.
             </param>
         </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.LogQueryValidationError(Microsoft.AspNetCore.Http.HttpContext,System.Exception)">
+            <summary>
+            Records diagnostic details about a query that failed validation, using the request state that is
+            available even when the query options could not be fully parsed. Does nothing unless logging is enabled
+            through <see cref="P:Microsoft.AspNetCore.OData.ODataMiniOptions.EnableQueryValidationErrorLogging"/> and a logger is available. The diagnostic
+            is written at the level from <see cref="P:Microsoft.AspNetCore.OData.ODataMiniOptions.QueryValidationErrorLogLevel"/>. This never
+            changes the response produced for the failed query.
+            </summary>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <param name="exception">The exception raised while validating the query.</param>
+        </member>
         <member name="M:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter.CreateQueryOptionsOnExecuting(Microsoft.AspNetCore.OData.Extensions.ODataQueryFilterInvocationContext)">
             <summary>
             Creates the <see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryOptions"/> for action executing validation.
@@ -12533,6 +12620,32 @@
             </summary>
             <param name="type">The type</param>
             <returns><c>true</c> if the type is IQueryable.</returns>
+        </member>
+        <member name="T:Microsoft.AspNetCore.OData.Query.QueryValidationErrorLogger">
+            <summary>
+            Writes structured diagnostics about a query that failed validation, using request state that is available
+            even when the query options could not be fully parsed. This is shared by the controller
+            (<see cref="T:Microsoft.AspNetCore.OData.Query.EnableQueryAttribute"/>) and minimal API (<see cref="T:Microsoft.AspNetCore.OData.Query.ODataQueryEndpointFilter"/>) paths so both
+            report the same information. It never changes the response produced for the failed query.
+            </summary>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.QueryValidationErrorLogger.LogQueryValidationFailure(Microsoft.Extensions.Logging.ILogger,Microsoft.Extensions.Logging.LogLevel,Microsoft.AspNetCore.Http.HttpContext,System.Exception)">
+            <summary>
+            Writes the diagnostic entry for a failed query validation at the specified level. Does nothing when no
+            logger is available or the level is not enabled.
+            </summary>
+            <param name="logger">The logger to write to, or <c>null</c> when none is available.</param>
+            <param name="logLevel">The level at which the diagnostic is written.</param>
+            <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> for the current request.</param>
+            <param name="exception">The exception raised while validating the query.</param>
+        </member>
+        <member name="M:Microsoft.AspNetCore.OData.Query.QueryValidationErrorLogger.FormatRequestedQueryOptions(Microsoft.AspNetCore.OData.Query.ODataRawQueryOptions)">
+            <summary>
+            Builds a compact description of the requested query options that reference properties, including only
+            the options that were supplied so empty options are not reported.
+            </summary>
+            <param name="rawValues">The raw query option values, or <c>null</c> when unavailable.</param>
+            <returns>The requested query options, or an empty string when none apply.</returns>
         </member>
         <member name="T:Microsoft.AspNetCore.OData.Query.ApplyQueryOption">
             <summary>

--- a/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataMiniOptions.cs
@@ -9,6 +9,7 @@ using System;
 using Microsoft.AspNetCore.OData.Batch;
 using Microsoft.AspNetCore.OData.Common;
 using Microsoft.AspNetCore.OData.Query;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 
 namespace Microsoft.AspNetCore.OData;
@@ -25,6 +26,8 @@ public class ODataMiniOptions
     private TimeZoneInfo _timeZone = TimeZoneInfo.Local;
     private ODataVersion _version = ODataVersionConstraint.DefaultODataVersion;
     private long _maxReceivedMessageSize = ODataBatchHandler.DefaultMaxReceivedMessageSize;
+    private bool _enableQueryValidationErrorLogging = false;
+    private LogLevel _queryValidationErrorLogLevel = LogLevel.Warning;
 
     /// <summary>
     /// Gets the query configurations. for example, enable '$select' or not.
@@ -68,6 +71,19 @@ public class ODataMiniOptions
     public long MaxReceivedMessageSize { get => _maxReceivedMessageSize; }
 
     /// <summary>
+    /// Gets a value indicating whether diagnostic details are recorded when an incoming query fails validation.
+    /// Please call 'SetQueryValidationErrorLogging()' to config. The default value is <c>false</c>.
+    /// </summary>
+    public bool EnableQueryValidationErrorLogging { get => _enableQueryValidationErrorLogging; }
+
+    /// <summary>
+    /// Gets the <see cref="LogLevel"/> at which query validation diagnostics are written when
+    /// <see cref="EnableQueryValidationErrorLogging"/> is enabled. Please call 'SetQueryValidationErrorLogLevel()' to
+    /// config. The default value is <see cref="LogLevel.Warning"/>.
+    /// </summary>
+    public LogLevel QueryValidationErrorLogLevel { get => _queryValidationErrorLogLevel; }
+
+    /// <summary>
     /// Config whether or not no '$' sign query option.
     /// </summary>
     /// <param name="enableNoDollarQueryOptions">Case insensitive or not.</param>
@@ -86,6 +102,30 @@ public class ODataMiniOptions
     public ODataMiniOptions SetCaseInsensitive(bool enableCaseInsensitive)
     {
         _enableCaseInsensitive = enableCaseInsensitive;
+        return this;
+    }
+
+    /// <summary>
+    /// Config whether or not diagnostic details are recorded when an incoming query fails validation. When
+    /// enabled, the endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the
+    /// failure reason are written.
+    /// </summary>
+    /// <param name="enableQueryValidationErrorLogging">Whether to record query validation diagnostics.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetQueryValidationErrorLogging(bool enableQueryValidationErrorLogging)
+    {
+        _enableQueryValidationErrorLogging = enableQueryValidationErrorLogging;
+        return this;
+    }
+
+    /// <summary>
+    /// Config the <see cref="LogLevel"/> at which query validation diagnostics are written.
+    /// </summary>
+    /// <param name="logLevel">The level at which query validation diagnostics are written.</param>
+    /// <returns>The current <see cref="ODataMiniOptions"/> instance to enable further configuration.</returns>
+    public ODataMiniOptions SetQueryValidationErrorLogLevel(LogLevel logLevel)
+    {
+        _queryValidationErrorLogLevel = logLevel;
         return this;
     }
 
@@ -240,5 +280,7 @@ public class ODataMiniOptions
         this._enableContinueOnErrorHeader = otherOptions.EnableContinueOnErrorHeader;
         this._timeZone = otherOptions.TimeZone;
         this._maxReceivedMessageSize = otherOptions.MaxReceivedMessageSize;
+        this._enableQueryValidationErrorLogging = otherOptions.EnableQueryValidationErrorLogging;
+        this._queryValidationErrorLogLevel = otherOptions.QueryValidationErrorLogLevel;
     }
 }

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.AspNetCore.OData.Routing.Conventions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder.Config;
@@ -311,6 +312,25 @@ public class ODataOptions
     /// Gets or sets whether or not the OData system query options should be prefixed with '$'.
     /// </summary>
     public bool EnableNoDollarQueryOptions { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+    /// fails validation for actions annotated with <see cref="EnableQueryAttribute"/>. When enabled, the
+    /// endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the failure
+    /// reason are written. This value provides
+    /// the default for every such action, allowing the behavior to be configured once instead of on each
+    /// attribute; an individual <see cref="EnableQueryAttribute"/> overrides it by setting
+    /// <see cref="EnableQueryAttribute.EnableQueryValidationErrorLogging"/> explicitly. The default value is <c>false</c>.
+    /// </summary>
+    public bool EnableQueryValidationErrorLogging { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="LogLevel"/> at which query validation diagnostics are written for actions
+    /// annotated with <see cref="EnableQueryAttribute"/> when <see cref="EnableQueryValidationErrorLogging"/> is enabled.
+    /// This value applies to every such action, so the level can be configured once. The default value is
+    /// <see cref="LogLevel.Warning"/>.
+    /// </summary>
+    public LogLevel QueryValidationErrorLogLevel { get; set; } = LogLevel.Warning;
 
     /// <summary>
     /// Gets the query settings.

--- a/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AspNetCore.OData/PublicAPI.Unshipped.txt
@@ -2,6 +2,16 @@ Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.get 
 Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeout.set -> void
 Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.get -> int
 Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.MatchesPatternTimeoutMilliseconds.set -> void
+Microsoft.AspNetCore.OData.ODataMiniOptions.EnableQueryValidationErrorLogging.get -> bool
+Microsoft.AspNetCore.OData.ODataMiniOptions.QueryValidationErrorLogLevel.get -> Microsoft.Extensions.Logging.LogLevel
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetQueryValidationErrorLogLevel(Microsoft.Extensions.Logging.LogLevel logLevel) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataMiniOptions.SetQueryValidationErrorLogging(bool enableQueryValidationErrorLogging) -> Microsoft.AspNetCore.OData.ODataMiniOptions
+Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging.get -> bool
+Microsoft.AspNetCore.OData.ODataOptions.EnableQueryValidationErrorLogging.set -> void
+Microsoft.AspNetCore.OData.ODataOptions.QueryValidationErrorLogLevel.get -> Microsoft.Extensions.Logging.LogLevel
+Microsoft.AspNetCore.OData.ODataOptions.QueryValidationErrorLogLevel.set -> void
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.EnableQueryValidationErrorLogging.get -> bool
+Microsoft.AspNetCore.OData.Query.EnableQueryAttribute.EnableQueryValidationErrorLogging.set -> void
 Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.get -> System.TimeSpan?
 Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MatchesPatternTimeout.set -> void
 Microsoft.AspNetCore.OData.Query.ODataQuerySettings.MaxFunctionCallDepth.get -> int

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.Config.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.Config.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Microsoft.AspNetCore.OData.Query.Validator;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.OData.Query;
 
@@ -20,6 +21,7 @@ public partial class EnableQueryAttribute
     // validation settings
     private ODataValidationSettings _validationSettings;
     private string _allowedOrderByProperties;
+    private bool? _enableQueryValidationErrorLogging;
 
     // query settings
     private ODataQuerySettings _querySettings;
@@ -308,5 +310,23 @@ public partial class EnableQueryAttribute
     {
         get => _validationSettings.MaxOrderByNodeCount;
         set => _validationSettings.MaxOrderByNodeCount = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+    /// fails validation. When enabled, the endpoint's route template, the queried type, the attempted
+    /// <c>$select</c> and <c>$expand</c> options, and the failure reason are written, together with the
+    /// validation exception, to an <see cref="ILogger{TCategoryName}"/> resolved from the request services
+    /// and categorized for <see cref="EnableQueryAttribute"/>. This information is captured from the request
+    /// even when the query options cannot be fully parsed. When this property is not set on the attribute,
+    /// the value of <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> is used, so the behavior can be
+    /// configured once for all actions; setting it here overrides that global value for this action. The
+    /// diagnostic is written at the level from <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
+    /// (default <see cref="LogLevel.Warning"/>). The default value is <c>false</c>.
+    /// </summary>
+    public bool EnableQueryValidationErrorLogging
+    {
+        get => _enableQueryValidationErrorLogging ?? false;
+        set => _enableQueryValidationErrorLogging = value;
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/EnableQueryAttribute.cs
@@ -27,6 +27,8 @@ using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Results;
 using Microsoft.AspNetCore.OData.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder.Config;
@@ -82,18 +84,21 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         catch (ArgumentOutOfRangeException e)
         {
             actionExecutingContext.Result = CreateBadRequestResult(
+                actionExecutingContext.HttpContext,
                 Error.Format(SRResources.QueryParameterNotSupported, e.Message),
                 e);
         }
         catch (NotImplementedException e)
         {
             actionExecutingContext.Result = CreateBadRequestResult(
+                actionExecutingContext.HttpContext,
                 Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                 e);
         }
         catch (NotSupportedException e)
         {
             actionExecutingContext.Result = CreateBadRequestResult(
+                actionExecutingContext.HttpContext,
                 Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                 e);
         }
@@ -101,6 +106,7 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         {
             // Will also catch ODataException here because ODataException derives from InvalidOperationException.
             actionExecutingContext.Result = CreateBadRequestResult(
+                actionExecutingContext.HttpContext,
                 Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                 e);
         }
@@ -359,28 +365,28 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
             }
             catch (ArgumentOutOfRangeException e)
             {
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.QueryParameterNotSupported, e.Message), e);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.QueryParameterNotSupported, e.Message), e);
             }
             catch (RegexMatchTimeoutException e)
             {
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
             }
             catch (TargetInvocationException e) when (e.InnerException is RegexMatchTimeoutException)
             {
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.InnerException.Message), e.InnerException);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.InnerException.Message), e.InnerException);
             }
             catch (NotImplementedException e)
             {
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
             }
             catch (NotSupportedException e)
             {
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
             }
             catch (InvalidOperationException e)
             {
                 // Will also catch ODataException here because ODataException derives from InvalidOperationException.
-                actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+                actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
             }
         }
 
@@ -410,7 +416,7 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         }
         catch (InvalidOperationException e)
         {
-            actionExecutedContext.Result = CreateBadRequestResult(Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
+            actionExecutedContext.Result = CreateBadRequestResult(request.HttpContext, Error.Format(SRResources.UriQueryStringInvalid, e.Message), e);
             return;
         }
 
@@ -425,13 +431,55 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
     /// <summary>
     /// Create a BadRequestObjectResult.
     /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
     /// <param name="message">The error message.</param>
     /// <param name="exception">The exception.</param>
     /// <returns>A BadRequestObjectResult.</returns>
-    private static BadRequestObjectResult CreateBadRequestResult(string message, Exception exception)
+    private BadRequestObjectResult CreateBadRequestResult(HttpContext httpContext, string message, Exception exception)
     {
+        LogQueryValidationError(httpContext, exception);
+
         SerializableError error = CreateErrorResponse(message, exception);
         return new BadRequestObjectResult(error);
+    }
+
+    /// <summary>
+    /// Records diagnostic details about a query that failed validation, using the request state that is
+    /// available even when the query options could not be fully parsed. Does nothing unless logging is
+    /// enabled for the action — either on the attribute or through the global
+    /// <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> value — and a logger is available. The diagnostic
+    /// is written at the level from the global <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
+    /// (default <see cref="LogLevel.Warning"/>). This never changes the response produced for
+    /// the failed query.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="exception">The exception raised while validating the query.</param>
+    private void LogQueryValidationError(HttpContext httpContext, Exception exception)
+    {
+        if (httpContext == null)
+        {
+            return;
+        }
+
+        // When the attribute does not set the flag, fall back to the global value from ODataOptions so the
+        // behavior can be configured once for all actions. An explicit value on the attribute takes precedence.
+        ODataOptions odataOptions = httpContext.ODataOptions();
+        bool loggingEnabled = _enableQueryValidationErrorLogging ?? odataOptions?.EnableQueryValidationErrorLogging ?? false;
+        if (!loggingEnabled)
+        {
+            return;
+        }
+
+        ILogger logger = httpContext.RequestServices?.GetService<ILogger<EnableQueryAttribute>>();
+        if (logger == null)
+        {
+            return;
+        }
+
+        // The global level from ODataOptions applies, defaulting to Warning when it is not configured.
+        LogLevel logLevel = odataOptions?.QueryValidationErrorLogLevel ?? LogLevel.Warning;
+
+        QueryValidationErrorLogger.LogQueryValidationFailure(logger, logLevel, httpContext, exception);
     }
 
     /// <summary>
@@ -607,6 +655,13 @@ public partial class EnableQueryAttribute : ActionFilterAttribute
         }
 
         ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, request);
+
+        if (requestQueryData != null)
+        {
+            // Capture the options so diagnostics on the post-action validation path can report the element
+            // type and the attempted query, consistent with the pre-action path.
+            requestQueryData.ProcessedQueryOptions = queryOptions;
+        }
 
         ValidateQuery(request, queryOptions);
 

--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryEndpointFilter.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryEndpointFilter.cs
@@ -23,6 +23,9 @@ using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.OData.Results;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder.Config;
@@ -469,18 +472,50 @@ public class ODataQueryEndpointFilter : IODataQueryEndpointFilter
         ArgumentNullException.ThrowIfNull(httpContext, nameof(httpContext));
         ArgumentNullException.ThrowIfNull(queryOptions, nameof(queryOptions));
 
-        IQueryCollection queryParameters = httpContext.Request.Query;
-        foreach (var kvp in queryParameters)
+        try
         {
-            if (!queryOptions.IsSupportedQueryOption(kvp.Key) &&
-                 kvp.Key.StartsWith("$", StringComparison.Ordinal))
+            IQueryCollection queryParameters = httpContext.Request.Query;
+            foreach (var kvp in queryParameters)
             {
-                // we don't support any custom query options that start with $
-                throw new ODataException(Error.Format(SRResources.CustomQueryOptionNotSupportedWithDollarSign, kvp.Key));
+                if (!queryOptions.IsSupportedQueryOption(kvp.Key) &&
+                     kvp.Key.StartsWith("$", StringComparison.Ordinal))
+                {
+                    // we don't support any custom query options that start with $
+                    throw new ODataException(Error.Format(SRResources.CustomQueryOptionNotSupportedWithDollarSign, kvp.Key));
+                }
             }
+
+            queryOptions.Validate(ValidationSettings);
+        }
+        catch (Exception exception)
+        {
+            LogQueryValidationError(httpContext, exception);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Records diagnostic details about a query that failed validation, using the request state that is
+    /// available even when the query options could not be fully parsed. Does nothing unless logging is enabled
+    /// through <see cref="ODataMiniOptions.EnableQueryValidationErrorLogging"/> and a logger is available. The diagnostic
+    /// is written at the level from <see cref="ODataMiniOptions.QueryValidationErrorLogLevel"/>. This never
+    /// changes the response produced for the failed query.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="exception">The exception raised while validating the query.</param>
+    private static void LogQueryValidationError(HttpContext httpContext, Exception exception)
+    {
+        // The per-endpoint metadata already merges the global options; fall back to the global options when the
+        // endpoint has no metadata.
+        ODataMiniOptions options = httpContext.GetEndpoint()?.Metadata.GetMetadata<ODataMiniMetadata>()?.Options
+            ?? httpContext.RequestServices?.GetService<IOptions<ODataMiniOptions>>()?.Value;
+        if (options == null || !options.EnableQueryValidationErrorLogging)
+        {
+            return;
         }
 
-        queryOptions.Validate(ValidationSettings);
+        ILogger logger = httpContext.RequestServices?.GetService<ILogger<ODataQueryEndpointFilter>>();
+        QueryValidationErrorLogger.LogQueryValidationFailure(logger, options.QueryValidationErrorLogLevel, httpContext, exception);
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Query/QueryValidationErrorLogger.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/QueryValidationErrorLogger.cs
@@ -1,0 +1,111 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLogger.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNetCore.OData.Query;
+
+/// <summary>
+/// Writes structured diagnostics about a query that failed validation, using request state that is available
+/// even when the query options could not be fully parsed. This is shared by the controller
+/// (<see cref="EnableQueryAttribute"/>) and minimal API (<see cref="ODataQueryEndpointFilter"/>) paths so both
+/// report the same information. It never changes the response produced for the failed query.
+/// </summary>
+internal static class QueryValidationErrorLogger
+{
+    private const string MessageTemplate =
+        "OData query validation failed. Endpoint: {Endpoint}, Type: {QueryType}, Query options: {QueryOptions}. {Reason}";
+
+    /// <summary>
+    /// Writes the diagnostic entry for a failed query validation at the specified level. Does nothing when no
+    /// logger is available or the level is not enabled.
+    /// </summary>
+    /// <param name="logger">The logger to write to, or <c>null</c> when none is available.</param>
+    /// <param name="logLevel">The level at which the diagnostic is written.</param>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="exception">The exception raised while validating the query.</param>
+    internal static void LogQueryValidationFailure(ILogger logger, LogLevel logLevel, HttpContext httpContext, Exception exception)
+    {
+        if (logger == null || httpContext == null || !logger.IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        // The processed query options are captured before validation runs; they carry the raw values that
+        // were normalized during parsing, so the requested set is reported regardless of whether the request
+        // used the '$' prefix. They may be null when the query options could not be built, in which case the
+        // element type and requested options are omitted.
+        ODataQueryOptions processedQueryOptions = null;
+        if (httpContext.Items.TryGetValue(nameof(RequestQueryData), out object item) &&
+            item is RequestQueryData requestQueryData)
+        {
+            processedQueryOptions = requestQueryData.ProcessedQueryOptions;
+        }
+
+        try
+        {
+            // Record the matched endpoint's route template (for example, "v1.0/Users({key})") rather than the
+            // concrete request path. The template identifies the endpoint and keeps the route prefix while
+            // representing entity keys as placeholders, so the same endpoint is reported consistently across
+            // requests. It is null when the endpoint is not a routed endpoint, in which case it is omitted.
+            string endpoint = (httpContext.GetEndpoint() as RouteEndpoint)?.RoutePattern?.RawText;
+
+            logger.Log(
+                logLevel,
+                exception,
+                MessageTemplate,
+                endpoint,
+                processedQueryOptions?.Context?.ElementType?.FullTypeName(),
+                FormatRequestedQueryOptions(processedQueryOptions?.RawValues),
+                exception?.Message);
+        }
+        catch (Exception)
+        {
+            // Recording the diagnostic must never change the request outcome. If the configured logging
+            // provider throws while writing this entry, suppress it so the original validation response and
+            // the exception raised for the failed query are preserved unchanged.
+        }
+    }
+
+    /// <summary>
+    /// Builds a compact description of the requested query options that reference properties, including only
+    /// the options that were supplied so empty options are not reported.
+    /// </summary>
+    /// <param name="rawValues">The raw query option values, or <c>null</c> when unavailable.</param>
+    /// <returns>The requested query options, or an empty string when none apply.</returns>
+    private static string FormatRequestedQueryOptions(ODataRawQueryOptions rawValues)
+    {
+        if (rawValues == null)
+        {
+            return string.Empty;
+        }
+
+        bool hasSelect = !string.IsNullOrEmpty(rawValues.Select);
+        bool hasExpand = !string.IsNullOrEmpty(rawValues.Expand);
+
+        if (hasSelect && hasExpand)
+        {
+            return string.Concat("$select=", rawValues.Select, "&$expand=", rawValues.Expand);
+        }
+
+        if (hasSelect)
+        {
+            return string.Concat("$select=", rawValues.Select);
+        }
+
+        if (hasExpand)
+        {
+            return string.Concat("$expand=", rawValues.Expand);
+        }
+
+        return string.Empty;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingGlobalLevelTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingGlobalLevelTests.cs
@@ -1,0 +1,92 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MinimalApiQueryValidationErrorLoggingGlobalLevelTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+/// <summary>
+/// End-to-end tests that verify configuring the level once through <c>AddOData</c> with
+/// <see cref="ODataMiniOptions.SetQueryValidationErrorLogLevel(LogLevel)"/> applies to every minimal API
+/// endpoint that records query validation diagnostics.
+/// </summary>
+public class MinimalApiQueryValidationErrorLoggingGlobalLevelTests : IClassFixture<MinimalTestFixture<MinimalApiQueryValidationErrorLoggingGlobalLevelTests>>
+{
+    private readonly HttpClient _client;
+
+    public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+    public MinimalApiQueryValidationErrorLoggingGlobalLevelTests(MinimalTestFixture<MinimalApiQueryValidationErrorLoggingGlobalLevelTests> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(LoggerProvider);
+        });
+
+        // Enable logging and set the level once for every minimal API endpoint.
+        services.AddOData(o => o.SetQueryValidationErrorLogging(true).SetQueryValidationErrorLogLevel(LogLevel.Error));
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        // No per-endpoint configuration; the endpoint picks up the global level.
+        app.MapGet("globallevel/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model);
+    }
+
+    [Fact]
+    public async Task GlobalLogLevel_UnknownSelectProperty_WritesDiagnosticAtGlobalLevel()
+    {
+        // The endpoint records the diagnostic at the level configured once through AddOData.
+        LoggerProvider.Clear();
+
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/globallevel/todos?$select=NoSuchProperty"));
+
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Contains("globallevel/todos", entry.GetFieldValue("Endpoint"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+    }
+
+    private static IEnumerable<MiniTodo> GetTodos()
+    {
+        return new List<MiniTodo>
+        {
+            new MiniTodo { Id = 1, Owner = "Sam", Title = "Clean House", IsDone = false },
+        };
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(ODataQueryEndpointFilter).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingGlobalTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingGlobalTests.cs
@@ -1,0 +1,110 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MinimalApiQueryValidationErrorLoggingGlobalTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+/// <summary>
+/// End-to-end tests that verify configuring logging once through <c>AddOData</c> enables the diagnostic for
+/// every minimal API endpoint, and that an individual endpoint still overrides the global value through
+/// <see cref="ODataMiniOptions.SetQueryValidationErrorLogging(bool)"/>.
+/// </summary>
+public class MinimalApiQueryValidationErrorLoggingGlobalTests : IClassFixture<MinimalTestFixture<MinimalApiQueryValidationErrorLoggingGlobalTests>>
+{
+    private readonly HttpClient _client;
+
+    public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+    public MinimalApiQueryValidationErrorLoggingGlobalTests(MinimalTestFixture<MinimalApiQueryValidationErrorLoggingGlobalTests> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(LoggerProvider);
+        });
+
+        // Enable logging once for every minimal API endpoint.
+        services.AddOData(o => o.SetQueryValidationErrorLogging(true));
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        // No per-endpoint logging configuration; the endpoint picks up the global value.
+        app.MapGet("global/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model);
+
+        // The endpoint overrides the global value and opts out.
+        app.MapGet("optout/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model)
+            .WithODataOptions(o => o.SetQueryValidationErrorLogging(false));
+    }
+
+    [Fact]
+    public async Task GlobalLoggingEnabled_UnknownSelectProperty_WritesDiagnostic()
+    {
+        // An endpoint that does not configure logging picks up the global configuration.
+        LoggerProvider.Clear();
+
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/global/todos?$select=NoSuchProperty"));
+
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("global/todos", entry.GetFieldValue("Endpoint"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+    }
+
+    [Fact]
+    public async Task GlobalLoggingEnabled_EndpointOptOut_WritesNoDiagnostic()
+    {
+        // An endpoint that sets SetQueryValidationErrorLogging(false) overrides the global enabled value.
+        LoggerProvider.Clear();
+
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/optout/todos?$select=NoSuchProperty"));
+
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    private static IEnumerable<MiniTodo> GetTodos()
+    {
+        return new List<MiniTodo>
+        {
+            new MiniTodo { Id = 1, Owner = "Sam", Title = "Clean House", IsDone = false },
+        };
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(ODataQueryEndpointFilter).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingLoggerFailureTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingLoggerFailureTests.cs
@@ -1,0 +1,77 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MinimalApiQueryValidationErrorLoggingLoggerFailureTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+/// <summary>
+/// End-to-end test that verifies a logging provider which throws while recording the diagnostic never changes
+/// the outcome of a failed query on the minimal API path: the original validation exception is still the one
+/// that propagates, not the exception raised by the logger. The provider throws only for the diagnostic's own
+/// category, so the rest of the framework's logging is unaffected.
+/// </summary>
+public class MinimalApiQueryValidationErrorLoggingLoggerFailureTests : IClassFixture<MinimalTestFixture<MinimalApiQueryValidationErrorLoggingLoggerFailureTests>>
+{
+    private readonly HttpClient _client;
+
+    public MinimalApiQueryValidationErrorLoggingLoggerFailureTests(MinimalTestFixture<MinimalApiQueryValidationErrorLoggingLoggerFailureTests> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(new ThrowingLoggerProvider(typeof(ODataQueryEndpointFilter).FullName));
+        });
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        // Logging is enabled on the endpoint, but the only registered logging provider throws when it writes the
+        // diagnostic. The default level is Warning.
+        app.MapGet("logging/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model)
+            .WithODataOptions(o => o.Select().Expand().SetQueryValidationErrorLogging(true));
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_WhenLoggerThrows_OriginalValidationExceptionStillPropagates()
+    {
+        // The logger throws while writing the diagnostic, but that must not replace the validation failure:
+        // the original ODataException is still the exception that surfaces from the request.
+        ODataException exception = await Assert.ThrowsAsync<ODataException>(
+            () => _client.GetAsync("/logging/todos?$select=NoSuchProperty"));
+
+        Assert.Contains("NoSuchProperty", exception.Message);
+    }
+
+    private static IEnumerable<MiniTodo> GetTodos()
+    {
+        return new List<MiniTodo>
+        {
+            new MiniTodo { Id = 1, Owner = "Sam", Title = "Clean House", IsDone = false },
+        };
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/MinimalApis/MinimalApiQueryValidationErrorLoggingTests.cs
@@ -1,0 +1,180 @@
+//-----------------------------------------------------------------------------
+// <copyright file="MinimalApiQueryValidationErrorLoggingTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.MinimalApis;
+
+/// <summary>
+/// End-to-end tests that verify diagnostics are recorded through the real minimal API request pipeline when a
+/// query fails validation and logging is enabled per endpoint through
+/// <see cref="ODataMiniOptions.SetQueryValidationErrorLogging(bool)"/>. Logging is off by default; configuring it
+/// once for all endpoints through <c>AddOData</c> is covered by
+/// <see cref="MinimalApiQueryValidationErrorLoggingGlobalTests"/>.
+/// </summary>
+public class MinimalApiQueryValidationErrorLoggingTests : IClassFixture<MinimalTestFixture<MinimalApiQueryValidationErrorLoggingTests>>
+{
+    private readonly HttpClient _client;
+
+    public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+    public MinimalApiQueryValidationErrorLoggingTests(MinimalTestFixture<MinimalApiQueryValidationErrorLoggingTests> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    protected static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(LoggerProvider);
+        });
+    }
+
+    protected static void ConfigureAPIs(WebApplication app)
+    {
+        IEdmModel model = MinimalEdmModel.GetEdmModel();
+
+        // Logging enabled on the endpoint; the default level is Warning.
+        app.MapGet("logging/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model)
+            .WithODataOptions(o => o.Select().Expand().SetQueryValidationErrorLogging(true));
+
+        // Logging left at its default (off) on the endpoint.
+        app.MapGet("plain/todos", () => GetTodos())
+            .AddODataQueryEndpointFilter()
+            .WithODataResult()
+            .WithODataModel(model);
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_UnknownSelectProperty_WritesDiagnostic()
+    {
+        // Arrange
+        LoggerProvider.Clear();
+
+        // Act
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/logging/todos?$select=NoSuchProperty"));
+
+        // Assert
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("logging/todos", entry.GetFieldValue("Endpoint"));
+        Assert.Contains("MiniTodo", entry.GetFieldValue("QueryType"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+        Assert.Contains(" at ", entry.Exception.ToString());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_UnknownExpandProperty_WritesDiagnostic()
+    {
+        // Arrange
+        LoggerProvider.Clear();
+
+        // Act
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/logging/todos?$expand=NoSuchNavigation"));
+
+        // Assert
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal("$expand=NoSuchNavigation", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchNavigation", entry.Exception.Message);
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_UnknownSelectPropertyWithoutDollarPrefix_WritesDiagnostic()
+    {
+        // The '$' prefix on system query options is optional and enabled by default, so the attempted
+        // select set must be captured for the no-'$' form as well.
+        LoggerProvider.Clear();
+
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/logging/todos?select=NoSuchProperty"));
+
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+    }
+
+    [Fact]
+    public async Task PlainEndpoint_UnknownSelectProperty_WritesNoDiagnosticByDefault()
+    {
+        // An endpoint that does not enable logging writes nothing, even though the query still fails validation.
+        LoggerProvider.Clear();
+
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/plain/todos?$select=NoSuchProperty"));
+
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_ValidSelectProperty_WritesNoDiagnostic()
+    {
+        // Arrange
+        LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await _client.GetAsync("/logging/todos?$select=Owner");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEndpoint_SelectiveAcrossSequentialRequests()
+    {
+        // A bad request writes exactly one diagnostic.
+        LoggerProvider.Clear();
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/logging/todos?$select=NoSuchProperty"));
+        Assert.Single(GetQueryValidationEntries());
+
+        // A subsequent valid request writes no diagnostic.
+        LoggerProvider.Clear();
+        HttpResponseMessage validResponse = await _client.GetAsync("/logging/todos?$select=Owner");
+        Assert.Equal(HttpStatusCode.OK, validResponse.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+
+        // A repeated bad request writes the diagnostic again.
+        LoggerProvider.Clear();
+        await Assert.ThrowsAsync<ODataException>(() => _client.GetAsync("/logging/todos?$select=NoSuchProperty"));
+        Assert.Single(GetQueryValidationEntries());
+    }
+
+    private static IEnumerable<MiniTodo> GetTodos()
+    {
+        return new List<MiniTodo>
+        {
+            new MiniTodo { Id = 1, Owner = "Sam", Title = "Clean House", IsDone = false },
+        };
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(ODataQueryEndpointFilter).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingController.cs
@@ -1,0 +1,70 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+public class LoggingCustomersController : ControllerBase
+{
+    [HttpGet]
+    [EnableQuery(EnableQueryValidationErrorLogging = true)]
+    public ActionResult<IEnumerable<LoggingCustomer>> Get()
+    {
+        return new List<LoggingCustomer>
+        {
+            new LoggingCustomer { Id = 1, Name = "Alice" },
+        };
+    }
+}
+
+public class PlainCustomersController : ControllerBase
+{
+    [HttpGet]
+    [EnableQuery]
+    public ActionResult<IEnumerable<LoggingCustomer>> Get()
+    {
+        return new List<LoggingCustomer>
+        {
+            new LoggingCustomer { Id = 1, Name = "Alice" },
+        };
+    }
+}
+
+public class OptOutCustomersController : ControllerBase
+{
+    [HttpGet]
+    [EnableQuery(EnableQueryValidationErrorLogging = false)]
+    public ActionResult<IEnumerable<LoggingCustomer>> Get()
+    {
+        return new List<LoggingCustomer>
+        {
+            new LoggingCustomer { Id = 1, Name = "Alice" },
+        };
+    }
+}
+
+[Route("postaction")]
+public class PostActionLoggingCustomersController : ControllerBase
+{
+    // The non-generic IActionResult return type cannot be resolved before the action runs, so the query is
+    // validated on the post-action path. This exercises that path for the logging diagnostic.
+    [HttpGet("customers")]
+    [EnableQuery(EnableQueryValidationErrorLogging = true)]
+    public IActionResult Get()
+    {
+        IQueryable<LoggingCustomer> customers = new List<LoggingCustomer>
+        {
+            new LoggingCustomer { Id = 1, Name = "Alice" },
+        }.AsQueryable();
+
+        return Ok(customers);
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingCustomLevelTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingCustomLevelTests.cs
@@ -1,0 +1,89 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingCustomLevelTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+/// <summary>
+/// End-to-end tests that verify <see cref="ODataOptions.QueryValidationErrorLogLevel"/> sets the level of the
+/// diagnostic once for every <see cref="EnableQueryAttribute"/> action.
+/// </summary>
+public class QueryValidationErrorLoggingCustomLevelTests : WebODataTestBase<QueryValidationErrorLoggingCustomLevelTests.Startup>
+{
+    public class Startup : TestStartupBase
+    {
+        public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(PlainCustomersController));
+
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Warning);
+                builder.AddProvider(LoggerProvider);
+            });
+
+            IEdmModel model = QueryValidationErrorLoggingEdmModel.GetEdmModel();
+            services.AddControllers().AddOData(options =>
+            {
+                options.EnableQueryValidationErrorLogging = true; // Enable once for every [EnableQuery] action.
+                options.QueryValidationErrorLogLevel = LogLevel.Error; // Record at a non-default level for every action.
+                options.AddRouteComponents("odata", model).Select().Expand();
+            });
+        }
+    }
+
+    public QueryValidationErrorLoggingCustomLevelTests(WebODataTestFixture<Startup> fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task PlainEntitySet_UnknownSelectProperty_WritesDiagnosticAtGlobalLevel()
+    {
+        // A plain [EnableQuery] attribute records the diagnostic at the global level (Error).
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/PlainCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+    }
+
+    private static HttpRequestMessage CreateGet(string url)
+    {
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+        return request;
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return Startup.LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(EnableQueryAttribute).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingEdmModel.cs
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingEdmModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+public class QueryValidationErrorLoggingEdmModel
+{
+    public static IEdmModel GetEdmModel()
+    {
+        ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+        builder.EntitySet<LoggingCustomer>("LoggingCustomers");
+        builder.EntitySet<LoggingCustomer>("PlainCustomers");
+        builder.EntitySet<LoggingCustomer>("OptOutCustomers");
+        return builder.GetEdmModel();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingGlobalTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingGlobalTests.cs
@@ -1,0 +1,120 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingGlobalTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+/// <summary>
+/// End-to-end tests that verify <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> configures the
+/// diagnostic once for every <see cref="EnableQueryAttribute"/> action, and that an individual attribute
+/// still overrides the global value.
+/// </summary>
+public class QueryValidationErrorLoggingGlobalTests : WebODataTestBase<QueryValidationErrorLoggingGlobalTests.Startup>
+{
+    public class Startup : TestStartupBase
+    {
+        public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(LoggingCustomersController), typeof(PlainCustomersController), typeof(OptOutCustomersController));
+
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Warning);
+                builder.AddProvider(LoggerProvider);
+            });
+
+            IEdmModel model = QueryValidationErrorLoggingEdmModel.GetEdmModel();
+            services.AddControllers().AddOData(options =>
+            {
+                options.EnableQueryValidationErrorLogging = true; // Enable once for every [EnableQuery] action.
+                options.AddRouteComponents("odata", model).Select().Expand();
+            });
+        }
+    }
+
+    public QueryValidationErrorLoggingGlobalTests(WebODataTestFixture<Startup> fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task PlainEntitySet_UnknownSelectProperty_WritesDiagnostic_WhenConfiguredGlobally()
+    {
+        // A plain [EnableQuery] attribute that does not set the flag picks up the global configuration.
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/PlainCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("PlainCustomers", entry.GetFieldValue("Endpoint"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+    }
+
+    [Fact]
+    public async Task OptOutEntitySet_UnknownSelectProperty_WritesNoDiagnostic_WhenConfiguredGlobally()
+    {
+        // An attribute that sets EnableQueryValidationErrorLogging = false overrides the global enabled value.
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/OptOutCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task AttributeEnabledEntitySet_UnknownSelectProperty_WritesDiagnostic_WhenConfiguredGlobally()
+    {
+        // An attribute that sets EnableQueryValidationErrorLogging = true logs, consistent with the global value.
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+    }
+
+    private static HttpRequestMessage CreateGet(string url)
+    {
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+        return request;
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return Startup.LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(EnableQueryAttribute).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingODataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingODataModel.cs
@@ -1,0 +1,15 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingODataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+public class LoggingCustomer
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingTests.cs
@@ -1,0 +1,206 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+/// <summary>
+/// End-to-end tests that verify diagnostics are recorded through the real request pipeline when a query
+/// fails validation and <see cref="EnableQueryAttribute.EnableQueryValidationErrorLogging"/> is enabled on the
+/// attribute. Logging is off by default; configuring it once for all actions through
+/// <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> is covered by
+/// <see cref="QueryValidationErrorLoggingGlobalTests"/>.
+/// </summary>
+public class QueryValidationErrorLoggingTests : WebODataTestBase<QueryValidationErrorLoggingTests.Startup>
+{
+    public class Startup : TestStartupBase
+    {
+        public static readonly CapturingLoggerProvider LoggerProvider = new CapturingLoggerProvider();
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(LoggingCustomersController), typeof(PlainCustomersController), typeof(PostActionLoggingCustomersController), typeof(OptOutCustomersController));
+
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Warning);
+                builder.AddProvider(LoggerProvider);
+            });
+
+            IEdmModel model = QueryValidationErrorLoggingEdmModel.GetEdmModel();
+            services.AddControllers().AddOData(options => options.AddRouteComponents("odata", model).Select().Expand());
+        }
+    }
+
+    public QueryValidationErrorLoggingTests(WebODataTestFixture<Startup> fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEntitySet_UnknownSelectProperty_WritesDiagnostic()
+    {
+        // Arrange
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("LoggingCustomers", entry.GetFieldValue("Endpoint"));
+        Assert.Contains("LoggingCustomer", entry.GetFieldValue("QueryType"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+        Assert.Contains(" at ", entry.Exception.ToString());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEntitySet_UnknownExpandProperty_WritesDiagnostic()
+    {
+        // Arrange
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$expand=NoSuchNavigation"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal("$expand=NoSuchNavigation", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchNavigation", entry.Exception.Message);
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEntitySet_UnknownSelectPropertyWithoutDollarPrefix_WritesDiagnostic()
+    {
+        // The '$' prefix on system query options is optional and enabled by default, so the attempted
+        // select set must be captured for the no-'$' form as well.
+        Startup.LoggerProvider.Clear();
+
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?select=NoSuchProperty"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+    }
+
+    [Fact]
+    public async Task LoggingEnabledPostActionValidation_UnknownSelectProperty_CapturesElementTypeAndAttemptedSet()
+    {
+        // A controller whose result type is only known after the action runs validates the query on the
+        // post-action path; the diagnostic must still report the element type and the attempted select set.
+        Startup.LoggerProvider.Clear();
+
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("postaction/customers?$select=NoSuchProperty"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        CapturedLogEntry entry = Assert.Single(GetQueryValidationEntries());
+        Assert.Contains("LoggingCustomer", entry.GetFieldValue("QueryType"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+    }
+
+    [Fact]
+    public async Task PlainEntitySet_UnknownSelectProperty_WritesNoDiagnosticByDefault()
+    {
+        // A plain [EnableQuery] attribute writes nothing because logging is off by default and no global
+        // configuration enables it.
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/PlainCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task OptOutEntitySet_UnknownSelectProperty_WritesNoDiagnostic()
+    {
+        // A controller that explicitly opts out with [EnableQuery(EnableQueryValidationErrorLogging = false)] writes nothing.
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/OptOutCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEntitySet_ValidSelectProperty_WritesNoDiagnostic()
+    {
+        // Arrange
+        Startup.LoggerProvider.Clear();
+
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=Name"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+    }
+
+    [Fact]
+    public async Task LoggingEnabledEntitySet_SelectiveAcrossSequentialRequests()
+    {
+        // A bad request writes exactly one diagnostic.
+        Startup.LoggerProvider.Clear();
+        HttpResponseMessage badResponse = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=NoSuchProperty"));
+        Assert.Equal(HttpStatusCode.BadRequest, badResponse.StatusCode);
+        Assert.Single(GetQueryValidationEntries());
+
+        // A subsequent valid request writes no diagnostic.
+        Startup.LoggerProvider.Clear();
+        HttpResponseMessage validResponse = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=Name"));
+        Assert.Equal(HttpStatusCode.OK, validResponse.StatusCode);
+        Assert.Empty(GetQueryValidationEntries());
+
+        // A repeated bad request writes the diagnostic again.
+        Startup.LoggerProvider.Clear();
+        HttpResponseMessage repeatBadResponse = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=NoSuchProperty"));
+        Assert.Equal(HttpStatusCode.BadRequest, repeatBadResponse.StatusCode);
+        Assert.Single(GetQueryValidationEntries());
+    }
+
+    private static HttpRequestMessage CreateGet(string url)
+    {
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+        return request;
+    }
+
+    private static IReadOnlyList<CapturedLogEntry> GetQueryValidationEntries()
+    {
+        return Startup.LoggerProvider.Entries
+            .Where(entry => entry.Category == typeof(EnableQueryAttribute).FullName)
+            .ToList();
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingWithoutLoggingTests.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Query/QueryValidationErrorLogging/QueryValidationErrorLoggingWithoutLoggingTests.cs
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLoggingWithoutLoggingTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OData.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNetCore.OData.E2E.Tests.Query.QueryValidationErrorLogging;
+
+/// <summary>
+/// End-to-end tests verifying that enabling query validation error logging is safe when the application
+/// has not configured any capturing logging: the request still produces the unchanged bad request response.
+/// </summary>
+public class QueryValidationErrorLoggingWithoutLoggingTests : WebODataTestBase<QueryValidationErrorLoggingWithoutLoggingTests.Startup>
+{
+    public class Startup : TestStartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(LoggingCustomersController));
+
+            IEdmModel model = QueryValidationErrorLoggingEdmModel.GetEdmModel();
+            services.AddControllers().AddOData(options => options.AddRouteComponents("odata", model).Select().Expand());
+        }
+    }
+
+    public QueryValidationErrorLoggingWithoutLoggingTests(WebODataTestFixture<Startup> fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task LoggingEnabled_NoLoggingConfigured_ReturnsUnchangedBadRequest()
+    {
+        // Act
+        HttpResponseMessage response = await this.Client.SendAsync(CreateGet("odata/LoggingCustomers?$select=NoSuchProperty"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("NoSuchProperty", body);
+    }
+
+    private static HttpRequestMessage CreateGet(string url)
+    {
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+        return request;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.TestCommon/CapturingLoggerProvider.cs
+++ b/test/Microsoft.AspNetCore.OData.TestCommon/CapturingLoggerProvider.cs
@@ -1,0 +1,149 @@
+//-----------------------------------------------------------------------------
+// <copyright file="CapturingLoggerProvider.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.OData.TestCommon;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> that captures every log entry it receives so tests can assert on the
+/// category, level, formatted message, and the individual structured fields that were logged.
+/// </summary>
+public sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<CapturedLogEntry> _entries = new ConcurrentQueue<CapturedLogEntry>();
+
+    /// <summary>
+    /// Gets a snapshot of the log entries captured so far.
+    /// </summary>
+    public IReadOnlyList<CapturedLogEntry> Entries => _entries.ToArray();
+
+    /// <summary>
+    /// Removes all captured entries.
+    /// </summary>
+    public void Clear()
+    {
+        while (_entries.TryDequeue(out _))
+        {
+        }
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new CapturingLogger(categoryName, _entries);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly string _categoryName;
+        private readonly ConcurrentQueue<CapturedLogEntry> _entries;
+
+        public CapturingLogger(string categoryName, ConcurrentQueue<CapturedLogEntry> entries)
+        {
+            _categoryName = categoryName;
+            _entries = entries;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            Dictionary<string, object> fields = new Dictionary<string, object>();
+            if (state is IReadOnlyList<KeyValuePair<string, object>> structuredState)
+            {
+                foreach (KeyValuePair<string, object> pair in structuredState)
+                {
+                    fields[pair.Key] = pair.Value;
+                }
+            }
+
+            CapturedLogEntry entry = new CapturedLogEntry
+            {
+                Category = _categoryName,
+                Level = logLevel,
+                EventId = eventId,
+                Message = formatter != null ? formatter(state, exception) : null,
+                Exception = exception,
+                Fields = fields
+            };
+
+            _entries.Enqueue(entry);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}
+
+/// <summary>
+/// A single captured log entry.
+/// </summary>
+public sealed class CapturedLogEntry
+{
+    /// <summary>
+    /// Gets or sets the logger category name.
+    /// </summary>
+    public string Category { get; set; }
+
+    /// <summary>
+    /// Gets or sets the log level.
+    /// </summary>
+    public LogLevel Level { get; set; }
+
+    /// <summary>
+    /// Gets or sets the event id.
+    /// </summary>
+    public EventId EventId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the formatted message.
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exception associated with the entry, if any.
+    /// </summary>
+    public Exception Exception { get; set; }
+
+    /// <summary>
+    /// Gets or sets the structured fields captured from the log state.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Fields { get; set; }
+
+    /// <summary>
+    /// Gets the string value of a structured field, or <c>null</c> when the field is not present.
+    /// </summary>
+    /// <param name="name">The field name.</param>
+    /// <returns>The field value as a string, or <c>null</c>.</returns>
+    public string GetFieldValue(string name)
+    {
+        if (Fields != null && Fields.TryGetValue(name, out object value))
+        {
+            return value?.ToString();
+        }
+
+        return null;
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.TestCommon/ThrowingLoggerProvider.cs
+++ b/test/Microsoft.AspNetCore.OData.TestCommon/ThrowingLoggerProvider.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ThrowingLoggerProvider.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.OData.TestCommon;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> whose logger throws when it writes an entry, so tests can verify that a
+/// misbehaving logging sink never changes the outcome of the request. By default it throws for every category;
+/// pass a category name to throw only for that category and act as a no-op for all others, which keeps the rest
+/// of the framework's logging working while still failing the write under test.
+/// </summary>
+public sealed class ThrowingLoggerProvider : ILoggerProvider
+{
+    private readonly string _throwForCategory;
+    private readonly string _message;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThrowingLoggerProvider"/> class.
+    /// </summary>
+    /// <param name="throwForCategory">
+    /// The category the logger throws for, or <c>null</c> to throw for every category.
+    /// </param>
+    /// <param name="message">The message of the thrown exception.</param>
+    public ThrowingLoggerProvider(string throwForCategory = null, string message = "Simulated logging sink failure.")
+    {
+        _throwForCategory = throwForCategory;
+        _message = message;
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName)
+    {
+        bool shouldThrow = _throwForCategory == null || string.Equals(categoryName, _throwForCategory, StringComparison.Ordinal);
+        return new ThrowingLogger(_message, shouldThrow);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+
+    private sealed class ThrowingLogger : ILogger
+    {
+        private readonly string _message;
+        private readonly bool _shouldThrow;
+
+        public ThrowingLogger(string message, bool shouldThrow)
+        {
+            _message = message;
+            _shouldThrow = shouldThrow;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (_shouldThrow)
+            {
+                throw new InvalidOperationException(_message);
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Batch/DefaultODataBatchHandlerTest.cs
@@ -665,7 +665,7 @@ Accept-Charset: UTF-8
         HttpRequestMessage customerRequest = new HttpRequestMessage(HttpMethod.Get, $"{endpoint}/BatchTestCustomers(2)?$expand=Orders");
         customerRequest.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(acceptJson));
 
-        var customerResponse = client.SendAsync(customerRequest).Result;
+        var customerResponse = await client.SendAsync(customerRequest);
         var objAsJsonString = await customerResponse.Content.ReadAsStringAsync();
         var customer = JsonConvert.DeserializeObject<BatchTestCustomer>(objAsJsonString);
 

--- a/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/Microsoft.AspNetCore.OData.Tests/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -218,8 +218,10 @@ public class Microsoft.AspNetCore.OData.ODataMiniOptions {
 	bool EnableCaseInsensitive  { public get; }
 	bool EnableContinueOnErrorHeader  { public get; }
 	bool EnableNoDollarQueryOptions  { public get; }
+	bool EnableQueryValidationErrorLogging  { public get; }
 	long MaxReceivedMessageSize  { public get; }
 	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
+	Microsoft.Extensions.Logging.LogLevel QueryValidationErrorLogLevel  { public get; }
 	System.TimeZoneInfo TimeZone  { public get; }
 	Microsoft.OData.ODataVersion Version  { public get; }
 
@@ -234,6 +236,8 @@ public class Microsoft.AspNetCore.OData.ODataMiniOptions {
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetMaxReceivedMessageSize (long maxReceivedMessageSize)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetMaxTop (System.Nullable`1[[System.Int32]] maxTopValue)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetNoDollarQueryOptions (bool enableNoDollarQueryOptions)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetQueryValidationErrorLogging (bool enableQueryValidationErrorLogging)
+	public Microsoft.AspNetCore.OData.ODataMiniOptions SetQueryValidationErrorLogLevel (Microsoft.Extensions.Logging.LogLevel logLevel)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetTimeZoneInfo (System.TimeZoneInfo tzi)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SetVersion (Microsoft.OData.ODataVersion version)
 	public Microsoft.AspNetCore.OData.ODataMiniOptions SkipToken ()
@@ -252,6 +256,7 @@ public class Microsoft.AspNetCore.OData.ODataOptions {
 	bool EnableAttributeRouting  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
 	bool EnableNoDollarQueryOptions  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	long MaxReceivedMessageSize  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.DefaultQueryConfigurations QueryConfigurations  { public get; }
 	[
@@ -259,6 +264,7 @@ public class Microsoft.AspNetCore.OData.ODataOptions {
 	]
 	Microsoft.OData.ModelBuilder.Config.DefaultQuerySettings QuerySettings  { public get; }
 
+	Microsoft.Extensions.Logging.LogLevel QueryValidationErrorLogLevel  { public get; public set; }
 	[
 	TupleElementNamesAttribute(),
 	]
@@ -1512,6 +1518,7 @@ public class Microsoft.AspNetCore.OData.Query.EnableQueryAttribute : Microsoft.A
 	Microsoft.AspNetCore.OData.Query.AllowedQueryOptions AllowedQueryOptions  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	Microsoft.AspNetCore.OData.Query.HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
 	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/EnableQueryAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/EnableQueryAttributeTests.cs
@@ -9,17 +9,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.TestCommon;
 using Microsoft.AspNetCore.OData.Tests.Commons;
 using Microsoft.AspNetCore.OData.Tests.Extensions;
 using Microsoft.AspNetCore.OData.Tests.Models;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
@@ -477,6 +482,417 @@ public class EnableQueryAttributeTests
         {
             Called = true;
             return null;
+        }
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_UnknownSelectProperty_WritesDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(typeof(EnableQueryAttribute).FullName, entry.Category);
+        Assert.Equal("Customers({key})", entry.GetFieldValue("Endpoint"));
+        Assert.Contains("QCustomer", entry.GetFieldValue("QueryType"));
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("ODataException", entry.Exception.GetType().FullName);
+        Assert.Contains("NoSuchProperty", entry.Exception.Message);
+        Assert.Contains(" at ", entry.Exception.ToString());
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_UnknownExpandProperty_WritesDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$expand=NoSuchNavigation", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal("$expand=NoSuchNavigation", entry.GetFieldValue("QueryOptions"));
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("NoSuchNavigation", entry.Exception.Message);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_UnknownPropertyAmongMany_CapturesFullAttemptedSelectSet()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=Name,NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal("$select=Name,NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithDefaultConfiguration_UnknownSelectProperty_WritesNoDiagnostic()
+    {
+        // Arrange
+        // Logging is off by default and no global configuration enables it, so nothing is written.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model); // EnableQueryValidationErrorLogging is off by default.
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithGlobalLoggingEnabled_UnknownSelectProperty_WritesDiagnostic()
+    {
+        // Arrange
+        // The attribute leaves the flag unset, so the global ODataOptions value enables logging for it.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model); // Flag unset -> defers to global.
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithGlobalLoggingEnabled_AttributeOptOut_WritesNoDiagnostic()
+    {
+        // Arrange
+        // An explicit false on the attribute overrides the global enabled value.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = false };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithGlobalLoggingDisabled_AttributeEnabled_WritesDiagnostic()
+    {
+        // Arrange
+        // An explicit true on the attribute overrides the global disabled value.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: false));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Single(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingDisabled_UnknownSelectProperty_WritesNoDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = false }; // Explicitly disabled on the attribute.
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_ValidSelectProperty_WritesNoDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=Name", BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.Null(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_NoQueryOptions_WritesNoDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(string.Empty, BuildLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.Null(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_NoLoggerFactoryRegistered_DoesNotThrowAndReturnsBadRequest()
+    {
+        // Arrange
+        IServiceProvider emptyServices = new ServiceCollection().BuildServiceProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", emptyServices);
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_WarningLevelDisabled_WritesNoDiagnostic()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider, LogLevel.Error));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_CustomLogLevel_WritesDiagnosticAtThatLevel()
+    {
+        // Arrange
+        // The global level selects a non-default level; the diagnostic is written at that level.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true, globalLogLevel: LogLevel.Error));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_InformationLogLevel_WritesDiagnosticAtThatLevel()
+    {
+        // Arrange
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true, globalLogLevel: LogLevel.Information));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithGlobalLogLevel_WritesDiagnosticAtGlobalLevel()
+    {
+        // Arrange
+        // The global ODataOptions level applies to the diagnostic.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true, globalLogLevel: LogLevel.Error));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        CapturedLogEntry entry = Assert.Single(loggerProvider.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_CustomLevelDisabled_WritesNoDiagnostic()
+    {
+        // Arrange
+        // The effective level is Information but the logger only accepts Warning and above, so nothing is written.
+        CapturingLoggerProvider loggerProvider = new CapturingLoggerProvider();
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext(
+            "?$select=NoSuchProperty",
+            BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnableQueryValidationErrorLogging: true, globalLogLevel: LogLevel.Information, minimumLevel: LogLevel.Warning));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.Empty(loggerProvider.Entries);
+    }
+
+    [Fact]
+    public void EnableQueryValidationErrorLogging_DefaultsToFalse()
+    {
+        // The attribute leaves the value unset by default, which resolves to false.
+        Assert.False(new EnableQueryAttribute().EnableQueryValidationErrorLogging);
+    }
+
+    [Fact]
+    public void OnActionExecuting_WithLoggingEnabled_WhenLoggerThrows_ResponseIsUnchanged()
+    {
+        // Arrange
+        // A logging provider that throws while writing the diagnostic must never change the response produced
+        // for the failed query: the same 400 result is returned and no exception surfaces from the action filter.
+        ThrowingLoggerProvider loggerProvider = new ThrowingLoggerProvider(typeof(EnableQueryAttribute).FullName);
+        LoggingEnableQueryAttribute attribute = new LoggingEnableQueryAttribute(_model) { EnableQueryValidationErrorLogging = true };
+        ActionExecutingContext context = CreateLoggingActionExecutingContext("?$select=NoSuchProperty", BuildThrowingLoggerServices(loggerProvider));
+
+        // Act
+        attribute.OnActionExecuting(context);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(context.Result);
+    }
+
+    private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider)
+    {
+        return BuildLoggerServices(loggerProvider, LogLevel.Trace);
+    }
+
+    private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider, LogLevel minimumLevel)
+    {
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(minimumLevel);
+            builder.AddProvider(loggerProvider);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static IServiceProvider BuildLoggerServicesWithGlobalOption(CapturingLoggerProvider loggerProvider, bool globalEnableQueryValidationErrorLogging, LogLevel? globalLogLevel = null, LogLevel minimumLevel = LogLevel.Trace)
+    {
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(minimumLevel);
+            builder.AddProvider(loggerProvider);
+        });
+        services.Configure<ODataOptions>(options =>
+        {
+            options.EnableQueryValidationErrorLogging = globalEnableQueryValidationErrorLogging;
+            if (globalLogLevel.HasValue)
+            {
+                options.QueryValidationErrorLogLevel = globalLogLevel.Value;
+            }
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static IServiceProvider BuildThrowingLoggerServices(ThrowingLoggerProvider loggerProvider)
+    {
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(loggerProvider);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ActionExecutingContext CreateLoggingActionExecutingContext(string queryString, IServiceProvider requestServices)
+    {
+        DefaultHttpContext httpContext = new DefaultHttpContext();
+        httpContext.RequestServices = requestServices;
+        httpContext.Request.Path = "/Customers";
+        httpContext.Request.QueryString = new QueryString(queryString);
+
+        // Match a routed endpoint so the diagnostic records the endpoint's route template rather than the
+        // concrete request path. The template uses "{key}" placeholders for entity keys, so the same endpoint
+        // is reported consistently across requests.
+        httpContext.SetEndpoint(new RouteEndpoint(
+            context => Task.CompletedTask,
+            RoutePatternFactory.Parse("Customers({key})"),
+            order: 0,
+            metadata: new EndpointMetadataCollection(Array.Empty<object>()),
+            displayName: "Customers"));
+
+        ActionContext actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        return new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object>(),
+            controller: new object());
+    }
+
+    private class LoggingEnableQueryAttribute : EnableQueryAttribute
+    {
+        private readonly IEdmModel _edmModel;
+
+        public LoggingEnableQueryAttribute(IEdmModel edmModel)
+        {
+            _edmModel = edmModel;
+        }
+
+        protected override ODataQueryOptions CreateQueryOptionsOnExecuting(ActionExecutingContext actionExecutingContext)
+        {
+            HttpRequest request = actionExecutingContext.HttpContext.Request;
+            ODataQueryContext queryContext = new ODataQueryContext(_edmModel, typeof(QCustomer));
+            queryContext.DefaultQueryConfigurations.EnableSelect = true;
+            queryContext.DefaultQueryConfigurations.EnableExpand = true;
+            return new ODataQueryOptions(queryContext, request);
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Ports the query-validation diagnostic logging feature [OData/AspNetCoreOData#1592](https://github.com/OData/AspNetCoreOData/pull/1592).

Adds opt-in diagnostic logging that records structured details when an incoming OData query fails validation, for both the controller (`EnableQueryAttribute`) and Minimal API paths.

### What's included
- `EnableQueryAttribute.EnableQueryValidationErrorLogging` to opt in per action.
- Global `ODataOptions.EnableQueryValidationErrorLogging` + `ODataOptions.QueryValidationErrorLogLevel` (default `Warning`); the attribute overrides the global value.
- Minimal API parity via `ODataMiniOptions`.
- New internal `QueryValidationErrorLogger` emitting endpoint, queried type, attempted `$select`/`$expand`, and failure reason with the validation exception.
- Diagnostics never change the response produced for the failed query.

Cherrypick: https://github.com/OData/AspNetCoreOData/commit/c852dbe28cd8db400c1ee9f28447d660c523e5c6

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*