### PR TITLE
Fixes #989: Fix DateOnly comparisons with DateTime and DateTimeOffset in filter expressions

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/Expressions/ExpressionBinderHelper.cs
@@ -129,8 +129,8 @@ internal static class ExpressionBinderHelper
             right = CreateTimeBinaryExpression(right, querySettings);
         }
 
-        if ((IsType<DateOnly>(leftUnderlyingType) && IsDate(rightUnderlyingType)) ||
-            (IsDate(leftUnderlyingType) && IsType<DateOnly>(rightUnderlyingType)))
+        if ((IsType<DateOnly>(leftUnderlyingType) && (IsDate(rightUnderlyingType) || IsDateOrOffset(rightUnderlyingType))) ||
+            ((IsDate(leftUnderlyingType) || IsDateOrOffset(leftUnderlyingType)) && IsType<DateOnly>(rightUnderlyingType)))
         {
             left = CreateDateBinaryExpression(left, querySettings);
             right = CreateDateBinaryExpression(right, querySettings);

--- a/test/Microsoft.AspNetCore.OData.Tests/Models/Product.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Models/Product.cs
@@ -41,6 +41,9 @@ public class Product
     public Date DateProperty { get; set; }
     public Date? NullableDateProperty { get; set; }
 
+    public DateOnly DateOnlyProperty { get; set; }
+    public DateOnly? NullableDateOnlyProperty { get; set; }
+
     public Guid GuidProperty { get; set; }
     public Guid? NullableGuidProperty { get; set; }
 

--- a/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
+++ b/test/Microsoft.AspNetCore.OData.Tests/Query/Expressions/FilterBinderTests.cs
@@ -199,6 +199,22 @@ public class FilterBinderTests
         BindFilterAndVerify<DataTypes>(clause, expectedExpression);
     }
 
+    [Theory]
+    [InlineData("DateOnlyProperty gt NonNullableDiscontinuedDate",
+        "$it => (((($it.DateOnlyProperty.Year * 10000) + ($it.DateOnlyProperty.Month * 100)) + $it.DateOnlyProperty.Day) > ((($it.NonNullableDiscontinuedDate.Year * 10000) + ($it.NonNullableDiscontinuedDate.Month * 100)) + $it.NonNullableDiscontinuedDate.Day))",
+        null)]
+    [InlineData("NullableDateOnlyProperty gt DiscontinuedDate",
+        "$it => (((($it.NullableDateOnlyProperty.Value.Year * 10000) + ($it.NullableDateOnlyProperty.Value.Month * 100)) + $it.NullableDateOnlyProperty.Value.Day) > ((($it.DiscontinuedDate.Value.Year * 10000) + ($it.DiscontinuedDate.Value.Month * 100)) + $it.DiscontinuedDate.Value.Day))",
+        "$it => ((IIF((IIF(($it.NullableDateOnlyProperty == null), null, $it.NullableDateOnlyProperty) == null), null, Convert(((($it.NullableDateOnlyProperty.Value.Year * 10000) + ($it.NullableDateOnlyProperty.Value.Month * 100)) + $it.NullableDateOnlyProperty.Value.Day))) > IIF(($it.DiscontinuedDate == null), null, Convert(((($it.DiscontinuedDate.Value.Year * 10000) + ($it.DiscontinuedDate.Value.Month * 100)) + $it.DiscontinuedDate.Value.Day)))) == True)")]
+    [InlineData("DateOnlyProperty gt DateProperty",
+        "$it => (((($it.DateOnlyProperty.Year * 10000) + ($it.DateOnlyProperty.Month * 100)) + $it.DateOnlyProperty.Day) > ((($it.DateProperty.Year * 10000) + ($it.DateProperty.Month * 100)) + $it.DateProperty.Day))",
+        null)]
+    public void LogicalOperators_WithDateOnlyAndDateOrDateTimeOffsetInEqualities(string clause, string expectedFalseNullPropagation, string expectedTrueNullPropagation)
+    {
+        // Arrange & Act & Assert
+        BindFilterAndVerify<Product>(clause, expectedFalseNullPropagation, expectedTrueNullPropagation);
+    }
+
     [Fact]
     [ReplaceCulture]
     public void LogicalOperators_BooleanOperatorNullableTypes()


### PR DESCRIPTION
Fixes #989 

CreateBinaryExpression only recognized the legacy OData Date struct as comparable to DateOnly and never checked for DateTime/DateTimeOffset. So comparing a DateOnly property against a DateTimeOffset property (e.g. $filter=DateOnlyProp gt DateTimeOffsetProp) fell through to a raw Expression.MakeBinary, which throws since no CLR operator exists between those types.

Fix: extend the existing DateOnly branch to also match IsDateOrOffset, so it routes through CreateDateBinaryExpression (same conversion already used for Date↔DateTimeOffset).

Added unit tests in FilterBinderTests covering DateOnly gt DateTimeOffset (nullable + non-nullable) and DateOnly gt Date, verified they reproduce the original exception on main and pass with the fix.

I will cherry pick this on to `dev-10.x` when merged. 