### PR TITLE
Fixes #1581: Nullable enum with 'in' operator throws when collection contains starts with a null value

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -1492,44 +1492,44 @@ public abstract partial class QueryBinder
         if (edmTypeReference != null && edmTypeReference.IsEnum())
         {
             constantType = Nullable.GetUnderlyingType(constantType) ?? constantType;
+        }
 
-            if (value != null)
+        if (value != null && edmTypeReference != null && edmTypeReference.IsEnum())
+        {
+            ODataEnumValue odataEnumValue = (ODataEnumValue)value;
+            string strValue = odataEnumValue.Value;
+            Contract.Assert(strValue != null);
+
+            IEdmEnumType enumType = edmTypeReference.AsEnum().EnumDefinition();
+            ClrEnumMemberAnnotation memberMapAnnotation = context.Model.GetClrEnumMemberAnnotation(enumType);
+            if (memberMapAnnotation != null)
             {
-                ODataEnumValue odataEnumValue = (ODataEnumValue)value;
-                string strValue = odataEnumValue.Value;
-                Contract.Assert(strValue != null);
-
-                IEdmEnumType enumType = edmTypeReference.AsEnum().EnumDefinition();
-                ClrEnumMemberAnnotation memberMapAnnotation = context.Model.GetClrEnumMemberAnnotation(enumType);
-                if (memberMapAnnotation != null)
+                IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == strValue);
+                if (enumMember == null)
                 {
-                    IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == strValue);
-                    if (enumMember == null)
-                    {
-                        enumMember = enumType.Members.FirstOrDefault(m => m.Value.ToString() == strValue);
-                    }
+                    enumMember = enumType.Members.FirstOrDefault(m => m.Value.ToString() == strValue);
+                }
 
-                    if (enumMember != null)
+                if (enumMember != null)
+                {
+                    Enum clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
+                    if (clrMember != null)
                     {
-                        Enum clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
-                        if (clrMember != null)
-                        {
-                            value = clrMember;
-                        }
-                        else
-                        {
-                            throw new ODataException(Error.Format(SRResources.CannotGetEnumClrMember, enumMember.Name));
-                        }
+                        value = clrMember;
                     }
                     else
                     {
-                        value = Enum.Parse(constantType, strValue);
+                        throw new ODataException(Error.Format(SRResources.CannotGetEnumClrMember, enumMember.Name));
                     }
                 }
                 else
                 {
                     value = Enum.Parse(constantType, strValue);
                 }
+            }
+            else
+            {
+                value = Enum.Parse(constantType, strValue);
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/QueryBinder.cs
@@ -1489,44 +1489,47 @@ public abstract partial class QueryBinder
     {
         Type constantType = context.Model.GetClrType(edmTypeReference, context.AssembliesResolver);
 
-        if (value != null && edmTypeReference != null && edmTypeReference.IsEnum())
+        if (edmTypeReference != null && edmTypeReference.IsEnum())
         {
-            ODataEnumValue odataEnumValue = (ODataEnumValue)value;
-            string strValue = odataEnumValue.Value;
-            Contract.Assert(strValue != null);
-
             constantType = Nullable.GetUnderlyingType(constantType) ?? constantType;
 
-            IEdmEnumType enumType = edmTypeReference.AsEnum().EnumDefinition();
-            ClrEnumMemberAnnotation memberMapAnnotation = context.Model.GetClrEnumMemberAnnotation(enumType);
-            if (memberMapAnnotation != null)
+            if (value != null)
             {
-                IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == strValue);
-                if (enumMember == null)
-                {
-                    enumMember = enumType.Members.FirstOrDefault(m => m.Value.ToString() == strValue);
-                }
+                ODataEnumValue odataEnumValue = (ODataEnumValue)value;
+                string strValue = odataEnumValue.Value;
+                Contract.Assert(strValue != null);
 
-                if (enumMember != null)
+                IEdmEnumType enumType = edmTypeReference.AsEnum().EnumDefinition();
+                ClrEnumMemberAnnotation memberMapAnnotation = context.Model.GetClrEnumMemberAnnotation(enumType);
+                if (memberMapAnnotation != null)
                 {
-                    Enum clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
-                    if (clrMember != null)
+                    IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == strValue);
+                    if (enumMember == null)
                     {
-                        value = clrMember;
+                        enumMember = enumType.Members.FirstOrDefault(m => m.Value.ToString() == strValue);
+                    }
+
+                    if (enumMember != null)
+                    {
+                        Enum clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
+                        if (clrMember != null)
+                        {
+                            value = clrMember;
+                        }
+                        else
+                        {
+                            throw new ODataException(Error.Format(SRResources.CannotGetEnumClrMember, enumMember.Name));
+                        }
                     }
                     else
                     {
-                        throw new ODataException(Error.Format(SRResources.CannotGetEnumClrMember, enumMember.Name));
+                        value = Enum.Parse(constantType, strValue);
                     }
                 }
                 else
                 {
                     value = Enum.Parse(constantType, strValue);
                 }
-            }
-            else
-            {
-                value = Enum.Parse(constantType, strValue);
             }
         }
 

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsController.cs
@@ -44,6 +44,7 @@ public class EmployeesController : ODataController
                 Name="Name1",
                 SkillSet=new List<Skill> { Skill.CSharp, Skill.Sql },
                 Gender=Gender.Female,
+                MaritalStatus=null,
                 AccessLevel=AccessLevel.Execute,
                 EmployeeType = EmployeeType.FullTime | EmployeeType.PartTime,
                 FavoriteSports=new FavoriteSports()
@@ -57,6 +58,7 @@ public class EmployeesController : ODataController
                 ID=2,Name="Name2",
                 SkillSet=new List<Skill>(),
                 Gender=Gender.Female,
+                MaritalStatus=MaritalStatus.Married,
                 AccessLevel=AccessLevel.Read,
                 EmployeeType = EmployeeType.Contract,
                 FavoriteSports=new FavoriteSports()
@@ -70,6 +72,7 @@ public class EmployeesController : ODataController
                 ID=3,Name="Name3",
                 SkillSet=new List<Skill> { Skill.Web, Skill.Sql },
                 Gender=Gender.Female,
+                MaritalStatus=MaritalStatus.Single,
                 AccessLevel=AccessLevel.Read|AccessLevel.Write,
                 EmployeeType = EmployeeType.Intern | EmployeeType.FullTime | EmployeeType.PartTime,
                 FavoriteSports=new FavoriteSports()

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsDataModel.cs
@@ -21,6 +21,8 @@ public class Employee
 
     public Gender Gender { get; set; }
 
+    public MaritalStatus? MaritalStatus { get; set; }
+
     public AccessLevel AccessLevel { get; set; }
 
     public EmployeeType EmployeeType { get; set; }
@@ -64,6 +66,17 @@ public enum Gender
     Male = 1,
 
     Female = 2
+}
+
+public enum MaritalStatus
+{
+    Single,
+
+    Married,
+
+    Divorced,
+
+    Widowed
 }
 
 public enum Skill

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsEdmModel.cs
@@ -20,6 +20,7 @@ internal class EnumsEdmModel
         employee.Property(c => c.Name);
         employee.CollectionProperty<Skill>(c => c.SkillSet);
         employee.EnumProperty<Gender>(c => c.Gender);
+        employee.EnumProperty<MaritalStatus>(c => c.MaritalStatus);
         employee.EnumProperty<AccessLevel>(c => c.AccessLevel);
         employee.EnumProperty<EmployeeType>(c => c.EmployeeType);
         employee.ComplexProperty<FavoriteSports>(c => c.FavoriteSports);
@@ -32,6 +33,12 @@ internal class EnumsEdmModel
         var gender = builder.EnumType<Gender>();
         gender.Member(Gender.Female);
         gender.Member(Gender.Male);
+
+        var maritalStatus = builder.EnumType<MaritalStatus>();
+        maritalStatus.Member(MaritalStatus.Single);
+        maritalStatus.Member(MaritalStatus.Married);
+        maritalStatus.Member(MaritalStatus.Divorced);
+        maritalStatus.Member(MaritalStatus.Widowed);
 
         var accessLevel = builder.EnumType<AccessLevel>();
         accessLevel.Member(AccessLevel.None);

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
@@ -454,15 +454,17 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
 
         string requestUri = "/convention/Employees?$filter=MaritalStatus in (null,'Married')&$format=application/json;odata.metadata=none";
 
-        HttpResponseMessage response = await client.GetAsync(requestUri);
-        Assert.True(response.IsSuccessStatusCode);
+        using(var response = await client.GetAsync(requestUri))
+        {
+            Assert.True(response.IsSuccessStatusCode);
 
-        var json = await response.Content.ReadAsObject<JObject>();
-        var value = json.GetValue("value") as JArray;
-        Assert.NotNull(value);
+            var json = await response.Content.ReadAsObject<JObject>();
+            var value = json.GetValue("value") as JArray;
+            Assert.NotNull(value);
 
-        var ids = value.Select(v => (int)v["ID"]).OrderBy(id => id).ToArray();
-        Assert.Equal(new[] { 1, 2 }, ids);
+            var ids = value.Select(v => (int)v["ID"]).OrderBy(id => id).ToArray();
+            Assert.Equal(new[] { 1, 2 }, ids);
+        }
     }
 
     [Theory]

--- a/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
+++ b/test/Microsoft.AspNetCore.OData.E2E.Tests/Enums/EnumsTest.cs
@@ -83,7 +83,7 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
         var employee = edmModel.SchemaElements.SingleOrDefault(e => e.Name == "Employee") as IEdmEntityType;
         Assert.Single(employee.Key());
         Assert.Equal("ID", employee.Key().First().Name);
-        Assert.Equal(7, employee.Properties().Count());
+        Assert.Equal(8, employee.Properties().Count());
 
         //Entity Enum Collection Property
         var skillSet = employee.Properties().SingleOrDefault(p => p.Name == "SkillSet");
@@ -94,6 +94,11 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
         Assert.True(gender.Type.IsEnum());
         var edmEnumType = gender.Type.Definition as IEdmEnumType;
         Assert.False(edmEnumType.IsFlags);
+
+        //Entity Nullable Enum Property
+        var maritalStatus = employee.Properties().SingleOrDefault(p => p.Name == "MaritalStatus");
+        Assert.True(maritalStatus.Type.IsEnum());
+        Assert.True(maritalStatus.Type.IsNullable);
 
         var accessLevel = employee.Properties().SingleOrDefault(p => p.Name == "AccessLevel") as IEdmStructuralProperty;
         edmEnumType = accessLevel.Type.Definition as IEdmEnumType;
@@ -439,6 +444,25 @@ public class EnumsTest : WebApiTestBase<EnumsTest>
             Assert.NotNull(value);
             Assert.Equal(2, value.Count);
         }
+    }
+
+    [Fact]
+    public async Task QueryEntitiesFilterByNullableEnumInOperatorWithNullValueFirst()
+    {
+        await ResetDatasource();
+        HttpClient client = CreateClient();
+
+        string requestUri = "/convention/Employees?$filter=MaritalStatus in (null,'Married')&$format=application/json;odata.metadata=none";
+
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+        Assert.True(response.IsSuccessStatusCode);
+
+        var json = await response.Content.ReadAsObject<JObject>();
+        var value = json.GetValue("value") as JArray;
+        Assert.NotNull(value);
+
+        var ids = value.Select(v => (int)v["ID"]).OrderBy(id => id).ToArray();
+        Assert.Equal(new[] { 1, 2 }, ids);
     }
 
     [Theory]

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
@@ -2001,6 +2001,20 @@ public class FilterBinderTests
     }
 
     [Fact]
+    public void EnumInExpression_NullableEnum_WithNullValueFirst()
+    {
+        // Arrange & Act & Assert
+        var result = BindFilterAndVerify<DataTypes>(
+            "NullableSimpleEnumProp in (null, 'First')",
+            "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNetCore.OData.Tests.Models.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+        Expression<Func<DataTypes, bool>> expression = result.Item2 as Expression<Func<DataTypes, bool>>;
+
+        var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+        var values = (IList<SimpleEnum?>)ExpressionBinderHelper.ExtractParameterizedConstant(memberAccess);
+        Assert.Equal(new SimpleEnum?[] {null, SimpleEnum.First}, values);
+    }
+
+    [Fact]
     public void RealLiteralSuffixes()
     {
         // Arrange & Act & Assert - Float F


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Fixes #1581. `$filter=SomeEnum in (null, 'Value')` on a **nullable** enum property threw:                                                                                                                      
                                                                                                                                                                                                                 
  System.ArgumentException: The value "Value" is not of type "System.Nullable`1[...]"                                                                                                                            
  and cannot be used in this generic collection.                                                                                                                                                                 
                                                                                                                                                                                                                 
  ...whenever a `null` appeared *before* a real enum value in the `in (...)` list. The                                                                                                                           
  reverse order (`in ('Value', null)`) already worked, which is why this slipped                                                                                                                                 
  through existing coverage.                                                                                                                                                                                     
                                                                                                                                                                                                                 
  ## Root cause                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  `QueryBinder.BindCollectionConstantNode` determines the CLR item type for the whole                                                                                                                            
  `in (...)` list from the **first** element only. `RetrieveClrTypeForConstant` only                                                                                                                             
  unwrapped `Nullable<TEnum>` → `TEnum` when the value it was inspecting was non-null.                                                                                                                           
  So when the first item was `null`, the CLR type stayed `Nullable<TEnum>` for the rest                                                                                                                          
  of the loop, `constantType.IsEnum` came back `false` (always false for `Nullable<T>`),                                                                                                                         
  and the next real item's `ODataEnumValue` got added directly into a `List<TEnum?>`                                                                                                                             
  instead of being converted first.                                                                                                                                                                              
                                                                                                                                                                                                                 
  ## Fix                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  `QueryBinder.cs` only — hoisted the `Nullable<TEnum>` unwrap into its own preceding                                                                                                                            
  check that runs regardless of whether the value being inspected is null; the                                                                                                                                   
  value-conversion step still only runs when non-null. No other logic touched.                                                                                                                                   
                                                                                                                                                                                                                 
  ## Tests                                                                                                                                                                                                       
                                                                                                                                                                                                                 
  - Unit: `EnumInExpression_NullableEnum_WithNullValueFirst` in `FilterBinderTests.cs`                                                                                                                           
    — the null-first ordering not covered by the existing                                                                                                                                                        
    `EnumInExpression_NullableEnum_WithNullValue` test.                                                                                                                                                          
  - E2E: nullable `MaritalStatus` property added to the `Enums` test model/controller,                                                                                                                           
    with a test filtering `MaritalStatus in (null,'Married')` through the real pipeline.                                                                                                                         
                                                                                                                                                                                                                 
  Both reproduce the exact reported exception when the fix is reverted, and pass with it.